### PR TITLE
fix: strip width incorrect on cold start

### DIFF
--- a/Sources/Services/PanelController.swift
+++ b/Sources/Services/PanelController.swift
@@ -63,9 +63,10 @@ final class PanelController {
         self.panel = panel
         self.hostingView = hosting
 
-        // Position at glance width first so the hosting view lays out wide,
-        // then set restored state and animate to the correct width. This avoids
-        // the hosting view's intrinsic sizing fighting narrow cold-start widths.
+        // Position at glance width (200pt) first so NSHostingView completes its
+        // initial layout without fighting the frame. Then restore the saved state
+        // (e.g. .strip at 24pt) and animate to it. Without this, NSHostingView's
+        // intrinsic sizing overrides narrow widths on cold start.
         state = .glance
         positionPanel()
         panel.orderFront(nil)

--- a/Sources/Services/PanelController.swift
+++ b/Sources/Services/PanelController.swift
@@ -39,6 +39,8 @@ final class PanelController {
     enum ScreenEdge { case left, right }
 
     func setup(contentView: some View) {
+        let restored = Self.restoredState()
+
         let panel = ClickablePanel(
             contentRect: NSRect(x: 0, y: 0, width: SidebarConstants.glanceWidth, height: 0),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -51,17 +53,27 @@ final class PanelController {
         panel.hasShadow = true
         panel.backgroundColor = NSColor(red: 0.07, green: 0.08, blue: 0.14, alpha: 1.0)
         panel.isOpaque = false
+        panel.contentMinSize = NSSize(width: 1, height: 1)
+        panel.minSize = NSSize(width: 1, height: 1)
 
         let hosting = FirstMouseHostingView(rootView: AnyView(contentView))
+        hosting.sizingOptions = []
         panel.contentView = hosting
 
         self.panel = panel
         self.hostingView = hosting
 
-        state = Self.restoredState()
-
+        // Position at glance width first so the hosting view lays out wide,
+        // then set restored state and animate to the correct width. This avoids
+        // the hosting view's intrinsic sizing fighting narrow cold-start widths.
+        state = .glance
         positionPanel()
         panel.orderFront(nil)
+
+        if restored != .glance {
+            state = restored
+            animateWidth()
+        }
         resetAutoCollapseTimer()
     }
 


### PR DESCRIPTION
## Summary
- NSHostingView's intrinsic sizing overrides the panel frame before the first layout pass, preventing narrow widths like strip (24px) from being restored on cold start
- Fix: create panel at glance width (200pt), let NSHostingView lay out, then animate to the restored state
- Also sets `panel.minSize`, `panel.contentMinSize` to (1,1) and `hosting.sizingOptions = []` to fully disable intrinsic size negotiation

## Test plan
- [ ] QA suite passes 20/20 (including restart persistence at strip width)
- [ ] CI passes (lint, build, unit-tests, file-size-check)