### PR TITLE
fix: eliminate remaining try? patterns and add PanelController tests

### DIFF
--- a/Sources/Services/HeuristicsStore.swift
+++ b/Sources/Services/HeuristicsStore.swift
@@ -42,10 +42,23 @@ final class HeuristicsStore {
   }
 
   private func loadBundled(from bundle: Bundle) {
-    guard let url = bundle.url(forResource: "peak-times", withExtension: "json"),
-      let data = try? Data(contentsOf: url),
-      let json = try? JSONSerialization.jsonObject(with: data) as? [String: [String: Any]]
-    else { return }
+    guard let url = bundle.url(forResource: "peak-times", withExtension: "json") else {
+      NSLog("RedditReminder: peak-times.json not found in bundle")
+      return
+    }
+
+    let json: [String: [String: Any]]
+    do {
+      let data = try Data(contentsOf: url)
+      guard let parsed = try JSONSerialization.jsonObject(with: data) as? [String: [String: Any]] else {
+        NSLog("RedditReminder: peak-times.json has unexpected structure")
+        return
+      }
+      json = parsed
+    } catch {
+      NSLog("RedditReminder: failed to load peak-times.json: \(error)")
+      return
+    }
 
     for (sub, info) in json {
       if let days = info["peak_days"] as? [String],

--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -34,6 +34,8 @@ final class MediaStore {
       } catch {
         NSLog("RedditReminder: failed to write thumbnail: \(error)")
       }
+    } else {
+      NSLog("RedditReminder: failed to encode thumbnail PNG for \(fileName)")
     }
 
     return fileName
@@ -58,6 +60,8 @@ final class MediaStore {
     let dir = rootDir.appendingPathComponent(captureId.uuidString)
     do {
       try fm.removeItem(at: dir)
+    } catch CocoaError.fileNoSuchFile {
+      // Directory already absent — nothing to clean up
     } catch {
       NSLog("RedditReminder: failed to delete media for \(captureId): \(error)")
     }

--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -29,7 +29,11 @@ final class MediaStore {
     let thumbnail = generateThumbnail(from: image, maxSize: MediaConstants.thumbnailMaxSize)
     if let thumbData = pngData(from: thumbnail) {
       let thumbURL = thumbDir.appendingPathComponent(fileName)
-      try? thumbData.write(to: thumbURL)
+      do {
+        try thumbData.write(to: thumbURL)
+      } catch {
+        NSLog("RedditReminder: failed to write thumbnail: \(error)")
+      }
     }
 
     return fileName
@@ -52,7 +56,11 @@ final class MediaStore {
 
   func deleteAll(captureId: UUID) {
     let dir = rootDir.appendingPathComponent(captureId.uuidString)
-    try? fm.removeItem(at: dir)
+    do {
+      try fm.removeItem(at: dir)
+    } catch {
+      NSLog("RedditReminder: failed to delete media for \(captureId): \(error)")
+    }
   }
 
   private func generateThumbnail(from image: NSImage, maxSize: CGFloat) -> NSImage {

--- a/Tests/RedditReminderTests/PanelControllerTests.swift
+++ b/Tests/RedditReminderTests/PanelControllerTests.swift
@@ -2,12 +2,14 @@ import Testing
 import Foundation
 @testable import RedditReminder
 
+@Suite(.serialized)
 @MainActor
 struct PanelControllerTests {
     private let testDefaults = UserDefaults(suiteName: "PanelControllerTests")!
 
     init() {
         testDefaults.removePersistentDomain(forName: "PanelControllerTests")
+        UserDefaults.standard.removeObject(forKey: "sidebarState")
     }
 
     @Test func statePersistsToUserDefaults() {
@@ -15,7 +17,6 @@ struct PanelControllerTests {
         pc.state = .browse
         let saved = UserDefaults.standard.string(forKey: "sidebarState")
         #expect(saved == "browse")
-        UserDefaults.standard.removeObject(forKey: "sidebarState")
     }
 
     @Test func captureRestoresToBrowse() {

--- a/Tests/RedditReminderTests/PanelControllerTests.swift
+++ b/Tests/RedditReminderTests/PanelControllerTests.swift
@@ -46,4 +46,66 @@ struct PanelControllerTests {
         let result = PanelController.restoredState(from: testDefaults)
         #expect(result == .glance)
     }
+
+    // MARK: - setAutoCollapse
+
+    @Test func setAutoCollapseAcceptsValidInputs() {
+        let pc = PanelController()
+        pc.setAutoCollapse(minutes: 10, restingState: .strip)
+        pc.setAutoCollapse(minutes: 5, restingState: .glance)
+        pc.setAutoCollapse(minutes: 30, restingState: .browse)
+        // No crash = pass; values are private but timer is reset each call
+    }
+
+    @Test func setAutoCollapseZeroDisablesTimer() {
+        let pc = PanelController()
+        pc.state = .browse
+        pc.setAutoCollapse(minutes: 0, restingState: .strip)
+        // With minutes=0, timer should not fire — state remains unchanged
+        #expect(pc.state == .browse)
+    }
+
+    // MARK: - isWiderThan
+
+    @Test func isWiderThanComparesCorrectly() {
+        #expect(SidebarState.capture.isWiderThan(.browse))
+        #expect(SidebarState.browse.isWiderThan(.glance))
+        #expect(SidebarState.glance.isWiderThan(.strip))
+        #expect(!SidebarState.strip.isWiderThan(.glance))
+        #expect(!SidebarState.glance.isWiderThan(.browse))
+        #expect(!SidebarState.glance.isWiderThan(.glance))
+    }
+
+    // MARK: - stepDown / toggleCapture
+
+    @Test func stepDownFollowsLadder() {
+        let pc = PanelController()
+        pc.state = .capture
+        pc.stepDown()
+        #expect(pc.state == .browse)
+        pc.stepDown()
+        #expect(pc.state == .glance)
+        pc.stepDown()
+        #expect(pc.state == .strip)
+        pc.stepDown()
+        #expect(pc.state == .strip)  // can't go below strip
+    }
+
+    @Test func stepDownFromSettingsReturnsToPreviousState() {
+        let pc = PanelController()
+        pc.state = .browse
+        pc.goToSettings()
+        #expect(pc.state == .settings)
+        pc.stepDown()
+        #expect(pc.state == .browse)
+    }
+
+    @Test func toggleCaptureFlipsBetweenCaptureAndBrowse() {
+        let pc = PanelController()
+        pc.state = .glance
+        pc.toggleCapture()
+        #expect(pc.state == .capture)
+        pc.toggleCapture()
+        #expect(pc.state == .browse)
+    }
 }

--- a/Tests/RedditReminderTests/PanelControllerTests.swift
+++ b/Tests/RedditReminderTests/PanelControllerTests.swift
@@ -57,11 +57,12 @@ struct PanelControllerTests {
         // No crash = pass; values are private but timer is reset each call
     }
 
-    @Test func setAutoCollapseZeroDisablesTimer() {
+    @Test func setAutoCollapseZeroDoesNotCrash() {
         let pc = PanelController()
         pc.state = .browse
         pc.setAutoCollapse(minutes: 0, restingState: .strip)
-        // With minutes=0, timer should not fire — state remains unchanged
+        // Smoke test: zero minutes accepted without crash.
+        // Timer behavior is asynchronous and not verified here.
         #expect(pc.state == .browse)
     }
 
@@ -98,6 +99,16 @@ struct PanelControllerTests {
         #expect(pc.state == .settings)
         pc.stepDown()
         #expect(pc.state == .browse)
+    }
+
+    @Test func goToSettingsFromStripReturnesToGlance() {
+        let pc = PanelController()
+        pc.state = .strip
+        pc.goToSettings()
+        #expect(pc.state == .settings)
+        pc.stepDown()
+        // Strip has no header — previousState saved as .glance instead
+        #expect(pc.state == .glance)
     }
 
     @Test func toggleCaptureFlipsBetweenCaptureAndBrowse() {


### PR DESCRIPTION
## Summary

- Replace all remaining `try?` with do/catch + logging in HeuristicsStore and MediaStore — zero `try?` now remains in Sources/
- HeuristicsStore: 3 distinct failure paths with specific log messages (was silent, could disable entire timing system)
- MediaStore: log thumbnail write/encoding failures, filter benign `fileNoSuchFile` in deleteAll
- Add 7 PanelController tests: setAutoCollapse, isWiderThan, stepDown ladder, settings navigation, toggleCapture (27 → 34)

## Test plan
- [x] Build succeeds
- [x] 34/34 unit tests pass
- [x] `grep -rn 'try?' Sources/` returns zero matches
- [x] Existing HeuristicsStore + MediaStore tests still pass (happy paths unchanged)