### PR TITLE
feat: optional project, default subreddits, settings management

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
 		F3D7FA560D0118761704A5A1 /* BrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0C24D2A29397F286CFCCF5 /* BrowseView.swift */; };
+		F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */; };
 		FBA7D68E7031F3E4736725FB /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2587FDCA2CF244148425F802 /* CalendarMonthView.swift */; };
 		FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
 		FF8BF82A6287E5C03DD74E42 /* PanelControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C9729B349E72502E22A9A25 /* PanelControllerTests.swift */; };
@@ -66,6 +67,7 @@
 		3D98059F1147872F9CF81808 /* GlanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlanceView.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4C9729B349E72502E22A9A25 /* PanelControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelControllerTests.swift; sourceTree = "<group>"; };
+		4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubreddits.swift; sourceTree = "<group>"; };
 		4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngine.swift; sourceTree = "<group>"; };
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 			isa = PBXGroup;
 			children = (
 				5DB4E56FCDA7A1CB1F24566D /* Constants.swift */,
+				4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */,
 				56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */,
 				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
@@ -307,6 +310,7 @@
 				1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */,
 				1AD1095D15AF2B7E0E3327CD /* CaptureFormView.swift in Sources */,
 				81C26D97123D840A9130AF7E /* Constants.swift in Sources */,
+				F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */,
 				0D7E617E7C0A1186A30950D2 /* EventCardView.swift in Sources */,
 				E0718F0D864C93466EDE5853 /* GlanceView.swift in Sources */,
 				EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */,

