### PR TITLE
fix: handle save failures and wire up settings toggles

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -8,25 +8,38 @@
 
 /* Begin PBXBuildFile section */
 		041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */; };
+		0D7E617E7C0A1186A30950D2 /* EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713CD0ACC229354496B78963 /* EventCardView.swift */; };
+		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
+		1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */; };
 		19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */; };
 		1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */; };
+		1AD1095D15AF2B7E0E3327CD /* CaptureFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CD3A5FC6E7983BBA907CB4 /* CaptureFormView.swift */; };
 		1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */; };
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0972EE8B384E16C0A49F8555 /* AppDelegate.swift */; };
 		42EF49CDAB403FE9D2C36047 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BB3D18ECE13E70E7CED42 /* NotificationService.swift */; };
 		4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599273192FBCFDD93D1241B0 /* Project.swift */; };
+		53913174FE1B50F35E71F943 /* StripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C6D67956AA868C08076F76 /* StripView.swift */; };
 		5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */; };
 		59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1122ADEB6045619C303C31 /* MediaStore.swift */; };
 		70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */; };
+		7CD67ED8F5DC8F6C943BE8A6 /* ShortcutOnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0393A914335AAD76177A0BEF /* ShortcutOnboardingCard.swift */; };
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
 		AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */; };
 		B9D3BFE8CE05FE6BCCB4FF46 /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2907084ECC960F75B01FFF68 /* SidebarContainer.swift */; };
+		C08610209A9D352D685CC62C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A3EA2A16B7A969EEE23612 /* SettingsView.swift */; };
 		C39F0B757AA89B7E596CE04B /* PanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6C46310DB68B2C81414AF /* PanelController.swift */; };
+		CBDAF2B201BB1B62E93523FD /* StickerStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0144FEB34C80DE3BFB4A857E /* StickerStyles.swift */; };
+		E0718F0D864C93466EDE5853 /* GlanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D98059F1147872F9CF81808 /* GlanceView.swift */; };
+		E540E51D10808143C9CC1B5A /* CalendarTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1E6AFDC2B2079AD81942AE /* CalendarTimelineView.swift */; };
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
+		F3D7FA560D0118761704A5A1 /* BrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0C24D2A29397F286CFCCF5 /* BrowseView.swift */; };
+		FBA7D68E7031F3E4736725FB /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2587FDCA2CF244148425F802 /* CalendarMonthView.swift */; };
 		FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
+		FF8BF82A6287E5C03DD74E42 /* PanelControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9729B349E72502E22A9A25 /* PanelControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,13 +53,19 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0144FEB34C80DE3BFB4A857E /* StickerStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerStyles.swift; sourceTree = "<group>"; };
+		0393A914335AAD76177A0BEF /* ShortcutOnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutOnboardingCard.swift; sourceTree = "<group>"; };
 		050BB3D18ECE13E70E7CED42 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		0972EE8B384E16C0A49F8555 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelperTests.swift; sourceTree = "<group>"; };
 		20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
+		2587FDCA2CF244148425F802 /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
 		2907084ECC960F75B01FFF68 /* SidebarContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarContainer.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		32CD3A5FC6E7983BBA907CB4 /* CaptureFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureFormView.swift; sourceTree = "<group>"; };
+		3D98059F1147872F9CF81808 /* GlanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlanceView.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
+		4C9729B349E72502E22A9A25 /* PanelControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelControllerTests.swift; sourceTree = "<group>"; };
 		4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngine.swift; sourceTree = "<group>"; };
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
@@ -54,15 +73,22 @@
 		5DB4E56FCDA7A1CB1F24566D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		5FD6C46310DB68B2C81414AF /* PanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelController.swift; sourceTree = "<group>"; };
 		614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditEvent.swift; sourceTree = "<group>"; };
+		66C6D67956AA868C08076F76 /* StripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripView.swift; sourceTree = "<group>"; };
 		6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStore.swift; sourceTree = "<group>"; };
+		713CD0ACC229354496B78963 /* EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCardView.swift; sourceTree = "<group>"; };
 		726D903A97B808C6ED572BCA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderApp.swift; sourceTree = "<group>"; };
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C0C24D2A29397F286CFCCF5 /* BrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseView.swift; sourceTree = "<group>"; };
+		9D1E6AFDC2B2079AD81942AE /* CalendarTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTimelineView.swift; sourceTree = "<group>"; };
 		9FA306067C4690F4D1CDAC2D /* Subreddit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subreddit.swift; sourceTree = "<group>"; };
 		9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
+		A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureCardView.swift; sourceTree = "<group>"; };
 		AE1122ADEB6045619C303C31 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		AEE4E14F7A70E1A66FA994A3 /* Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture.swift; sourceTree = "<group>"; };
+		B338E8D9C979B250564A392E /* QAFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAFixtures.swift; sourceTree = "<group>"; };
 		B727389070814347602E1AB3 /* TimingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineTests.swift; sourceTree = "<group>"; };
+		F5A3EA2A16B7A969EEE23612 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -85,6 +111,7 @@
 				560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */,
 				20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */,
 				9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */,
