### PR TITLE
refactor: fix concurrency issues and replace Timer with async loop

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -11,12 +11,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var modelContainer: ModelContainer?
 
     private let globalShortcut = GlobalShortcut()
-    private var refreshTimer: Timer?
+    private var refreshTask: Task<Void, Never>?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Register global shortcut
         globalShortcut.register { [weak self] in
-            self?.menuBarController.togglePopover()
+            MainActor.assumeIsolated {
+                self?.menuBarController.togglePopover()
+            }
         }
 
         // Request notification permission
@@ -24,25 +26,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             _ = await notificationService.requestPermission()
         }
 
-        // Start 5-minute refresh timer
-        startRefreshTimer()
+        // Start 5-minute refresh loop
+        startRefreshLoop()
 
-        NSLog("RedditReminder: launched, ⌘⇧R registered, refresh timer started")
+        NSLog("RedditReminder: launched, ⌘⇧R registered, refresh loop started")
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         globalShortcut.unregister()
-        refreshTimer?.invalidate()
+        refreshTask?.cancel()
     }
 
-    private func startRefreshTimer() {
-        refreshTimer?.invalidate()
-        refreshTimer = Timer.scheduledTimer(
-            withTimeInterval: 5 * 60,
-            repeats: true
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.runRefreshCycle()
+    private func startRefreshLoop() {
+        refreshTask?.cancel()
+        refreshTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(300))
+                guard !Task.isCancelled else { break }
+                runRefreshCycle()
             }
         }
     }
@@ -53,9 +54,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        // Use a fresh context to avoid contention with the view's context,
-        // but stay on @MainActor since SwiftData model objects aren't Sendable.
-        let context = ModelContext(container)
+        let context = container.mainContext
 
         let events: [SubredditEvent]
         let captures: [Capture]

--- a/Sources/Utilities/KeyboardShortcuts.swift
+++ b/Sources/Utilities/KeyboardShortcuts.swift
@@ -1,21 +1,23 @@
 @preconcurrency import CoreFoundation
 import AppKit
 import Carbon.HIToolbox
+import os
 
 @MainActor
 final class GlobalShortcut {
   private var eventTap: CFMachPort?
   private var tapThread: Thread?
 
-  // These properties are written/read across isolation boundaries (main thread
-  // ↔ background event-tap thread). Access is safe because register() completes
-  // before the thread reads, and unregister() runs after disabling the tap.
-  private nonisolated(unsafe) var runLoopSource: CFRunLoopSource?
-  private nonisolated(unsafe) var tapRunLoop: CFRunLoop?
-  private nonisolated(unsafe) var handler: (() -> Void)?
+  private struct TapState: Sendable {
+    var runLoopSource: CFRunLoopSource?
+    var tapRunLoop: CFRunLoop?
+    var handler: (@Sendable () -> Void)?
+  }
 
-  func register(handler: @escaping () -> Void) {
-    self.handler = handler
+  private let state = OSAllocatedUnfairLock(initialState: TapState())
+
+  func register(handler: @escaping @Sendable () -> Void) {
+    state.withLock { $0.handler = handler }
 
     let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
     let callback: CGEventTapCallBack = { proxy, type, event, refcon in
@@ -42,14 +44,12 @@ final class GlobalShortcut {
 
     eventTap = tap
     let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-    runLoopSource = source
+    state.withLock { $0.runLoopSource = source }
 
-    // Capture locals for the thread closure so it doesn't cross isolation
-    // boundaries to access @MainActor properties at runtime.
-    let thread = Thread { [weak self] in
+    let thread = Thread { [state] in
       guard let source else { return }
       let rl = CFRunLoopGetCurrent()
-      self?.tapRunLoop = rl
+      state.withLock { $0.tapRunLoop = rl }
       CFRunLoopAddSource(rl, source, .commonModes)
       CGEvent.tapEnable(tap: tap, enable: true)
       CFRunLoopRun()
@@ -64,15 +64,18 @@ final class GlobalShortcut {
     if let tap = eventTap {
       CGEvent.tapEnable(tap: tap, enable: false)
     }
-    if let rl = tapRunLoop {
+    let rl = state.withLock { $0.tapRunLoop }
+    if let rl {
       CFRunLoopStop(rl)
     }
     tapThread?.cancel()
     eventTap = nil
-    runLoopSource = nil
-    tapRunLoop = nil
+    state.withLock {
+      $0.runLoopSource = nil
+      $0.tapRunLoop = nil
+      $0.handler = nil
+    }
     tapThread = nil
-    handler = nil
   }
 
   private nonisolated func handleEvent(
@@ -88,8 +91,9 @@ final class GlobalShortcut {
     let isR = keyCode == 15
 
     if isCmd && isShift && isR {
-      Task { @MainActor in
-        self.handler?()
+      let handler = state.withLock { $0.handler }
+      if let handler {
+        Task { @MainActor in handler() }
       }
       return nil  // consume the event
     }


### PR DESCRIPTION
Closes #20

## Summary
- Replace `Timer.scheduledTimer` in `AppDelegate` with a structured `Task` loop (`startRefreshLoop`) that is cancelled in `applicationWillTerminate`, eliminating leak risk from missed `invalidate` calls
- Fix data race in `KeyboardShortcuts.swift` by replacing three `nonisolated(unsafe)` properties with an `OSAllocatedUnfairLock<TapState>`, ensuring thread-safe access from the event-tap background thread
- Fix `runRefreshCycle` to use `container.mainContext` instead of creating a fresh `ModelContext`, eliminating potential data races with the view's context

## Test plan
- [x] Build succeeds with no errors or warnings on both modified files
- [x] App launches and menu bar icon appears
- [x] Keyboard shortcut (Cmd+Shift+R) toggles popover
- [x] Refresh cycle runs without crashes
- [x] Both files remain under 300-line CI limit (139 and 104 lines respectively)