### PR TITLE
fix: SwiftData inverse relationship and urgency lookup optimization

### DIFF
--- a/Sources/Models/Subreddit.swift
+++ b/Sources/Models/Subreddit.swift
@@ -12,6 +12,9 @@ final class Subreddit {
     @Relationship(deleteRule: .cascade, inverse: \SubredditEvent.subreddit)
     var events: [SubredditEvent]
 
+    @Relationship(inverse: \Capture.subreddits)
+    var captures: [Capture]
+
     init(
         name: String,
         sortOrder: Int = 0,
@@ -24,5 +27,6 @@ final class Subreddit {
         self.peakDaysOverride = peakDaysOverride
         self.peakHoursUtcOverride = peakHoursUtcOverride
         self.events = []
+        self.captures = []
     }
 }

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -50,18 +50,7 @@ struct PopoverContentView: View {
                             }
                         )
 
-                        ForEach(displayedCaptures, id: \.id) { capture in
-                            CaptureCardView(
-                                capture: capture,
-                                urgency: urgencyForCapture(capture),
-                                onTap: { openCaptureForEditing(capture) }
-                            )
-
-                            if capture.id != displayedCaptures.last?.id {
-                                Divider()
-                                    .padding(.horizontal, 16)
-                            }
-                        }
+                        captureList(displayedCaptures)
                     }
                 }
             }
@@ -102,15 +91,30 @@ struct PopoverContentView: View {
 
     // MARK: - Urgency per capture
 
-    private func urgencyForCapture(_ capture: Capture) -> UrgencyLevel {
-        let captureSubIds = Set(capture.subreddits.map(\.id))
-        return timingEngine.upcomingWindows
-            .filter { window in
-                guard let subId = window.event.subreddit?.id else { return false }
-                return captureSubIds.contains(subId)
+    private var urgencyBySubredditId: [UUID: UrgencyLevel] {
+        var result: [UUID: UrgencyLevel] = [:]
+        for window in timingEngine.upcomingWindows {
+            guard let subId = window.event.subreddit?.id else { continue }
+            let current = result[subId] ?? .none
+            if window.urgency > current { result[subId] = window.urgency }
+        }
+        return result
+    }
+
+    private func captureList(_ captures: [Capture]) -> some View {
+        let map = urgencyBySubredditId
+        return ForEach(captures, id: \.id) { capture in
+            CaptureCardView(
+                capture: capture,
+                urgency: capture.subreddits.compactMap { map[$0.id] }.max() ?? .none,
+                onTap: { openCaptureForEditing(capture) }
+            )
+
+            if capture.id != captures.last?.id {
+                Divider()
+                    .padding(.horizontal, 16)
             }
-            .map(\.urgency)
-            .max() ?? .none
+        }
     }
 
     // MARK: - Header / Footer / Empty states

--- a/Tests/RedditReminderTests/CRUDTests.swift
+++ b/Tests/RedditReminderTests/CRUDTests.swift
@@ -274,6 +274,22 @@ private func makeContainer() throws -> ModelContainer {
     #expect(fetched[0].captures.count == 2)
 }
 
+@Test @MainActor func subredditCapturesBacklink() throws {
+    let container = try makeContainer()
+    let context = ModelContext(container)
+
+    let sub = Subreddit(name: "r/Test")
+    context.insert(sub)
+    let c1 = Capture(text: "Cap 1", subreddits: [sub])
+    let c2 = Capture(text: "Cap 2", subreddits: [sub])
+    context.insert(c1)
+    context.insert(c2)
+    try context.save()
+
+    let fetched = try context.fetch(FetchDescriptor<Subreddit>())
+    #expect(fetched[0].captures.count == 2)
+}
+
 @Test @MainActor func subredditEventsRelationshipBidirectional() throws {
     let container = try makeContainer()
     let context = ModelContext(container)


### PR DESCRIPTION
Closes #21

## Summary
- Add `@Relationship(inverse: \Capture.subreddits) var captures: [Capture]` backlink on `Subreddit`, making the many-to-many relationship fully managed by SwiftData
- Eliminate N+1 urgency computation in `PopoverContentView` by pre-building a `[UUID: UrgencyLevel]` lookup map once per render pass instead of iterating all upcoming windows per capture
- Add `subredditCapturesBacklink` test validating the new inverse relationship

## Test plan
- [x] All 130+ existing tests pass (including the new backlink test)
- [ ] Verify captures still display correctly in the popover with urgency dots
- [ ] Verify deleting a subreddit does not delete associated captures
- [ ] Verify deleting a capture does not delete associated subreddits