### PR TITLE
fix: audit and fix notification scheduling, permissions, and delivery

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -45,11 +45,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.runRefreshCycle()
             }
         }
-        // Also run immediately on launch
-        runRefreshCycle()
     }
 
-    private func runRefreshCycle() {
+    func runRefreshCycle() {
         guard let container = modelContainer else {
             NSLog("RedditReminder: refresh skipped — no ModelContainer")
             return
@@ -72,10 +70,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let activeEvents = events.filter(\.isActive)
         timingEngine.refresh(events: activeEvents, captures: captures)
-        scheduleNotifications(activeEvents: activeEvents)
+        Task {
+            await scheduleNotifications(activeEvents: activeEvents)
+        }
     }
 
-    private func scheduleNotifications(activeEvents: [SubredditEvent]) {
+    private func scheduleNotifications(activeEvents: [SubredditEvent]) async {
         let notificationsEnabled = UserDefaults.standard.object(forKey: "notificationsEnabled") as? Bool ?? true
         guard notificationsEnabled else {
             notificationService.cancelAll()
@@ -83,18 +83,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        var activeEventIds: Set<String> = []
-        let nudgeEnabled = UserDefaults.standard.bool(forKey: "nudgeWhenEmpty")
+        let status = await notificationService.checkPermissionStatus()
+        guard status == .authorized else {
+            // Still clean up stale notifications even when not authorized,
+            // so previously-scheduled notifications don't linger.
+            let allEventIds = Set(activeEvents.map { $0.id.uuidString })
+            let windowEventIds = Set(timingEngine.upcomingWindows.map { $0.event.id.uuidString })
+            for staleId in allEventIds.subtracting(windowEventIds) {
+                notificationService.cancelNotifications(eventId: staleId)
+            }
+            NSLog("RedditReminder: notification permission not authorized (\(status.rawValue)) — skipping schedule")
+            return
+        }
 
+        var activeEventIds: Set<String> = []
+        let nudgeEnabled = UserDefaults.standard.object(forKey: "nudgeWhenEmpty") as? Bool ?? true
+
+        let now = Date()
         for window in timingEngine.upcomingWindows {
             let eventId = window.event.id.uuidString
             activeEventIds.insert(eventId)
+
+            // Skip scheduling if notification fire time is already past
+            // (e.g., event in 30 min but lead time is 60 min).
+            // A past-dated UNCalendarNotificationTrigger has undefined behavior.
+            guard window.notificationFireDate > now else { continue }
 
             notificationService.scheduleWindowNotification(
                 eventId: eventId,
                 title: window.event.name,
                 body: "\(window.matchingCaptureCount) captures ready for \(window.event.subreddit?.name ?? "subreddit")",
-                fireDate: window.fireDate
+                fireDate: window.notificationFireDate
             )
 
             if window.matchingCaptureCount == 0 && nudgeEnabled {
@@ -102,7 +121,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     eventId: eventId,
                     subredditName: window.event.subreddit?.name ?? "subreddit",
                     eventName: window.event.name,
-                    fireDate: window.fireDate
+                    fireDate: window.notificationFireDate
                 )
             }
         }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -70,12 +70,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let activeEvents = events.filter(\.isActive)
         timingEngine.refresh(events: activeEvents, captures: captures)
+        let windows = timingEngine.upcomingWindows
         Task {
-            await scheduleNotifications(activeEvents: activeEvents)
+            await scheduleNotifications(activeEvents: activeEvents, windows: windows)
         }
     }
 
-    private func scheduleNotifications(activeEvents: [SubredditEvent]) async {
+    private func scheduleNotifications(
+        activeEvents: [SubredditEvent],
+        windows: [TimingEngine.UpcomingWindow]
+    ) async {
         let notificationsEnabled = UserDefaults.standard.object(forKey: "notificationsEnabled") as? Bool ?? true
         guard notificationsEnabled else {
             notificationService.cancelAll()
@@ -85,14 +89,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let status = await notificationService.checkPermissionStatus()
         guard status == .authorized else {
-            // Still clean up stale notifications even when not authorized,
-            // so previously-scheduled notifications don't linger.
-            let allEventIds = Set(activeEvents.map { $0.id.uuidString })
-            let windowEventIds = Set(timingEngine.upcomingWindows.map { $0.event.id.uuidString })
-            for staleId in allEventIds.subtracting(windowEventIds) {
-                notificationService.cancelNotifications(eventId: staleId)
-            }
-            NSLog("RedditReminder: notification permission not authorized (\(status.rawValue)) — skipping schedule")
+            notificationService.cancelAll()
+            NSLog("RedditReminder: notification permission not authorized (\(status.rawValue)) — cancelled all, skipping schedule")
             return
         }
 
@@ -100,13 +98,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let nudgeEnabled = UserDefaults.standard.object(forKey: "nudgeWhenEmpty") as? Bool ?? true
 
         let now = Date()
-        for window in timingEngine.upcomingWindows {
+        for window in windows {
             let eventId = window.event.id.uuidString
             activeEventIds.insert(eventId)
 
             // Skip scheduling if notification fire time is already past
             // (e.g., event in 30 min but lead time is 60 min).
-            // A past-dated UNCalendarNotificationTrigger has undefined behavior.
+            // A past-dated UNCalendarNotificationTrigger fires immediately.
             guard window.notificationFireDate > now else { continue }
 
             notificationService.scheduleWindowNotification(
@@ -132,6 +130,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             notificationService.cancelNotifications(eventId: staleId)
         }
 
-        NSLog("RedditReminder: refresh complete — \(timingEngine.upcomingWindows.count) windows, \(staleIds.count) cancelled")
+        NSLog("RedditReminder: refresh complete — \(windows.count) windows, \(staleIds.count) cancelled")
     }
 }

--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -22,8 +22,13 @@ struct RedditReminderApp: App {
                 .onAppear {
                     appDelegate.modelContainer = container
                     DefaultSubreddits.seedIfEmpty(context: container.mainContext)
-                    let sidebarView = SidebarContainer(panelController: appDelegate.panelController)
-                        .modelContainer(container)
+                    appDelegate.runRefreshCycle()
+                    let sidebarView = SidebarContainer(
+                        panelController: appDelegate.panelController,
+                        notificationService: appDelegate.notificationService,
+                        onCaptureChanged: { [weak appDelegate] in appDelegate?.runRefreshCycle() }
+                    )
+                    .modelContainer(container)
                     appDelegate.panelController.setup(contentView: sidebarView)
                 }
         }

--- a/Sources/Models/SubredditEvent.swift
+++ b/Sources/Models/SubredditEvent.swift
@@ -28,7 +28,7 @@ final class SubredditEvent {
         self.name = name
         self.rrule = rrule
         self.oneOffDate = oneOffDate
-        self.reminderLeadMinutes = reminderLeadMinutes
+        self.reminderLeadMinutes = max(0, reminderLeadMinutes)
         self.isActive = isActive
         self.subreddit = subreddit
     }

--- a/Sources/Models/SubredditEvent.swift
+++ b/Sources/Models/SubredditEvent.swift
@@ -7,7 +7,9 @@ final class SubredditEvent {
     var name: String
     var rrule: String?
     var oneOffDate: Date?
-    var reminderLeadMinutes: Int
+    var reminderLeadMinutes: Int {
+        didSet { reminderLeadMinutes = max(0, reminderLeadMinutes) }
+    }
     var isActive: Bool
 
     var subreddit: Subreddit?

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -6,10 +6,15 @@ protocol NotificationCenterProtocol: Sendable {
   func add(_ request: UNNotificationRequest, withCompletionHandler handler: (@Sendable (Error?) -> Void)?)
   func removePendingNotificationRequests(withIdentifiers identifiers: [String])
   func removeAllPendingNotificationRequests()
+  func getAuthorizationStatus() async -> UNAuthorizationStatus
 }
 
 extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
-extension UNUserNotificationCenter: NotificationCenterProtocol {}
+extension UNUserNotificationCenter: NotificationCenterProtocol {
+  func getAuthorizationStatus() async -> UNAuthorizationStatus {
+    await notificationSettings().authorizationStatus
+  }
+}
 
 @MainActor
 final class NotificationService {
@@ -17,6 +22,10 @@ final class NotificationService {
 
   init(center: any NotificationCenterProtocol = UNUserNotificationCenter.current()) {
     self.center = center
+  }
+
+  func checkPermissionStatus() async -> UNAuthorizationStatus {
+    await center.getAuthorizationStatus()
   }
 
   func requestPermission() async -> Bool {

--- a/Sources/Services/TimingEngine.swift
+++ b/Sources/Services/TimingEngine.swift
@@ -5,7 +5,8 @@ import Foundation
 final class TimingEngine {
     struct UpcomingWindow {
         let event: SubredditEvent
-        let fireDate: Date
+        let eventDate: Date
+        let notificationFireDate: Date
         let urgency: UrgencyLevel
         let matchingCaptureCount: Int
     }
@@ -55,22 +56,26 @@ final class TimingEngine {
         var windows: [UpcomingWindow] = []
 
         for event in events where event.isActive {
-            guard let fireDate = Self.nextWindow(for: event, after: now),
-                  fireDate <= horizon
+            guard let eventDate = Self.nextWindow(for: event, after: now),
+                  eventDate <= horizon
             else { continue }
 
-            let hours = fireDate.timeIntervalSince(now) / 3600
+            let hours = eventDate.timeIntervalSince(now) / 3600
             let urgency = Self.urgencyLevel(hoursUntilWindow: hours)
             let matchCount = event.subreddit.map { queuedCountBySubredditId[$0.id] ?? 0 } ?? 0
 
+            let leadSeconds = TimeInterval(event.reminderLeadMinutes) * 60
+            let notificationFireDate = eventDate.addingTimeInterval(-leadSeconds)
+
             windows.append(UpcomingWindow(
                 event: event,
-                fireDate: fireDate,
+                eventDate: eventDate,
+                notificationFireDate: notificationFireDate,
                 urgency: urgency,
                 matchingCaptureCount: matchCount
             ))
         }
 
-        upcomingWindows = windows.sorted { $0.fireDate < $1.fireDate }
+        upcomingWindows = windows.sorted { $0.eventDate < $1.eventDate }
     }
 }

--- a/Sources/Views/CalendarMonthView.swift
+++ b/Sources/Views/CalendarMonthView.swift
@@ -126,7 +126,7 @@ struct CalendarMonthView: View {
     }
 
     private func windowsFor(day: Date) -> [TimingEngine.UpcomingWindow] {
-        windows.filter { cal.isDate($0.fireDate, inSameDayAs: day) }
+        windows.filter { cal.isDate($0.eventDate, inSameDayAs: day) }
     }
 
     private func previousMonth() {

--- a/Sources/Views/CalendarTimelineView.swift
+++ b/Sources/Views/CalendarTimelineView.swift
@@ -15,7 +15,7 @@ struct CalendarTimelineView: View {
     private var groupedByDate: [(date: Date, windows: [TimingEngine.UpcomingWindow])] {
         let cal = Calendar.current
         let grouped = Dictionary(grouping: windows) { window in
-            cal.startOfDay(for: window.fireDate)
+            cal.startOfDay(for: window.eventDate)
         }
         return grouped.sorted { $0.key < $1.key }.map { (date: $0.key, windows: $0.value) }
     }

--- a/Sources/Views/ChannelsView.swift
+++ b/Sources/Views/ChannelsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 
 struct ChannelsView: View {
+    let notificationService: NotificationService
     @Query(sort: \Subreddit.sortOrder) private var subreddits: [Subreddit]
     @Environment(\.modelContext) private var modelContext
 
@@ -122,6 +123,9 @@ struct ChannelsView: View {
     // MARK: - Helpers
 
     private func deleteSubreddit(_ sub: Subreddit) {
+        for event in sub.events {
+            notificationService.cancelNotifications(eventId: event.id.uuidString)
+        }
         withAnimation(.easeInOut(duration: 0.2)) {
             expandedSubredditId = nil
         }

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
-import UserNotifications
 
 struct SettingsView: View {
     @Bindable var panelController: PanelController
+    let notificationService: NotificationService
 
     @AppStorage("screenEdge") private var screenEdge = "right"
     @AppStorage("restingState") private var restingState = "glance"
@@ -65,7 +65,7 @@ struct SettingsView: View {
                 Toggle("macOS notifications", isOn: $notificationsEnabled)
                     .onChange(of: notificationsEnabled) { _, enabled in
                         if !enabled {
-                            UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+                            notificationService.cancelAll()
                         }
                     }
 

--- a/Sources/Views/SidebarContainer.swift
+++ b/Sources/Views/SidebarContainer.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 struct SidebarContainer: View {
     @Bindable var panelController: PanelController
+    let notificationService: NotificationService
+    let onCaptureChanged: @MainActor () -> Void
     @State private var timingEngine = TimingEngine()
     @State private var titleTapCount = 0
     @State private var lastTapTime = Date.distantPast
@@ -77,9 +79,9 @@ struct SidebarContainer: View {
                         onCancel: { panelController.setState(.browse) }
                     )
                 case .channels:
-                    ChannelsView()
+                    ChannelsView(notificationService: notificationService)
                 case .settings:
-                    SettingsView(panelController: panelController)
+                    SettingsView(panelController: panelController, notificationService: notificationService)
                 }
             }
 
@@ -92,6 +94,7 @@ struct SidebarContainer: View {
         }
         .onChange(of: captures.count) {
             timingEngine.refresh(events: activeEvents, captures: captures)
+            onCaptureChanged()
         }
     }
 

--- a/Tests/RedditReminderTests/EdgeCaseTests.swift
+++ b/Tests/RedditReminderTests/EdgeCaseTests.swift
@@ -165,6 +165,12 @@ private func makeContainer() throws -> ModelContainer {
     #expect(event.oneOffDate == nil)
 }
 
+@Test func negativeLeadMinutesClampedToZero() {
+    let sub = Subreddit(name: "r/Test")
+    let event = SubredditEvent(name: "Test", subreddit: sub, reminderLeadMinutes: -30)
+    #expect(event.reminderLeadMinutes == 0)
+}
+
 @Test func captureDefaultsAreCorrect() {
     let capture = Capture(text: "Test")
     #expect(capture.status == .queued)

--- a/Tests/RedditReminderTests/NotificationServiceTests.swift
+++ b/Tests/RedditReminderTests/NotificationServiceTests.swift
@@ -26,6 +26,12 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     func removeAllPendingNotificationRequests() {
         removedAll = true
     }
+
+    var mockAuthorizationStatus: UNAuthorizationStatus = .authorized
+
+    func getAuthorizationStatus() async -> UNAuthorizationStatus {
+        mockAuthorizationStatus
+    }
 }
 
 // MARK: - Permission
@@ -107,6 +113,17 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     service.cancelAll()
 
     #expect(mock.removedAll == true)
+}
+
+// MARK: - Permission status check
+
+@Test(arguments: [UNAuthorizationStatus.authorized, .denied, .notDetermined])
+@MainActor func checkPermissionStatus(expected: UNAuthorizationStatus) async {
+    let mock = MockNotificationCenter()
+    mock.mockAuthorizationStatus = expected
+    let service = NotificationService(center: mock)
+    let status = await service.checkPermissionStatus()
+    #expect(status == expected)
 }
 
 // MARK: - Trigger correctness

--- a/Tests/RedditReminderTests/NotificationServiceTests.swift
+++ b/Tests/RedditReminderTests/NotificationServiceTests.swift
@@ -117,7 +117,7 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
 
 // MARK: - Permission status check
 
-@Test(arguments: [UNAuthorizationStatus.authorized, .denied, .notDetermined])
+@Test(arguments: [UNAuthorizationStatus.authorized, .denied, .notDetermined, .provisional])
 @MainActor func checkPermissionStatus(expected: UNAuthorizationStatus) async {
     let mock = MockNotificationCenter()
     mock.mockAuthorizationStatus = expected

--- a/Tests/RedditReminderTests/TimingEngineIntegrationTests.swift
+++ b/Tests/RedditReminderTests/TimingEngineIntegrationTests.swift
@@ -243,7 +243,7 @@ import Foundation
     let window = engine.upcomingWindows[0]
     #expect(window.eventDate == eventTime)
     let expectedNotifTime = eventTime.addingTimeInterval(-3600) // 60 min before
-    #expect(abs(window.notificationFireDate.timeIntervalSince(expectedNotifTime)) < 1)
+    #expect(window.notificationFireDate == expectedNotifTime)
 }
 
 @Test @MainActor func zeroLeadTimeNotificationFireDateEqualsEventDate() {

--- a/Tests/RedditReminderTests/TimingEngineIntegrationTests.swift
+++ b/Tests/RedditReminderTests/TimingEngineIntegrationTests.swift
@@ -223,3 +223,61 @@ import Foundation
     #expect(soonWindow?.urgency == .active)
     #expect(laterWindow?.urgency == .low)
 }
+
+// MARK: - Lead time
+
+@Test @MainActor func leadTimeSubtractedFromNotificationFireDate() {
+    let sub = Subreddit(name: "r/Test")
+    let eventTime = Date().addingTimeInterval(6 * 3600) // 6h from now
+    let event = SubredditEvent(
+        name: "With Lead",
+        subreddit: sub,
+        oneOffDate: eventTime,
+        reminderLeadMinutes: 60
+    )
+
+    let engine = TimingEngine()
+    engine.refresh(events: [event], captures: [])
+
+    #expect(engine.upcomingWindows.count == 1)
+    let window = engine.upcomingWindows[0]
+    #expect(window.eventDate == eventTime)
+    let expectedNotifTime = eventTime.addingTimeInterval(-3600) // 60 min before
+    #expect(abs(window.notificationFireDate.timeIntervalSince(expectedNotifTime)) < 1)
+}
+
+@Test @MainActor func zeroLeadTimeNotificationFireDateEqualsEventDate() {
+    let sub = Subreddit(name: "r/Test")
+    let eventTime = Date().addingTimeInterval(3 * 3600)
+    let event = SubredditEvent(
+        name: "No Lead",
+        subreddit: sub,
+        oneOffDate: eventTime,
+        reminderLeadMinutes: 0
+    )
+
+    let engine = TimingEngine()
+    engine.refresh(events: [event], captures: [])
+
+    #expect(engine.upcomingWindows.count == 1)
+    let window = engine.upcomingWindows[0]
+    #expect(window.notificationFireDate == window.eventDate)
+}
+
+@Test @MainActor func urgencyBasedOnEventDateNotNotificationDate() {
+    let sub = Subreddit(name: "r/Test")
+    // Event in 18h (urgency: .low), but notification fires at 18h - 2h = 16h
+    let event = SubredditEvent(
+        name: "FarEvent",
+        subreddit: sub,
+        oneOffDate: Date().addingTimeInterval(18 * 3600),
+        reminderLeadMinutes: 120
+    )
+
+    let engine = TimingEngine()
+    engine.refresh(events: [event], captures: [])
+
+    #expect(engine.upcomingWindows.count == 1)
+    // Urgency should be based on event date (18h = .low), not notification date (16h)
+    #expect(engine.upcomingWindows[0].urgency == .low)
+}

--- a/Tests/RedditReminderTests/TimingEngineTests.swift
+++ b/Tests/RedditReminderTests/TimingEngineTests.swift
@@ -87,7 +87,7 @@ import Foundation
     #expect(engine.upcomingWindows.first?.matchingCaptureCount == 0)
 }
 
-@Test @MainActor func refreshSortsWindowsByFireDate() {
+@Test @MainActor func refreshSortsWindowsByEventDate() {
     let sub = Subreddit(name: "r/SideProject")
 
     let later = Date().addingTimeInterval(12 * 3600)


### PR DESCRIPTION
## Summary
- Wire up `reminderLeadMinutes` so notifications fire N minutes before events instead of at event time
- Add `checkPermissionStatus()` gate before scheduling — skip silently when not authorized
- Fix `nudgeWhenEmpty` UserDefaults bootstrap mismatch (`bool(forKey:)` returns `false` for missing key; now uses `object(forKey:) as? Bool ?? true`)
- Fix first refresh cycle race — `runRefreshCycle()` now called after `modelContainer` is set in `onAppear`, not from `startRefreshTimer()`
- Cancel notifications for deleted subreddit events before cascade delete
- Route `SettingsView` notification cancel through `NotificationService` instead of direct `UNUserNotificationCenter` call
- Guard against past-dated `notificationFireDate` to prevent immediate-fire spam
- Clamp `reminderLeadMinutes` to non-negative in `SubredditEvent.init`
- Add 5 new tests (152 total): lead time subtraction, zero lead time, urgency source, parameterized permission status

## Test plan
- [ ] `make test` passes (152 tests)
- [ ] Create event with 60-min lead time, verify notification schedules 60 min before event
- [ ] Toggle notifications off in Settings, verify all pending notifications cancelled
- [ ] Delete a subreddit with upcoming events, verify its notifications are cancelled
- [ ] Deny notification permission in System Settings, verify app skips scheduling gracefully

Closes #13