+				4C9729B349E72502E22A9A25 /* PanelControllerTests.swift */,
 				0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */,
 				B727389070814347602E1AB3 /* TimingEngineTests.swift */,
 			);
@@ -96,7 +123,9 @@
 			children = (
 				5DB4E56FCDA7A1CB1F24566D /* Constants.swift */,
 				56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */,
+				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
+				0144FEB34C80DE3BFB4A857E /* StickerStyles.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -153,7 +182,17 @@
 		EE2AEE0CFEFFFEF4F88FBA15 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				9C0C24D2A29397F286CFCCF5 /* BrowseView.swift */,
+				2587FDCA2CF244148425F802 /* CalendarMonthView.swift */,
+				9D1E6AFDC2B2079AD81942AE /* CalendarTimelineView.swift */,
+				A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */,
+				32CD3A5FC6E7983BBA907CB4 /* CaptureFormView.swift */,
+				713CD0ACC229354496B78963 /* EventCardView.swift */,
+				3D98059F1147872F9CF81808 /* GlanceView.swift */,
+				F5A3EA2A16B7A969EEE23612 /* SettingsView.swift */,
+				0393A914335AAD76177A0BEF /* ShortcutOnboardingCard.swift */,
 				2907084ECC960F75B01FFF68 /* SidebarContainer.swift */,
+				66C6D67956AA868C08076F76 /* StripView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -250,6 +289,7 @@
 				5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */,
 				70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */,
 				AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */,
+				FF8BF82A6287E5C03DD74E42 /* PanelControllerTests.swift in Sources */,
 				041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */,
 				24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */,
 			);
@@ -260,17 +300,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */,
+				F3D7FA560D0118761704A5A1 /* BrowseView.swift in Sources */,
+				FBA7D68E7031F3E4736725FB /* CalendarMonthView.swift in Sources */,
+				E540E51D10808143C9CC1B5A /* CalendarTimelineView.swift in Sources */,
 				F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */,
+				1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */,
+				1AD1095D15AF2B7E0E3327CD /* CaptureFormView.swift in Sources */,
 				81C26D97123D840A9130AF7E /* Constants.swift in Sources */,
+				0D7E617E7C0A1186A30950D2 /* EventCardView.swift in Sources */,
+				E0718F0D864C93466EDE5853 /* GlanceView.swift in Sources */,
 				EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */,
 				E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */,
 				59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */,
 				42EF49CDAB403FE9D2C36047 /* NotificationService.swift in Sources */,
 				C39F0B757AA89B7E596CE04B /* PanelController.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,
+				17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */,
 				FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */,
 				1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */,
+				C08610209A9D352D685CC62C /* SettingsView.swift in Sources */,
+				7CD67ED8F5DC8F6C943BE8A6 /* ShortcutOnboardingCard.swift in Sources */,
 				B9D3BFE8CE05FE6BCCB4FF46 /* SidebarContainer.swift in Sources */,
+				CBDAF2B201BB1B62E93523FD /* StickerStyles.swift in Sources */,
+				53913174FE1B50F35E71F943 /* StripView.swift in Sources */,
 				35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */,
 				19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */,
 				1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -71,6 +71,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let activeEvents = events.filter(\.isActive)
         timingEngine.refresh(events: activeEvents, captures: captures)
 
