### PR TITLE
refactor: split CaptureWindowView into focused subviews

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
 		1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */; };
+		AA11BB22CC33DD44EE550001 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE550002 /* CaptureSubredditPicker.swift */; };
+		AA11BB22CC33DD44EE550003 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE550004 /* CaptureLinksSection.swift */; };
+		AA11BB22CC33DD44EE550005 /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */; };
 		19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */; };
 		1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */; };
 		1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */; };
@@ -68,6 +71,9 @@
 		09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
 		0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelperTests.swift; sourceTree = "<group>"; };
 		18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureFormResult.swift; sourceTree = "<group>"; };
+		AA11BB22CC33DD44EE550002 /* CaptureSubredditPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSubredditPicker.swift; sourceTree = "<group>"; };
+		AA11BB22CC33DD44EE550004 /* CaptureLinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksSection.swift; sourceTree = "<group>"; };
+		AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
 		20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
 		274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsTimezoneTests.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
@@ -210,6 +216,9 @@
 			isa = PBXGroup;
 			children = (
 				A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */,
+				AA11BB22CC33DD44EE550004 /* CaptureLinksSection.swift */,
+				AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */,
+				AA11BB22CC33DD44EE550002 /* CaptureSubredditPicker.swift */,
 				975C23592B958F445105973E /* CaptureWindowView.swift */,
 				09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */,
 				4CB005E503FDAD90271DB0AE /* EventBannerView.swift */,
@@ -340,6 +349,9 @@
 				F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */,
 				1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */,
 				6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */,
+				AA11BB22CC33DD44EE550003 /* CaptureLinksSection.swift in Sources */,
+				AA11BB22CC33DD44EE550005 /* CaptureMediaSection.swift in Sources */,
+				AA11BB22CC33DD44EE550001 /* CaptureSubredditPicker.swift in Sources */,
 				4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */,
 				6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */,
 				81C26D97123D840A9130AF7E /* Constants.swift in Sources */,

--- a/Sources/Views/CaptureLinksSection.swift
+++ b/Sources/Views/CaptureLinksSection.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct CaptureLinksSection: View {
+    @Binding var links: [String]
+    @Binding var newLinkText: String
+
+    private static let redditOrange = AppColors.redditOrange
+
+    var body: some View {
+        FlowLayout(spacing: 6) {
+            ForEach(Array(links.enumerated()), id: \.offset) { index, link in
+                LinkChipView(url: link, onRemove: {
+                    links.remove(at: index)
+                })
+            }
+
+            HStack(spacing: 4) {
+                TextField("Add link...", text: $newLinkText)
+                    .font(.system(size: 10))
+                    .textFieldStyle(.plain)
+                    .frame(width: 120)
+                    .onSubmit { addLink() }
+
+                if !newLinkText.isEmpty {
+                    Button(action: addLink) {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Self.redditOrange)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(NSColor.separatorColor), style: StrokeStyle(lineWidth: 0.5, dash: [4]))
+            )
+        }
+    }
+
+    private func addLink() {
+        let trimmed = newLinkText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        links.append(trimmed.hasPrefix("http") ? trimmed : "https://\(trimmed)")
+        newLinkText = ""
+    }
+}

--- a/Sources/Views/CaptureMediaSection.swift
+++ b/Sources/Views/CaptureMediaSection.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct CaptureMediaSection: View {
+    @Binding var droppedFiles: [URL]
+    @Binding var isDragOver: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if !droppedFiles.isEmpty {
+                FlowLayout(spacing: 6) {
+                    ForEach(Array(droppedFiles.enumerated()), id: \.offset) { index, url in
+                        HStack(spacing: 4) {
+                            Image(systemName: "doc")
+                                .font(.system(size: 9))
+                            Text(url.lastPathComponent)
+                                .font(.system(size: 10))
+                                .lineLimit(1)
+                            Button(action: { droppedFiles.remove(at: index) }) {
+                                Image(systemName: "xmark")
+                                    .font(.system(size: 7, weight: .bold))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(.quaternary.opacity(0.3))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                }
+            }
+
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(NSColor.separatorColor), style: StrokeStyle(lineWidth: 1, dash: [6]))
+                .frame(height: 48)
+                .overlay {
+                    Text("Drop images here or ").font(.system(size: 11)).foregroundStyle(.secondary)
+                    + Text("browse").font(.system(size: 11)).foregroundStyle(.blue)
+                }
+                .background(isDragOver ? Color.blue.opacity(0.05) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .onDrop(of: [.fileURL], isTargeted: $isDragOver) { providers in
+                    handleFileDrop(providers)
+                }
+        }
+    }
+
+    private func handleFileDrop(_ providers: [NSItemProvider]) -> Bool {
+        for provider in providers {
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                if let url { Task { @MainActor in droppedFiles.append(url) } }
+            }
+        }
+        return true
+    }
+}

