### PR TITLE
feat: add project management UI with CRUD in preferences

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */; };
 		4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975C23592B958F445105973E /* CaptureWindowView.swift */; };
 		4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599273192FBCFDD93D1241B0 /* Project.swift */; };
+		CC33DD44EE55FF66AA770001 /* ProjectsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */; };
 		55E73142A5F438F0600FF8F2 /* LinkChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0A7A7AAA2C09449780FF4F /* LinkChipView.swift */; };
 		5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */; };
 		59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1122ADEB6045619C303C31 /* MediaStore.swift */; };
@@ -76,6 +77,7 @@
 		AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
 		20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
 		274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsTimezoneTests.swift; sourceTree = "<group>"; };
+		CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsTabView.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
@@ -228,6 +230,7 @@
 				CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */,
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
 				28906380DECDA56AD0DDE325 /* PreferencesView.swift */,
+				CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */,
 				5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */,
 			);
 			path = Views;
@@ -369,6 +372,7 @@
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,
+				CC33DD44EE55FF66AA770001 /* ProjectsTabView.swift in Sources */,
 				17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */,
 				FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */,
 				1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */,

--- a/Sources/Views/PreferencesView.swift
+++ b/Sources/Views/PreferencesView.swift
@@ -7,6 +7,7 @@ struct PreferencesView: View {
 
     enum Tab: String, CaseIterable {
         case channels = "Channels"
+        case projects = "Projects"
         case general = "General"
         case notifications = "Notifications"
     }
@@ -42,6 +43,8 @@ struct PreferencesView: View {
             switch selectedTab {
             case .channels:
                 ChannelsTabView(notificationService: notificationService)
+            case .projects:
+                ProjectsTabView()
             case .general:
                 GeneralTabView()
             case .notifications:

--- a/Sources/Views/ProjectsTabView.swift
+++ b/Sources/Views/ProjectsTabView.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+import SwiftData
+
+struct ProjectsTabView: View {
+    @Query(sort: \Project.name) private var projects: [Project]
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var newProjectName = ""
+    @State private var editingProject: Project?
+    @State private var editName = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            addProjectBar
+            Divider()
+            projectList
+        }
+    }
+
+    private var addProjectBar: some View {
+        HStack(spacing: 8) {
+            TextField("New project name...", text: $newProjectName)
+                .font(.system(size: 11))
+                .textFieldStyle(.plain)
+                .padding(7)
+                .background(.quaternary.opacity(0.3))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+                )
+                .onSubmit { addProject() }
+
+            Button(action: addProject) {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .light))
+                    .foregroundStyle(canAdd ? AppColors.redditOrange : .secondary)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        canAdd
+                            ? AppColors.redditOrange.opacity(0.15)
+                            : Color.clear
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .disabled(!canAdd)
+        }
+        .padding(12)
+    }
+
+    private var projectList: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                let activeProjects = projects.filter { !$0.archived }
+                let archivedProjects = projects.filter { $0.archived }
+
+                if activeProjects.isEmpty && archivedProjects.isEmpty {
+                    emptyState
+                }
+
+                ForEach(activeProjects, id: \.id) { project in
+                    projectRow(project)
+                    if project.id != activeProjects.last?.id || !archivedProjects.isEmpty {
+                        Divider().padding(.horizontal, 12)
+                    }
+                }
+
+                if !archivedProjects.isEmpty {
+                    archivedHeader
+                    ForEach(archivedProjects, id: \.id) { project in
+                        projectRow(project)
+                        if project.id != archivedProjects.last?.id {
+                            Divider().padding(.horizontal, 12)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Text("No projects yet")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Text("Projects help organize your captures")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    private var archivedHeader: some View {
+        HStack {
+            Text("ARCHIVED")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+                .tracking(0.3)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 12)
+        .padding(.bottom, 4)
+    }
+
+    private func projectRow(_ project: Project) -> some View {
+        HStack(spacing: 10) {
+            if editingProject?.id == project.id {
+                editingRow(project)
+            } else {
+                displayRow(project)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button("Rename") { startEditing(project) }
+            Button(project.archived ? "Unarchive" : "Archive") {
+                project.archived.toggle()
+                try? modelContext.save()
+            }
+            Divider()
+            Button("Delete", role: .destructive) { deleteProject(project) }
+        }
+    }
+
+    private func editingRow(_ project: Project) -> some View {
+        Group {
+            TextField("Project name", text: $editName)
+                .font(.system(size: 12))
+                .textFieldStyle(.plain)
+                .onSubmit { finishEditing(project) }
+
+            Button("Done") { finishEditing(project) }
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(AppColors.redditOrange)
+                .buttonStyle(.plain)
+        }
+    }
+
+    private func displayRow(_ project: Project) -> some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(project.name)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(project.archived ? .secondary : .primary)
+                if let desc = project.projectDescription, !desc.isEmpty {
+                    Text(desc)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Text("\(project.captures.count) capture\(project.captures.count == 1 ? "" : "s")")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+        }
+    }
+
+    private var canAdd: Bool {
+        let trimmed = newProjectName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return !projects.contains(where: { $0.name.lowercased() == trimmed.lowercased() })
+    }
+
+    private func addProject() {
+        let trimmed = newProjectName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, canAdd else { return }
+        let project = Project(name: trimmed)
+        modelContext.insert(project)
+        try? modelContext.save()
+        newProjectName = ""
+    }
+
+    private func startEditing(_ project: Project) {
+        editingProject = project
+        editName = project.name
+    }
+
+    private func finishEditing(_ project: Project) {
+        let trimmed = editName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            project.name = trimmed
+            try? modelContext.save()
+        }
+        editingProject = nil
+        editName = ""
+    }
+
+    private func deleteProject(_ project: Project) {
+        modelContext.delete(project)
+        try? modelContext.save()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a "Projects" tab to the Preferences window between Channels and General
- Creates `ProjectsTabView` with full CRUD: add, rename (via context menu), archive/unarchive, and delete projects
- Layout follows the same pattern as ChannelsTabView: text field + add button at top, scrollable list below with active/archived sections

Closes #24

## Test plan
- [ ] Build succeeds with no compiler errors
- [ ] Open Preferences window and verify the "Projects" tab appears between Channels and General
- [ ] Add a new project via the text field and plus button
- [ ] Right-click a project to rename, archive, and delete
- [ ] Verify archived projects appear under the "ARCHIVED" header
- [ ] Verify empty state message shows when no projects exist
- [ ] Confirm all files are under 300 lines (ProjectsTabView: 199, PreferencesView: 56)