### PR TITLE
fix: panel click handling + automated QA tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test install install-login clean generate
+.PHONY: build test install install-login clean generate qa
 
 APP_NAME := RedditReminder
 PROJ := $(APP_NAME).xcodeproj
@@ -31,6 +31,9 @@ install: build
 	else \
 	  open $(INSTALL_DIR)/$(APP_NAME).app; \
 	fi
+
+qa: install
+	./scripts/qa.sh
 
 clean:
 	rm -rf $(PROJ) $(BUILD_DIR)

--- a/Sources/Services/PanelController.swift
+++ b/Sources/Services/PanelController.swift
@@ -2,6 +2,23 @@ import AppKit
 import SwiftUI
 import Observation
 
+/// NSPanel subclass that can become key even when borderless.
+/// Required so SwiftUI gesture recognizers receive mouse events.
+final class ClickablePanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+/// NSHostingView subclass that accepts first-mouse clicks and
+/// makes the panel key on mouseDown so SwiftUI gestures fire.
+final class FirstMouseHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeKey()
+        super.mouseDown(with: event)
+    }
+}
+
 @MainActor
 @Observable
 final class PanelController {
@@ -9,7 +26,7 @@ final class PanelController {
     var screenEdge: ScreenEdge = .right
 
     private var panel: NSPanel?
-    private var hostingView: NSHostingView<AnyView>?
+    private var hostingView: FirstMouseHostingView<AnyView>?
     private var autoCollapseTimer: Timer?
     private var restingState: SidebarState = .glance
     private var autoCollapseMinutes: Int = SidebarConstants.defaultAutoCollapseMinutes
@@ -17,7 +34,7 @@ final class PanelController {
     enum ScreenEdge { case left, right }
 
     func setup(contentView: some View) {
-        let panel = NSPanel(
+        let panel = ClickablePanel(
             contentRect: NSRect(x: 0, y: 0, width: SidebarConstants.glanceWidth, height: 0),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -30,7 +47,7 @@ final class PanelController {
         panel.backgroundColor = NSColor(red: 0.08, green: 0.08, blue: 0.16, alpha: 1.0)
         panel.isOpaque = false
 
-        let hosting = NSHostingView(rootView: AnyView(contentView))
+        let hosting = FirstMouseHostingView(rootView: AnyView(contentView))
         panel.contentView = hosting
 
         self.panel = panel

--- a/Sources/Views/StripView.swift
+++ b/Sources/Views/StripView.swift
@@ -6,42 +6,44 @@ struct StripView: View {
     let onTap: () -> Void
 
     var body: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "chevron.right")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
+        Button(action: onTap) {
+            VStack(spacing: 12) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
 
-            if queueCount > 0 {
-                ZStack {
+                if queueCount > 0 {
+                    ZStack {
+                        Circle()
+                            .fill(Color(nsColor: AppColors.reddit))
+                            .frame(width: 18, height: 18)
+                        Text("\(queueCount)")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.white)
+                    }
+                }
+
+                if hasUrgentEvent {
                     Circle()
                         .fill(Color(nsColor: AppColors.reddit))
-                        .frame(width: 18, height: 18)
-                    Text("\(queueCount)")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(.white)
+                        .frame(width: 8, height: 8)
+                        .shadow(color: Color(nsColor: AppColors.reddit).opacity(0.6), radius: 4)
                 }
+
+                Spacer()
+
+                Text("REDDIT")
+                    .font(.system(size: 9, weight: .medium))
+                    .tracking(2)
+                    .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(90))
+                    .fixedSize()
+                    .padding(.bottom, 16)
             }
-
-            if hasUrgentEvent {
-                Circle()
-                    .fill(Color(nsColor: AppColors.reddit))
-                    .frame(width: 8, height: 8)
-                    .shadow(color: Color(nsColor: AppColors.reddit).opacity(0.6), radius: 4)
-            }
-
-            Spacer()
-
-            Text("REDDIT")
-                .font(.system(size: 9, weight: .medium))
-                .tracking(2)
-                .foregroundStyle(.tertiary)
-                .rotationEffect(.degrees(90))
-                .fixedSize()
-                .padding(.bottom, 16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.top, 14)
+            .contentShape(Rectangle())
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.top, 14)
-        .contentShape(Rectangle())
-        .onTapGesture(perform: onTap)
+        .buttonStyle(.plain)
     }
 }

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -2,8 +2,8 @@
 # RedditReminder QA — automated state-transition tests
 # Requires: the app to have been built via `make install` first.
 #
-# Uses macOS Accessibility (System Events) to click SwiftUI Buttons
-# and verifies window width matches expected sidebar state.
+# Uses macOS System Events to click at computed coordinates
+# and verify window width after each sidebar state transition.
 #
 # NOTE: This does NOT test the ⌘⇧R global shortcut — that requires
 # granting Accessibility permission to RedditReminder manually.
@@ -15,7 +15,7 @@ APP_PATH="$HOME/Applications/$APP_NAME.app"
 ANIM_WAIT=0.6          # seconds to wait for width animation (0.35s) + margin
 LAUNCH_WAIT=2           # seconds to wait after launch
 
-# Expected widths from Constants.swift
+# Expected widths from SidebarConstants (Sources/Utilities/Constants.swift)
 W_STRIP=24
 W_GLANCE=200
 W_BROWSE=320
@@ -39,81 +39,59 @@ get_width() {
                 return w as integer
             end tell
         end tell
-    " 2>/dev/null
+    "
 }
 
-get_pos_size() {
-    osascript -e "
-        tell application \"System Events\"
-            tell process \"$APP_NAME\"
-                set {x, y} to position of window 1
-                set {w, h} to size of window 1
-                return (x as text) & \",\" & (y as text) & \",\" & (w as text) & \",\" & (h as text)
-            end tell
-        end tell
-    " 2>/dev/null
-}
-
-click_back_chevron() {
-    # The back chevron is button 1 inside the header group — the first button
-    # in the window, positioned top-right with padding(.horizontal, 14).
+click_at_rel() {
+    # Click at a position relative to the window origin.
+    # $1 = AppleScript x expression using winX, winW
+    # $2 = AppleScript y expression using winY, winH
+    local x_expr="$1" y_expr="$2"
     osascript -e "
         tell application \"System Events\"
             tell process \"$APP_NAME\"
                 set {winX, winY} to position of window 1
                 set {winW, winH} to size of window 1
-                click at {winX + winW - 21, winY + 20}
+                click at {$x_expr, $y_expr}
             end tell
         end tell
-    " >/dev/null 2>&1
+    " >/dev/null
     sleep "$ANIM_WAIT"
 }
 
-click_strip() {
-    # The strip is a full-height Button. Click its center.
-    osascript -e "
-        tell application \"System Events\"
-            tell process \"$APP_NAME\"
-                set {winX, winY} to position of window 1
-                set {winW, winH} to size of window 1
-                click at {winX + (winW / 2), winY + (winH / 2)}
-            end tell
-        end tell
-    " >/dev/null 2>&1
-    sleep "$ANIM_WAIT"
-}
+# Back chevron: top-right of header, fixed offset from window corner
+click_back_chevron() { click_at_rel "winX + winW - 21" "winY + 20"; }
 
-click_new_capture() {
-    # "+ New Capture" is the last button in the window, pinned to bottom.
-    # In both Glance and Browse it sits at padding(10/10) from bottom.
-    osascript -e "
-        tell application \"System Events\"
-            tell process \"$APP_NAME\"
-                set {winX, winY} to position of window 1
-                set {winW, winH} to size of window 1
-                click at {winX + (winW / 2), winY + winH - 20}
-            end tell
-        end tell
-    " >/dev/null 2>&1
-    sleep "$ANIM_WAIT"
-}
+# Strip: full-height Button, click center
+click_strip()        { click_at_rel "winX + (winW / 2)" "winY + (winH / 2)"; }
+
+# "+ New Capture": pinned to bottom with .padding(10)
+click_new_capture()  { click_at_rel "winX + (winW / 2)" "winY + winH - 20"; }
 
 click_cancel() {
-    # Cancel button coordinates are fragile across resolutions.
-    # Instead, use accessibility to find it: it is button 2 in the
-    # main group (button 1 is the back chevron).
-    osascript -e "
+    # Cancel button: use accessibility element lookup rather than
+    # coordinates. Button order within group 1 is empirical — verify
+    # with Accessibility Inspector if the view hierarchy changes.
+    local result
+    result=$(osascript -e "
         tell application \"System Events\"
             tell process \"$APP_NAME\"
                 set grp to group 1 of window 1
                 set allBtns to every button of grp
-                -- Button order: 1=back chevron, 2=Cancel, 3=Add to Queue
                 if (count of allBtns) >= 2 then
                     click item 2 of allBtns
+                    return \"clicked\"
+                else
+                    return \"error: only \" & (count of allBtns) & \" buttons found, expected >= 2\"
                 end if
             end tell
         end tell
-    " >/dev/null 2>&1
+    ")
+    if [[ "$result" == error:* ]]; then
+        echo ""
+        echo "$(red ERROR): click_cancel: $result" >&2
+        exit 1
+    fi
     sleep "$ANIM_WAIT"
 }
 
@@ -122,7 +100,12 @@ assert_width() {
     local expected="$2"
     total=$((total + 1))
     local actual
-    actual=$(get_width)
+    actual=$(get_width) || true
+    if [ -z "$actual" ]; then
+        failed=$((failed + 1))
+        printf "  %-45s $(red FAIL)  (could not read window width)\n" "$label"
+        return
+    fi
     if [ "$actual" -eq "$expected" ]; then
         passed=$((passed + 1))
         printf "  %-45s $(green PASS)  (%dpx)\n" "$label" "$actual"
@@ -145,6 +128,18 @@ assert_running() {
         exit 1
     fi
 }
+
+# ─── pre-flight ────────────────────────────────────────────────────
+
+if ! osascript -e 'tell application "System Events" to return name of first process' >/dev/null 2>&1; then
+    echo ""
+    red "ERROR"
+    echo ": Cannot access System Events."
+    echo "  Grant Accessibility permission to your terminal app:"
+    echo "  System Settings > Privacy & Security > Accessibility"
+    echo ""
+    exit 1
+fi
 
 # ─── setup ─────────────────────────────────────────────────────────
 

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# RedditReminder QA — automated state-transition tests
+# Requires: the app to have been built via `make install` first.
+#
+# Uses macOS Accessibility (System Events) to click SwiftUI Buttons
+# and verifies window width matches expected sidebar state.
+#
+# NOTE: This does NOT test the ⌘⇧R global shortcut — that requires
+# granting Accessibility permission to RedditReminder manually.
+
+set -euo pipefail
+
+APP_NAME="RedditReminder"
+APP_PATH="$HOME/Applications/$APP_NAME.app"
+ANIM_WAIT=0.6          # seconds to wait for width animation (0.35s) + margin
+LAUNCH_WAIT=2           # seconds to wait after launch
+
+# Expected widths from Constants.swift
+W_STRIP=24
+W_GLANCE=200
+W_BROWSE=320
+W_CAPTURE=480
+
+passed=0
+failed=0
+total=0
+
+# ─── helpers ───────────────────────────────────────────────────────
+
+red()   { printf '\033[31m%s\033[0m' "$1"; }
+green() { printf '\033[32m%s\033[0m' "$1"; }
+bold()  { printf '\033[1m%s\033[0m' "$1"; }
+
+get_width() {
+    osascript -e "
+        tell application \"System Events\"
+            tell process \"$APP_NAME\"
+                set {w, h} to size of window 1
+                return w as integer
+            end tell
+        end tell
+    " 2>/dev/null
+}
+
+get_pos_size() {
+    osascript -e "
+        tell application \"System Events\"
+            tell process \"$APP_NAME\"
+                set {x, y} to position of window 1
+                set {w, h} to size of window 1
+                return (x as text) & \",\" & (y as text) & \",\" & (w as text) & \",\" & (h as text)
+            end tell
+        end tell
+    " 2>/dev/null
+}
+
+click_back_chevron() {
+    # The back chevron is button 1 inside the header group — the first button
+    # in the window, positioned top-right with padding(.horizontal, 14).
+    osascript -e "
+        tell application \"System Events\"
+            tell process \"$APP_NAME\"
+                set {winX, winY} to position of window 1
+                set {winW, winH} to size of window 1
+                click at {winX + winW - 21, winY + 20}
+            end tell
+        end tell
+    " >/dev/null 2>&1
+    sleep "$ANIM_WAIT"
+}
+
+click_strip() {
+    # The strip is a full-height Button. Click its center.
+    osascript -e "
+        tell application \"System Events\"
+            tell process \"$APP_NAME\"
+                set {winX, winY} to position of window 1
+                set {winW, winH} to size of window 1
+                click at {winX + (winW / 2), winY + (winH / 2)}
+            end tell
+        end tell
+    " >/dev/null 2>&1
+    sleep "$ANIM_WAIT"
+}
+
+click_new_capture() {
+    # "+ New Capture" is the last button in the window, pinned to bottom.
+    # In both Glance and Browse it sits at padding(10/10) from bottom.
+    osascript -e "
+        tell application \"System Events\"
+            tell process \"$APP_NAME\"
+                set {winX, winY} to position of window 1
+                set {winW, winH} to size of window 1
+                click at {winX + (winW / 2), winY + winH - 20}
+            end tell
+        end tell
+    " >/dev/null 2>&1
+    sleep "$ANIM_WAIT"
+}
+
+click_cancel() {
+    # Cancel button coordinates are fragile across resolutions.
+    # Instead, use accessibility to find it: it is button 2 in the
+    # main group (button 1 is the back chevron).
+    osascript -e "
+        tell application \"System Events\"
+            tell process \"$APP_NAME\"
+                set grp to group 1 of window 1
+                set allBtns to every button of grp
+                -- Button order: 1=back chevron, 2=Cancel, 3=Add to Queue
+                if (count of allBtns) >= 2 then
+                    click item 2 of allBtns
+                end if
+            end tell
+        end tell
+    " >/dev/null 2>&1
+    sleep "$ANIM_WAIT"
+}
+
+assert_width() {
+    local label="$1"
+    local expected="$2"
+    total=$((total + 1))
+    local actual
+    actual=$(get_width)
+    if [ "$actual" -eq "$expected" ]; then
+        passed=$((passed + 1))
+        printf "  %-45s $(green PASS)  (%dpx)\n" "$label" "$actual"
+    else
+        failed=$((failed + 1))
+        printf "  %-45s $(red FAIL)  (expected %dpx, got %dpx)\n" "$label" "$expected" "$actual"
+    fi
+}
+
+assert_running() {
+    total=$((total + 1))
+    if pgrep -x "$APP_NAME" >/dev/null 2>&1; then
+        passed=$((passed + 1))
+        printf "  %-45s $(green PASS)\n" "$1"
+    else
+        failed=$((failed + 1))
+        printf "  %-45s $(red FAIL)  (process not found)\n" "$1"
+        echo ""
+        echo "$(red 'ABORT'): App not running. Cannot continue."
+        exit 1
+    fi
+}
+
+# ─── setup ─────────────────────────────────────────────────────────
+
+echo ""
+bold "RedditReminder QA"
+echo ""
+echo "─────────────────────────────────────────────────"
+
+# Kill any existing instance
+pkill -x "$APP_NAME" 2>/dev/null || true
+sleep 1
+
+# Launch
+echo "  Launching $APP_NAME..."
+open "$APP_PATH"
+sleep "$LAUNCH_WAIT"
+
+# ─── tests ─────────────────────────────────────────────────────────
+
+echo ""
+bold "1. Launch"
+echo ""
+assert_running "App is running"
+assert_width   "Starts in Glance mode"              "$W_GLANCE"
+
+echo ""
+bold "2. Step down: Glance → Strip"
+echo ""
+click_back_chevron
+assert_width   "Back chevron → Strip"                "$W_STRIP"
+
+echo ""
+bold "3. Expand: Strip → Glance"
+echo ""
+click_strip
+assert_width   "Click strip → Glance"               "$W_GLANCE"
+
+echo ""
+bold "4. New Capture: Glance → Capture"
+echo ""
+click_new_capture
+assert_width   "New Capture → Capture"               "$W_CAPTURE"
+
+echo ""
+bold "5. Cancel: Capture → Browse"
+echo ""
+click_cancel
+assert_width   "Cancel → Browse"                     "$W_BROWSE"
+
+echo ""
+bold "6. Step down: Browse → Glance"
+echo ""
+click_back_chevron
+assert_width   "Back chevron → Glance"               "$W_GLANCE"
+
+echo ""
+bold "7. Step down: Glance → Strip"
+echo ""
+click_back_chevron
+assert_width   "Back chevron → Strip"                "$W_STRIP"
+
+echo ""
+bold "8. Expand + New Capture: Strip → Glance → Capture"
+echo ""
+click_strip
+assert_width   "Click strip → Glance"               "$W_GLANCE"
+click_new_capture
+assert_width   "New Capture → Capture"               "$W_CAPTURE"
+
+echo ""
+bold "9. Full step-down: Capture → Browse → Glance → Strip"
+echo ""
+click_back_chevron
+assert_width   "Back chevron → Browse"               "$W_BROWSE"
+click_back_chevron
+assert_width   "Back chevron → Glance"               "$W_GLANCE"
+click_back_chevron
+assert_width   "Back chevron → Strip"                "$W_STRIP"
+
+echo ""
+bold "10. Restart persistence"
+echo ""
+click_strip    # back to Glance so we can verify it restarts at Glance
+assert_width   "Pre-restart: Glance"                 "$W_GLANCE"
+
+pkill -x "$APP_NAME" 2>/dev/null || true
+sleep 2
+open "$APP_PATH"
+sleep "$LAUNCH_WAIT"
+
+assert_running "App restarts after kill"
+assert_width   "Restart in Glance mode"              "$W_GLANCE"
+
+# ─── summary ───────────────────────────────────────────────────────
+
+echo ""
+echo "─────────────────────────────────────────────────"
+if [ "$failed" -eq 0 ]; then
+    green "ALL $total TESTS PASSED"
+    echo ""
+else
+    red "$failed/$total TESTS FAILED"
+    echo ""
+fi
+echo ""
+
+# Clean up — leave app running
+exit "$failed"


### PR DESCRIPTION
## Summary

- **Fix mouse click handling on non-activating NSPanel** — borderless panels with `.nonactivatingPanel` didn't deliver mouse events to SwiftUI gesture recognizers. Added `ClickablePanel` (overrides `canBecomeKey`), `FirstMouseHostingView` (overrides `acceptsFirstMouse` + calls `makeKey` on mouseDown), and converted `StripView` from `onTapGesture` to `Button` for accessibility compatibility.
- **Add `make qa` target** — 16 automated state-transition tests using macOS System Events. Covers all sidebar width transitions (Strip 24px ↔ Glance 200px ↔ Browse 320px ↔ Capture 480px), Cancel button, and restart persistence. Includes pre-flight Accessibility permission check and explicit error reporting.

## Test plan

- [x] `make qa` — 16/16 pass (ran 3x for stability)
- [x] `make test` — 21/21 unit tests pass
- [x] PR review toolkit — all 5 agents passed, findings addressed
- [ ] Manual: grant Accessibility permission to RedditReminder, verify ⌘⇧R toggles Capture mode