--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -21,7 +21,7 @@ struct RedditReminderApp: App {
                 .frame(width: 1, height: 1)
                 .onAppear {
                     appDelegate.modelContainer = container
-                    DefaultSubreddits.seedIfEmpty(context: ModelContext(container))
+                    DefaultSubreddits.seedIfEmpty(context: container.mainContext)
                     let sidebarView = SidebarContainer(panelController: appDelegate.panelController)
                         .modelContainer(container)
                     appDelegate.panelController.setup(contentView: sidebarView)

--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -21,6 +21,7 @@ struct RedditReminderApp: App {
                 .frame(width: 1, height: 1)
                 .onAppear {
                     appDelegate.modelContainer = container
+                    DefaultSubreddits.seedIfEmpty(context: ModelContext(container))
                     let sidebarView = SidebarContainer(panelController: appDelegate.panelController)
                         .modelContainer(container)
                     appDelegate.panelController.setup(contentView: sidebarView)

--- a/Sources/Models/Capture.swift
+++ b/Sources/Models/Capture.swift
@@ -23,8 +23,8 @@ final class Capture {
         text: String,
         notes: String? = nil,
         mediaRefs: [String] = [],
-        project: Project,
-        subreddits: [Subreddit]
+        project: Project? = nil,
+        subreddits: [Subreddit] = []
     ) {
         self.id = UUID()
         self.text = text

--- a/Sources/Models/Subreddit.swift
+++ b/Sources/Models/Subreddit.swift
@@ -8,7 +8,7 @@ final class Subreddit {
     var peakDaysOverride: [String]?
     var peakHoursUtcOverride: [Int]?
 
-    @Relationship(inverse: \SubredditEvent.subreddit)
+    @Relationship(deleteRule: .cascade, inverse: \SubredditEvent.subreddit)
     var events: [SubredditEvent]
 
     init(

--- a/Sources/Utilities/DefaultSubreddits.swift
+++ b/Sources/Utilities/DefaultSubreddits.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftData
+
+enum DefaultSubreddits {
+    static let names = [
+        "r/SideProject",
+        "r/SwiftUI",
+        "r/macOS",
+        "r/iOSProgramming",
+        "r/programming",
+        "r/webdev",
+        "r/golang",
+        "r/Python",
+        "r/MachineLearning",
+        "r/learnprogramming",
+        "r/devops",
+        "r/selfhosted",
+    ]
+
+    /// Seeds default subreddits if none exist in the store.
+    @MainActor
+    static func seedIfEmpty(context: ModelContext) {
+        let count: Int
+        do {
+            count = try context.fetchCount(FetchDescriptor<Subreddit>())
+        } catch {
+            NSLog("RedditReminder: failed to check subreddit count: \(error)")
+            return
+        }
+
+        guard count == 0 else { return }
+
+        for name in names {
+            context.insert(Subreddit(name: name))
+        }
+
+        do {
+            try context.save()
+            NSLog("RedditReminder: seeded \(names.count) default subreddits")
+        } catch {
+            context.rollback()
+            NSLog("RedditReminder: failed to seed default subreddits: \(error)")
+        }
+    }
+}

--- a/Sources/Views/CaptureFormView.swift
+++ b/Sources/Views/CaptureFormView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct CaptureFormView: View {
     let projects: [Project]
     let subreddits: [Subreddit]
-    let onSave: (String, String?, Project, [Subreddit], [URL]) -> Void
+    let onSave: (String, String?, Project?, [Subreddit], [URL]) -> Void
     let onCancel: () -> Void
 
     @State private var text = ""
@@ -21,7 +21,7 @@ struct CaptureFormView: View {
 
                     HStack(spacing: 8) {
                         VStack(alignment: .leading, spacing: 3) {
-                            Text("PROJECT").font(.system(size: 9, weight: .bold)).tracking(0.5).foregroundStyle(StickerColors.textSecondary)
+                            Text("PROJECT (optional)").font(.system(size: 9, weight: .bold)).tracking(0.5).foregroundStyle(StickerColors.textSecondary)
                             Picker("", selection: $selectedProject) {
                                 Text("Select...").tag(nil as Project?)
                                 ForEach(projects.filter { !$0.archived }, id: \.id) { project in
@@ -106,13 +106,12 @@ struct CaptureFormView: View {
     }
 
     private var canSave: Bool {
-        !text.isEmpty && selectedProject != nil && !selectedSubreddits.isEmpty
+        !text.isEmpty && !selectedSubreddits.isEmpty
     }
 
     private func save() {
-        guard let project = selectedProject else { return }
         let subs = subreddits.filter { selectedSubreddits.contains($0.id) }
-        onSave(text, notes.isEmpty ? nil : notes, project, subs, droppedFiles)
+        onSave(text, notes.isEmpty ? nil : notes, selectedProject, subs, droppedFiles)
     }
 
     private var subredditMultiSelect: some View {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @AppStorage("nudgeWhenEmpty") private var nudgeWhenEmpty = true
 
     @State private var newSubredditName = ""
+    @State private var subredditToDelete: Subreddit?
 
     private func syncAutoCollapse() {
         guard let state = SidebarState(rawValue: restingState) else {
@@ -97,7 +98,7 @@ struct SettingsView: View {
                             .font(.system(size: 12))
                             .foregroundStyle(StickerColors.textPrimary)
                         Spacer()
-                        Button(action: { deleteSubreddit(sub) }) {
+                        Button(action: { subredditToDelete = sub }) {
                             Image(systemName: "trash")
                                 .font(.system(size: 11))
                                 .foregroundStyle(StickerColors.reddit)
@@ -108,6 +109,22 @@ struct SettingsView: View {
                 }
             }
             .padding(16)
+        }
+        .alert("Delete Subreddit?", isPresented: Binding(
+            get: { subredditToDelete != nil },
+            set: { if !$0 { subredditToDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { subredditToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let sub = subredditToDelete {
+                    deleteSubreddit(sub)
+                    subredditToDelete = nil
+                }
+            }
+        } message: {
+            if let sub = subredditToDelete {
+                Text("Remove \(sub.name) and its events?")
+            }
         }
     }
 
@@ -129,19 +146,21 @@ struct SettingsView: View {
         }
     }
 
-    private var canAddSubreddit: Bool {
+    /// Returns the normalized name if valid and not a duplicate, nil otherwise.
+    private func validatedSubredditName() -> String? {
         let trimmed = newSubredditName.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return false }
-        let normalized = trimmed.hasPrefix("r/") ? trimmed : "r/\(trimmed)"
-        return !subreddits.contains { $0.name.lowercased() == normalized.lowercased() }
+        guard !trimmed.isEmpty else { return nil }
+        let name = trimmed.hasPrefix("r/") ? trimmed : "r/\(trimmed)"
+        guard !subreddits.contains(where: { $0.name.lowercased() == name.lowercased() }) else { return nil }
+        return name
+    }
+
+    private var canAddSubreddit: Bool {
+        validatedSubredditName() != nil
     }
 
     private func addSubreddit() {
-        let trimmed = newSubredditName.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        let name = trimmed.hasPrefix("r/") ? trimmed : "r/\(trimmed)"
-
-        guard !subreddits.contains(where: { $0.name.lowercased() == name.lowercased() }) else { return }
+        guard let name = validatedSubredditName() else { return }
 
         let sub = Subreddit(name: name)
         modelContext.insert(sub)

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
+import SwiftData
 import UserNotifications
 
 struct SettingsView: View {
     @Bindable var panelController: PanelController
+
+    @Query(sort: \Subreddit.name) private var subreddits: [Subreddit]
+    @Environment(\.modelContext) private var modelContext
 
     @AppStorage("screenEdge") private var screenEdge = "right"
     @AppStorage("restingState") private var restingState = "glance"
@@ -10,6 +14,8 @@ struct SettingsView: View {
     @AppStorage("notificationsEnabled") private var notificationsEnabled = true
     @AppStorage("defaultLeadTimeMinutes") private var defaultLeadTimeMinutes = 60
     @AppStorage("nudgeWhenEmpty") private var nudgeWhenEmpty = true
+
+    @State private var newSubredditName = ""
 
     private func syncAutoCollapse() {
         guard let state = SidebarState(rawValue: restingState) else {
@@ -79,8 +85,82 @@ struct SettingsView: View {
                 }
 
                 Toggle("Nudge when queue empty", isOn: $nudgeWhenEmpty)
+
+                StickerDivider()
+                stickerSectionLabel("Subreddits", size: 10)
+
+                subredditAddRow
+
+                ForEach(subreddits, id: \.id) { sub in
+                    HStack {
+                        Text(sub.name)
+                            .font(.system(size: 12))
+                            .foregroundStyle(StickerColors.textPrimary)
+                        Spacer()
+                        Button(action: { deleteSubreddit(sub) }) {
+                            Image(systemName: "trash")
+                                .font(.system(size: 11))
+                                .foregroundStyle(StickerColors.reddit)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.vertical, 2)
+                }
             }
             .padding(16)
+        }
+    }
+
+    private var subredditAddRow: some View {
+        HStack(spacing: 6) {
+            TextField("r/NewSubreddit", text: $newSubredditName)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .stickerInput()
+                .onSubmit { addSubreddit() }
+
+            Button(action: addSubreddit) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(canAddSubreddit ? StickerColors.green : StickerColors.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canAddSubreddit)
+        }
+    }
+
+    private var canAddSubreddit: Bool {
+        let trimmed = newSubredditName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+        let normalized = trimmed.hasPrefix("r/") ? trimmed : "r/\(trimmed)"
+        return !subreddits.contains { $0.name.lowercased() == normalized.lowercased() }
+    }
+
+    private func addSubreddit() {
+        let trimmed = newSubredditName.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        let name = trimmed.hasPrefix("r/") ? trimmed : "r/\(trimmed)"
+
+        guard !subreddits.contains(where: { $0.name.lowercased() == name.lowercased() }) else { return }
+
+        let sub = Subreddit(name: name)
+        modelContext.insert(sub)
+        do {
+            try modelContext.save()
+            newSubredditName = ""
+        } catch {
+            modelContext.rollback()
+            NSLog("RedditReminder: failed to add subreddit: \(error)")
+        }
+    }
+
+    private func deleteSubreddit(_ sub: Subreddit) {
+        modelContext.delete(sub)
+        do {
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            NSLog("RedditReminder: failed to delete subreddit: \(error)")
         }
     }
 

--- a/Sources/Views/SidebarContainer.swift
+++ b/Sources/Views/SidebarContainer.swift
@@ -60,12 +60,12 @@ struct SidebarContainer: View {
                     CaptureFormView(
                         projects: projects,
                         subreddits: subreddits,
-                        onSave: { text, notes, project, subs, mediaURLs in
+                        onSave: { text, notes, optionalProject, subs, mediaURLs in
                             let capture = Capture(
                                 text: text,
                                 notes: notes,
                                 mediaRefs: mediaURLs.map(\.lastPathComponent),
-                                project: project,
+                                project: optionalProject,
                                 subreddits: subs
                             )
                             modelContext.insert(capture)


### PR DESCRIPTION
## Summary
- Make project optional in capture form — captures no longer require a project to save
- Seed 12 common tech subreddits on first launch when the SwiftData store is empty
- Add subreddit add/delete section to Settings with `r/` prefix normalization and duplicate detection
- Cascade-delete subreddit events when a subreddit is removed, with confirmation dialog

## Test plan
- [ ] Fresh launch: verify 12 default subreddits appear in capture form and settings
- [ ] Create capture without selecting a project — should save successfully
- [ ] Create capture with a project selected — still works as before
- [ ] Settings > add subreddit with and without `r/` prefix — both normalize correctly
- [ ] Settings > attempt duplicate subreddit (case-insensitive) — add button stays disabled
- [ ] Settings > delete subreddit — confirmation dialog appears, events cascade-deleted
- [ ] Relaunch after adding custom subreddits — defaults should NOT re-seed (idempotent)
- [ ] All 34 unit tests pass, build succeeds with warnings-as-errors