### PR TITLE
fix: release job skipped due to transitive skip propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,10 @@ jobs:
 
   release:
     name: Release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      always() && !cancelled() &&
+      needs.ci-gate.result == 'success' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [ci-gate]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- The release job was skipped on push to main because `detect-changes` (PR-only) was skipped, and GitHub Actions propagates skip status through the dependency graph
- Added `always() && !cancelled() && needs.ci-gate.result == 'success'` guard so the release job runs when ci-gate passes, regardless of transitive skips

## Test plan
- [ ] CI passes on this PR (release job should show as "skipping" since it's a PR, not push to main)
- [ ] After merge, release job should run (not skip) on the push-to-main CI run