--- a/Sources/Views/CaptureSubredditPicker.swift
+++ b/Sources/Views/CaptureSubredditPicker.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct CaptureSubredditPicker: View {
+    let subreddits: [Subreddit]
+    @Binding var selectedSubreddits: Set<UUID>
+
+    private static let redditOrange = AppColors.redditOrange
+
+    var body: some View {
+        Menu {
+            ForEach(subreddits, id: \.id) { sub in
+                Button(action: {
+                    if selectedSubreddits.contains(sub.id) {
+                        selectedSubreddits.remove(sub.id)
+                    } else {
+                        selectedSubreddits.insert(sub.id)
+                    }
+                }) {
+                    HStack {
+                        Text(sub.name)
+                        if selectedSubreddits.contains(sub.id) {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack {
+                if selectedSubreddits.isEmpty {
+                    Text("Select subreddit...")
+                        .foregroundStyle(.secondary)
+                } else {
+                    let names = subreddits
+                        .filter { selectedSubreddits.contains($0.id) }
+                        .map(\.name)
+                        .joined(separator: ", ")
+                    Text(names)
+                        .foregroundStyle(Self.redditOrange)
+                }
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+            .font(.system(size: 12))
+            .padding(8)
+            .background(.quaternary.opacity(0.3))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+            )
+        }
+        .menuStyle(.borderlessButton)
+    }
+}

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -46,51 +46,10 @@ struct CaptureWindowView: View {
                     }
 
                     fieldSection("SUBREDDIT") {
-                        Menu {
-                            ForEach(subreddits, id: \.id) { sub in
-                                Button(action: {
-                                    if selectedSubreddits.contains(sub.id) {
-                                        selectedSubreddits.remove(sub.id)
-                                    } else {
-                                        selectedSubreddits.insert(sub.id)
-                                    }
-                                }) {
-                                    HStack {
-                                        Text(sub.name)
-                                        if selectedSubreddits.contains(sub.id) {
-                                            Image(systemName: "checkmark")
-                                        }
-                                    }
-                                }
-                            }
-                        } label: {
-                            HStack {
-                                if selectedSubreddits.isEmpty {
-                                    Text("Select subreddit...")
-                                        .foregroundStyle(.secondary)
-                                } else {
-                                    let names = subreddits
-                                        .filter { selectedSubreddits.contains($0.id) }
-                                        .map(\.name)
-                                        .joined(separator: ", ")
-                                    Text(names)
-                                        .foregroundStyle(Self.redditOrange)
-                                }
-                                Spacer()
-                                Image(systemName: "chevron.down")
-                                    .font(.system(size: 10))
-                                    .foregroundStyle(.secondary)
-                            }
-                            .font(.system(size: 12))
-                            .padding(8)
-                            .background(.quaternary.opacity(0.3))
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                            )
-                        }
-                        .menuStyle(.borderlessButton)
+                        CaptureSubredditPicker(
+                            subreddits: subreddits,
+                            selectedSubreddits: $selectedSubreddits
+                        )
                     }
 
                     fieldSection("PROJECT", optional: true) {
@@ -125,77 +84,11 @@ struct CaptureWindowView: View {
                     }
 
                     fieldSection("LINKS") {
-                        FlowLayout(spacing: 6) {
-                            ForEach(Array(links.enumerated()), id: \.offset) { index, link in
-                                LinkChipView(url: link, onRemove: {
-                                    links.remove(at: index)
-                                })
-                            }
-
-                            HStack(spacing: 4) {
-                                TextField("Add link...", text: $newLinkText)
-                                    .font(.system(size: 10))
-                                    .textFieldStyle(.plain)
-                                    .frame(width: 120)
-                                    .onSubmit { addLink() }
-
-                                if !newLinkText.isEmpty {
-                                    Button(action: addLink) {
-                                        Image(systemName: "plus.circle.fill")
-                                            .font(.system(size: 12))
-                                            .foregroundStyle(Self.redditOrange)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                            }
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .stroke(Color(NSColor.separatorColor), style: StrokeStyle(lineWidth: 0.5, dash: [4]))
-                            )
-                        }
+                        CaptureLinksSection(links: $links, newLinkText: $newLinkText)
                     }
 
                     fieldSection("MEDIA") {
-                        VStack(spacing: 8) {
-                            if !droppedFiles.isEmpty {
-                                FlowLayout(spacing: 6) {
-                                    ForEach(Array(droppedFiles.enumerated()), id: \.offset) { index, url in
-                                        HStack(spacing: 4) {
-                                            Image(systemName: "doc")
-                                                .font(.system(size: 9))
-                                            Text(url.lastPathComponent)
-                                                .font(.system(size: 10))
-                                                .lineLimit(1)
-                                            Button(action: { droppedFiles.remove(at: index) }) {
-                                                Image(systemName: "xmark")
-                                                    .font(.system(size: 7, weight: .bold))
-                                                    .foregroundStyle(.secondary)
-                                            }
-                                            .buttonStyle(.plain)
-                                        }
-                                        .padding(.horizontal, 8)
-                                        .padding(.vertical, 4)
-                                        .background(.quaternary.opacity(0.3))
-                                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                                    }
-                                }
-                            }
-
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color(NSColor.separatorColor), style: StrokeStyle(lineWidth: 1, dash: [6]))
-                                .frame(height: 48)
-                                .overlay {
-                                    Text("Drop images here or ").font(.system(size: 11)).foregroundStyle(.secondary)
-                                    + Text("browse").font(.system(size: 11)).foregroundStyle(.blue)
-                                }
-                                .background(isDragOver ? Color.blue.opacity(0.05) : Color.clear)
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
-                                .onDrop(of: [.fileURL], isTargeted: $isDragOver) { providers in
-                                    handleFileDrop(providers)
-                                }
-                        }
+                        CaptureMediaSection(droppedFiles: $droppedFiles, isDragOver: $isDragOver)
                     }
                 }
                 .padding(16)
@@ -267,20 +160,6 @@ struct CaptureWindowView: View {
             notes: notes.isEmpty ? nil : notes, links: links,
             project: selectedProject, subreddits: selectedSubs, mediaURLs: droppedFiles
         ))
-    }
-    private func handleFileDrop(_ providers: [NSItemProvider]) -> Bool {
-        for provider in providers {
-            _ = provider.loadObject(ofClass: URL.self) { url, _ in
-                if let url { Task { @MainActor in droppedFiles.append(url) } }
-            }
-        }
-        return true
-    }
-    private func addLink() {
-        let trimmed = newLinkText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        links.append(trimmed.hasPrefix("http") ? trimmed : "https://\(trimmed)")
-        newLinkText = ""
     }
     private func populateFromMode() {
         switch mode {


### PR DESCRIPTION
Closes #22

## Summary
- Extract `CaptureSubredditPicker` (56 lines) — subreddit multi-select menu
- Extract `CaptureLinksSection` (48 lines) — links FlowLayout with add-link logic
- Extract `CaptureMediaSection` (56 lines) — media drop zone with file chip display
- Slim `CaptureWindowView` from 300 to 179 lines, well under the 300-line CI limit
- All 3 new files registered in project.pbxproj (PBXBuildFile, PBXFileReference, Views group, Sources build phase)

## Test plan
- [x] Build succeeds (`xcodebuild build` passes)
- [x] Test runner crash is pre-existing on main (not introduced by this change)
- [x] CaptureWindowView.swift is 179 lines (was 300)
- [x] All extracted subviews match original code exactly — no behavioral changes