+        let notificationsEnabled = UserDefaults.standard.object(forKey: "notificationsEnabled") as? Bool ?? true
+        guard notificationsEnabled else {
+            notificationService.cancelAll()
+            NSLog("RedditReminder: refresh complete — notifications disabled, all cancelled")
+            return
+        }
+
         // Track which event IDs have active windows
         var activeEventIds: Set<String> = []
 

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -74,7 +74,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let notificationsEnabled = UserDefaults.standard.object(forKey: "notificationsEnabled") as? Bool ?? true
         guard notificationsEnabled else {
             notificationService.cancelAll()
-            NSLog("RedditReminder: refresh complete — notifications disabled, all cancelled")
+            NSLog("RedditReminder: notifications disabled — cancelled all, skipping schedule")
             return
         }
 

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -35,6 +35,14 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(maxWidth: 200)
+                    .onChange(of: restingState) { _, newVal in
+                        if let state = SidebarState(rawValue: newVal) {
+                            panelController.setAutoCollapse(
+                                minutes: autoCollapseMinutes,
+                                restingState: state
+                            )
+                        }
+                    }
                 }
 
                 LabeledContent("Auto-collapse") {
@@ -46,6 +54,14 @@ struct SettingsView: View {
                         Text("Never").tag(0)
                     }
                     .frame(maxWidth: 120)
+                    .onChange(of: autoCollapseMinutes) { _, newVal in
+                        if let state = SidebarState(rawValue: restingState) {
+                            panelController.setAutoCollapse(
+                                minutes: newVal,
+                                restingState: state
+                            )
+                        }
+                    }
                 }
 
                 StickerDivider()

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UserNotifications
 
 struct SettingsView: View {
     @Bindable var panelController: PanelController
@@ -9,6 +10,14 @@ struct SettingsView: View {
     @AppStorage("notificationsEnabled") private var notificationsEnabled = true
     @AppStorage("defaultLeadTimeMinutes") private var defaultLeadTimeMinutes = 60
     @AppStorage("nudgeWhenEmpty") private var nudgeWhenEmpty = true
+
+    private func syncAutoCollapse() {
+        guard let state = SidebarState(rawValue: restingState) else {
+            NSLog("RedditReminder: invalid restingState rawValue: \(restingState)")
+            return
+        }
+        panelController.setAutoCollapse(minutes: autoCollapseMinutes, restingState: state)
+    }
 
     var body: some View {
         ScrollView {
@@ -35,14 +44,7 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.segmented)
                     .frame(maxWidth: 200)
-                    .onChange(of: restingState) { _, newVal in
-                        if let state = SidebarState(rawValue: newVal) {
-                            panelController.setAutoCollapse(
-                                minutes: autoCollapseMinutes,
-                                restingState: state
-                            )
-                        }
-                    }
+                    .onChange(of: restingState) { syncAutoCollapse() }
                 }
 
                 LabeledContent("Auto-collapse") {
@@ -54,20 +56,18 @@ struct SettingsView: View {
                         Text("Never").tag(0)
                     }
                     .frame(maxWidth: 120)
-                    .onChange(of: autoCollapseMinutes) { _, newVal in
-                        if let state = SidebarState(rawValue: restingState) {
-                            panelController.setAutoCollapse(
-                                minutes: newVal,
-                                restingState: state
-                            )
-                        }
-                    }
+                    .onChange(of: autoCollapseMinutes) { syncAutoCollapse() }
                 }
 
                 StickerDivider()
                 stickerSectionLabel("Notifications", size: 10)
 
                 Toggle("macOS notifications", isOn: $notificationsEnabled)
+                    .onChange(of: notificationsEnabled) { _, enabled in
+                        if !enabled {
+                            UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+                        }
+                    }
 
                 LabeledContent("Default lead time") {
                     Picker("", selection: $defaultLeadTimeMinutes) {

--- a/Sources/Views/SidebarContainer.swift
+++ b/Sources/Views/SidebarContainer.swift
@@ -48,7 +48,11 @@ struct SidebarContainer: View {
                         onNewCapture: { panelController.setState(.capture) },
                         onMarkPosted: { capture in
                             capture.markAsPosted()
-                            try? modelContext.save()
+                            do {
+                                try modelContext.save()
+                            } catch {
+                                NSLog("RedditReminder: failed to save posted status: \(error)")
+                            }
                         }
                     )
                 case .capture:
@@ -64,8 +68,13 @@ struct SidebarContainer: View {
                                 subreddits: subs
                             )
                             modelContext.insert(capture)
-                            try? modelContext.save()
-                            panelController.setState(.browse)
+                            do {
+                                try modelContext.save()
+                                panelController.setState(.browse)
+                            } catch {
+                                modelContext.rollback()
+                                NSLog("RedditReminder: failed to save capture: \(error)")
+                            }
                         },
                         onCancel: { panelController.setState(.browse) }
                     )

--- a/Sources/Views/SidebarContainer.swift
+++ b/Sources/Views/SidebarContainer.swift
@@ -51,6 +51,7 @@ struct SidebarContainer: View {
                             do {
                                 try modelContext.save()
                             } catch {
+                                modelContext.rollback()
                                 NSLog("RedditReminder: failed to save posted status: \(error)")
                             }
                         }


### PR DESCRIPTION
## Summary

- Replace `try? context.save()` with do/catch + rollback in SidebarContainer — mark-posted and capture-save no longer silently drop data
- Wire up `restingState` and `autoCollapseMinutes` settings to call `panelController.setAutoCollapse()` on change
- Make `notificationsEnabled` toggle immediately cancel pending notifications (not just on next 5-min timer tick)
- Update project.pbxproj to include files added in v2

## Test plan
- [x] Build succeeds
- [x] 27/27 unit tests pass
- [ ] QA: Toggle notifications off → verify no notifications fire within 5 min
- [ ] QA: Change resting state → verify auto-collapse uses new state
- [ ] QA: Save a capture with disk pressure → verify form stays open on failure