### PR TITLE
feat: save toast, solid background, QA fixtures, review fixes

### DIFF
--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -21,7 +21,15 @@ struct RedditReminderApp: App {
                 .frame(width: 1, height: 1)
                 .onAppear {
                     appDelegate.modelContainer = container
+                    #if DEBUG
+                    if ProcessInfo.processInfo.arguments.contains("--seed-qa") {
+                        QAFixtures.seed(context: container.mainContext)
+                    } else {
+                        DefaultSubreddits.seedIfEmpty(context: container.mainContext)
+                    }
+                    #else
                     DefaultSubreddits.seedIfEmpty(context: container.mainContext)
+                    #endif
                     appDelegate.runRefreshCycle()
                     let popoverView = PopoverContentView(
                         menuBarController: appDelegate.menuBarController,

--- a/Sources/Services/MenuBarController.swift
+++ b/Sources/Services/MenuBarController.swift
@@ -57,6 +57,12 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
         }
     }
 
+    func openPopover() {
+        guard let popover, let button = statusItem?.button, !popover.isShown else { return }
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        isPopoverVisible = true
+    }
+
     func showCaptureWindow(title: String = "New Capture", content: some View) {
         // Always recreate window content so edit-after-edit shows fresh data
         if let existing = captureWindow {

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -19,6 +19,17 @@ enum AppColors {
   static let purple = NSColor(red: 0.66, green: 0.33, blue: 0.97, alpha: 1.0)
   static let gold = NSColor(red: 0.81, green: 0.60, blue: 0.03, alpha: 1.0)
   static let pink = NSColor(red: 0.93, green: 0.29, blue: 0.60, alpha: 1.0)
+
+  // Solid popover background — warm cream (light) / warm charcoal (dark)
+  static let popoverBg = Color(nsColor: NSColor(name: nil) { appearance in
+    appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+      ? NSColor(red: 0.13, green: 0.12, blue: 0.11, alpha: 1.0)
+      : NSColor(red: 0.98, green: 0.97, blue: 0.95, alpha: 1.0)
+  })
+}
+
+enum SettingsKey {
+  static let defaultProjectId = "defaultProjectId"
 }
 
 enum MediaConstants {

--- a/Sources/Utilities/QAFixtures.swift
+++ b/Sources/Utilities/QAFixtures.swift
@@ -26,9 +26,11 @@ enum QAFixtures {
     context.insert(macOS)
     context.insert(iosProg)
 
-    // Project
+    // Projects
     let project = Project(name: "BullhornApp", projectDescription: "Social media scheduler")
+    let project2 = Project(name: "WeekendHacks", projectDescription: "Weekend side projects")
     context.insert(project)
+    context.insert(project2)
 
     // Captures with varying link counts
     let c1 = Capture(
@@ -74,20 +76,37 @@ enum QAFixtures {
     c5.markAsPosted()
     context.insert(c5)
 
-    // Events
-    let upcoming = SubredditEvent(
-      name: "Weekly SideProject",
-      subreddit: sideProject,
-      oneOffDate: Calendar.current.date(byAdding: .day, value: 7, to: Date())
+    let c6 = Capture(
+      text: "Weekend hack: building a Reddit bot in Swift",
+      project: project2,
+      subreddits: [iosProg, sideProject]
     )
-    context.insert(upcoming)
+    context.insert(c6)
 
-    let overdue = SubredditEvent(
+    // Events — mix of urgency levels for dot testing
+    let imminent = SubredditEvent(
+      name: "SideProject Saturday",
+      subreddit: sideProject,
+      oneOffDate: Date().addingTimeInterval(1 * 3600)  // +1hr → high (orange dot)
+    )
+    context.insert(imminent)
+
+    let soonish = SubredditEvent(
       name: "SwiftUI Show & Tell",
       subreddit: swiftUI,
-      oneOffDate: Calendar.current.date(byAdding: .day, value: -1, to: Date())
+      oneOffDate: Date().addingTimeInterval(6 * 3600)  // +6hr → medium (green dot)
     )
-    context.insert(overdue)
+    context.insert(soonish)
+
+    let farOut = SubredditEvent(
+      name: "macOS Weekly",
+      subreddit: macOS,
+      oneOffDate: Calendar.current.date(byAdding: .day, value: 7, to: Date())  // +7d → none (no dot)
+    )
+    context.insert(farOut)
+
+    // Seed default project preference
+    UserDefaults.standard.set(project.id.uuidString, forKey: SettingsKey.defaultProjectId)
 
     do {
       try context.save()
@@ -105,6 +124,7 @@ enum QAFixtures {
       try context.delete(model: Project.self)
       try context.delete(model: Subreddit.self)
       try context.save()
+      UserDefaults.standard.removeObject(forKey: SettingsKey.defaultProjectId)
       NSLog("RedditReminder: all data cleared")
     } catch {
       NSLog("RedditReminder: failed to clear data: \(error)")

--- a/Sources/Views/CaptureCardView.swift
+++ b/Sources/Views/CaptureCardView.swift
@@ -53,7 +53,7 @@ struct CaptureCardView: View {
         switch urgency {
         case .active, .high: AppColors.redditOrange
         case .medium: Color.green
-        default: nil
+        case .none, .low, .expired: nil
         }
     }
 

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -285,8 +285,8 @@ struct CaptureWindowView: View {
     private func populateFromMode() {
         switch mode {
         case .create:
-            let defaultId = UserDefaults.standard.string(forKey: "defaultProjectId") ?? ""
-            if let uuid = UUID(uuidString: defaultId) {
+            if let defaultId = UserDefaults.standard.string(forKey: SettingsKey.defaultProjectId),
+               let uuid = UUID(uuidString: defaultId) {
                 selectedProject = projects.first { $0.id == uuid }
             }
         case .edit(let capture):

--- a/Sources/Views/GeneralTabView.swift
+++ b/Sources/Views/GeneralTabView.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 struct GeneralTabView: View {
     @AppStorage("defaultLeadTimeMinutes") private var defaultLeadTimeMinutes: Int = 60
-    @AppStorage("defaultProjectId") private var defaultProjectId: String = ""
+    @AppStorage(SettingsKey.defaultProjectId) private var defaultProjectId: String = ""
 
     @Query(sort: \Project.name) private var projects: [Project]
 

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -14,6 +14,8 @@ struct PopoverContentView: View {
 
     @State private var timingEngine = TimingEngine()
     @State private var filterSubredditId: UUID?
+    @State private var toastMessage: String?
+    @State private var toastTask: Task<Void, Never>?
 
     private var activeEvents: [SubredditEvent] { allEvents.filter(\.isActive) }
     private var queuedCaptures: [Capture] { captures.filter { $0.status == .queued } }
@@ -41,12 +43,9 @@ struct PopoverContentView: View {
                         EventBannerView(
                             upcomingWindows: timingEngine.upcomingWindows,
                             onTap: { window in
+                                let tappedId = window.event.subreddit?.id
                                 withAnimation(.easeInOut(duration: 0.15)) {
-                                    if filterSubredditId == window.event.subreddit?.id {
-                                        filterSubredditId = nil
-                                    } else {
-                                        filterSubredditId = window.event.subreddit?.id
-                                    }
+                                    filterSubredditId = filterSubredditId == tappedId ? nil : tappedId
                                 }
                             }
                         )
@@ -69,6 +68,20 @@ struct PopoverContentView: View {
 
             footer
         }
+        .overlay(alignment: .top) {
+            if let message = toastMessage {
+                Text(message)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(AppColors.redditOrange.opacity(0.9))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .padding(.top, 48)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .background(AppColors.popoverBg)
         .frame(width: 350)
         .frame(maxHeight: maxPopoverHeight)
         .onAppear {
@@ -91,13 +104,13 @@ struct PopoverContentView: View {
 
     private func urgencyForCapture(_ capture: Capture) -> UrgencyLevel {
         let captureSubIds = Set(capture.subreddits.map(\.id))
-        var highest: UrgencyLevel = .none
-        for window in timingEngine.upcomingWindows {
-            if let subId = window.event.subreddit?.id, captureSubIds.contains(subId) {
-                highest = max(highest, window.urgency)
+        return timingEngine.upcomingWindows
+            .filter { window in
+                guard let subId = window.event.subreddit?.id else { return false }
+                return captureSubIds.contains(subId)
             }
-        }
-        return highest
+            .map(\.urgency)
+            .max() ?? .none
     }
 
     // MARK: - Header / Footer / Empty states
@@ -200,8 +213,9 @@ struct PopoverContentView: View {
         let formView = CaptureWindowView(
             mode: .create,
             onSave: { result in
-                saveCapture(result)
+                let ok = saveCapture(result)
                 menuBarController.closeCaptureWindow()
+                showToastAfterReopen(ok ? "Draft saved" : "Save failed")
             },
             onCancel: {
                 menuBarController.closeCaptureWindow()
@@ -216,8 +230,9 @@ struct PopoverContentView: View {
         let formView = CaptureWindowView(
             mode: .edit(capture),
             onSave: { result in
-                updateCapture(capture, with: result)
+                let ok = updateCapture(capture, with: result)
                 menuBarController.closeCaptureWindow()
+                showToastAfterReopen(ok ? "Draft updated" : "Save failed")
             },
             onCancel: {
                 menuBarController.closeCaptureWindow()
@@ -235,26 +250,40 @@ struct PopoverContentView: View {
         menuBarController.showPreferencesWindow(content: prefsView)
     }
 
-    private func saveCapture(_ result: CaptureFormResult) {
+    @discardableResult
+    private func saveCapture(_ result: CaptureFormResult) -> Bool {
         let capture = Capture(
-            text: result.text,
-            notes: result.notes,
-            links: result.links,
+            text: result.text, notes: result.notes, links: result.links,
             mediaRefs: result.mediaURLs.map(\.lastPathComponent),
-            project: result.project,
-            subreddits: result.subreddits
+            project: result.project, subreddits: result.subreddits
         )
         modelContext.insert(capture)
-        try? modelContext.save()
+        do { try modelContext.save(); return true }
+        catch { NSLog("RedditReminder: save failed: \(error)"); return false }
     }
 
-    private func updateCapture(_ capture: Capture, with result: CaptureFormResult) {
+    @discardableResult
+    private func updateCapture(_ capture: Capture, with result: CaptureFormResult) -> Bool {
         capture.text = result.text
         capture.notes = result.notes
         capture.links = result.links
         capture.mediaRefs = result.mediaURLs.map(\.lastPathComponent)
         capture.project = result.project
         capture.subreddits = result.subreddits
-        try? modelContext.save()
+        do { try modelContext.save(); return true }
+        catch { NSLog("RedditReminder: update failed: \(error)"); return false }
+    }
+
+    private func showToastAfterReopen(_ message: String) {
+        toastTask?.cancel()
+        menuBarController.openPopover()
+        toastTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.2)) { toastMessage = message }
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.2)) { toastMessage = nil }
+        }
     }
 }

--- a/Tests/RedditReminderTests/EdgeCaseTests.swift
+++ b/Tests/RedditReminderTests/EdgeCaseTests.swift
@@ -124,9 +124,9 @@ private func makeContainer() throws -> ModelContainer {
     QAFixtures.seed(context: context)
 
     #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 4)
-    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 1)
-    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 5)
-    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 2)
+    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 2)
+    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 6)
+    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 3)
 }
 
 @Test @MainActor func qaFixturesClearAllOnEmptyDoesNotCrash() throws {


### PR DESCRIPTION
## Summary
- **Save toast** — orange banner slides down in popover after save ("Draft saved" / "Draft updated" / "Save failed"), auto-dismisses after 2s
- **Solid popover background** — warm cream (light) / warm charcoal (dark) replaces translucent blur
- **Expanded QA fixtures** — second project, sixth capture, three events at different urgency tiers (+1hr orange, +6hr green, +7d none), gated behind `--seed-qa` launch arg
- **PR review fixes** — toast race condition (task cancellation), `openPopover()` instead of toggle, save success/failure feedback, `SettingsKey` shared constant, exhaustive urgency switch, UserDefaults cleanup in clearAll

## Test plan
- [x] Build succeeds (macOS)
- [x] 129/129 tests pass
- [x] All files ≤ 300 lines
- [x] PR review toolkit passed (6 agents, all findings addressed)
- [ ] Manual: save a capture → see "Draft saved" toast
- [ ] Manual: edit a capture → see "Draft updated" toast
- [ ] Manual: verify solid background on complex desktop wallpapers
- [ ] Manual: run with `--seed-qa` to verify QA fixtures load