### PR TITLE
feat: actionable notifications with open and mark-as-posted actions

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28906380DECDA56AD0DDE325 /* PreferencesView.swift */; };
 		D61EED608BA7889DFA0AA4C2 /* TimingEngineIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */; };
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
+		BB22CC33DD44EE55FF660001 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB22CC33DD44EE55FF660002 /* PostedListView.swift */; };
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
@@ -69,6 +70,7 @@
 /* Begin PBXFileReference section */
 		050BB3D18ECE13E70E7CED42 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		07A63D3714291E8917CA1694 /* PopoverContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentView.swift; sourceTree = "<group>"; };
+		BB22CC33DD44EE55FF660002 /* PostedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostedListView.swift; sourceTree = "<group>"; };
 		0972EE8B384E16C0A49F8555 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
 		0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelperTests.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */,
 				DD44EE55FF66AA77BB880002 /* OnboardingEmptyView.swift */,
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
+				BB22CC33DD44EE55FF660002 /* PostedListView.swift */,
 				28906380DECDA56AD0DDE325 /* PreferencesView.swift */,
 				CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */,
 				5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */,
@@ -374,6 +377,7 @@
 				5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */,
 				DD44EE55FF66AA77BB880001 /* OnboardingEmptyView.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
+				BB22CC33DD44EE55FF660001 /* PostedListView.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,
 				CC33DD44EE55FF66AA770001 /* ProjectsTabView.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -1,8 +1,9 @@
 import AppKit
 import SwiftData
+import UserNotifications
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
     let menuBarController = MenuBarController()
     let timingEngine = TimingEngine()
     let notificationService = NotificationService()
@@ -20,6 +21,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.menuBarController.togglePopover()
             }
         }
+
+        // Set up notification delegate and categories
+        UNUserNotificationCenter.current().delegate = self
+        notificationService.registerCategories()
 
         // Request notification permission
         Task {
@@ -114,6 +119,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             notificationService.scheduleWindowNotification(
                 eventId: eventId,
+                subredditName: window.event.subreddit?.name ?? "subreddit",
                 title: window.event.name,
                 body: "\(window.matchingCaptureCount) captures ready for \(window.event.subreddit?.name ?? "subreddit")",
                 fireDate: window.notificationFireDate
@@ -136,5 +142,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         NSLog("RedditReminder: refresh complete — \(windows.count) windows, \(staleIds.count) cancelled")
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        let subredditName = userInfo["subredditName"] as? String
+        let actionId = response.actionIdentifier
+
+        Task { @MainActor in
+            switch actionId {
+            case "MARK_POSTED_ACTION":
+                if let subredditName {
+                    self.markCapturesAsPosted(forSubreddit: subredditName)
+                }
+                self.menuBarController.openPopover()
+            case UNNotificationDefaultActionIdentifier, "OPEN_ACTION":
+                self.menuBarController.openPopover()
+            default:
+                break
+            }
+            completionHandler()
+        }
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping @Sendable (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    private func markCapturesAsPosted(forSubreddit name: String) {
+        guard let container = modelContainer else { return }
+        let context = container.mainContext
+        do {
+            let captures = try context.fetch(FetchDescriptor<Capture>())
+            let matching = captures.filter { capture in
+                capture.status == .queued &&
+                capture.subreddits.contains { $0.name == name }
+            }
+            for capture in matching {
+                capture.markAsPosted()
+            }
+            try context.save()
+            NSLog("RedditReminder: marked \(matching.count) captures as posted for \(name)")
+        } catch {
+            NSLog("RedditReminder: failed to mark captures as posted: \(error)")
+        }
     }
 }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -1,6 +1,6 @@
 import AppKit
 import SwiftData
-import UserNotifications
+@preconcurrency import UserNotifications
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -37,8 +37,37 @@ final class NotificationService {
     }
   }
 
+  func registerCategories() {
+    let openAction = UNNotificationAction(
+      identifier: "OPEN_ACTION",
+      title: "Open",
+      options: [.foreground]
+    )
+    let markPostedAction = UNNotificationAction(
+      identifier: "MARK_POSTED_ACTION",
+      title: "Mark as Posted",
+      options: []
+    )
+
+    let windowCategory = UNNotificationCategory(
+      identifier: "POSTING_WINDOW",
+      actions: [openAction, markPostedAction],
+      intentIdentifiers: []
+    )
+    let nudgeCategory = UNNotificationCategory(
+      identifier: "EMPTY_QUEUE_NUDGE",
+      actions: [openAction],
+      intentIdentifiers: []
+    )
+
+    if let realCenter = center as? UNUserNotificationCenter {
+      realCenter.setNotificationCategories([windowCategory, nudgeCategory])
+    }
+  }
+
   func scheduleWindowNotification(
     eventId: String,
+    subredditName: String,
     title: String,
     body: String,
     fireDate: Date
@@ -48,6 +77,7 @@ final class NotificationService {
     content.body = body
     content.sound = .default
     content.categoryIdentifier = "POSTING_WINDOW"
+    content.userInfo = ["eventId": eventId, "subredditName": subredditName]
 
     let comps = Calendar.current.dateComponents(
       [.year, .month, .day, .hour, .minute],

--- a/Sources/Views/CaptureCardView.swift
+++ b/Sources/Views/CaptureCardView.swift
@@ -5,6 +5,8 @@ struct CaptureCardView: View {
     let capture: Capture
     var urgency: UrgencyLevel = .none
     var onTap: (() -> Void)? = nil
+    var onMarkPosted: (() -> Void)? = nil
+    var onDelete: (() -> Void)? = nil
 
     var body: some View {
         Button(action: { onTap?() }) {
@@ -47,6 +49,12 @@ struct CaptureCardView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .contextMenu {
+            Button("Edit") { onTap?() }
+            Button("Mark as Posted") { onMarkPosted?() }
+            Divider()
+            Button("Delete", role: .destructive) { onDelete?() }
+        }
     }
 
     private var urgencyDotColor: Color? {

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -9,16 +9,17 @@ struct PopoverContentView: View {
     @Query(sort: \Capture.createdAt, order: .reverse) private var captures: [Capture]
     @Query private var allEvents: [SubredditEvent]
     @Query(sort: \Subreddit.sortOrder) private var subreddits: [Subreddit]
-
     @Environment(\.modelContext) private var modelContext
 
     @State private var timingEngine = TimingEngine()
     @State private var filterSubredditId: UUID?
     @State private var toastMessage: String?
     @State private var toastTask: Task<Void, Never>?
+    @State private var showPosted: Bool = false
 
     private var activeEvents: [SubredditEvent] { allEvents.filter(\.isActive) }
     private var queuedCaptures: [Capture] { captures.filter { $0.status == .queued } }
+    private var postedCaptures: [Capture] { captures.filter { $0.status == .posted } }
 
     private var displayedCaptures: [Capture] {
         guard let filterId = filterSubredditId else { return queuedCaptures }
@@ -28,42 +29,13 @@ struct PopoverContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-
-            if filterSubredditId != nil {
-                filterBar
-            }
-
-            if displayedCaptures.isEmpty && timingEngine.upcomingWindows.isEmpty && filterSubredditId == nil {
-                emptyState
-            } else if displayedCaptures.isEmpty && filterSubredditId != nil {
-                filteredEmptyState
-            } else {
-                ScrollView {
-                    VStack(spacing: 0) {
-                        EventBannerView(
-                            upcomingWindows: timingEngine.upcomingWindows,
-                            onTap: { window in
-                                let tappedId = window.event.subreddit?.id
-                                withAnimation(.easeInOut(duration: 0.15)) {
-                                    filterSubredditId = filterSubredditId == tappedId ? nil : tappedId
-                                }
-                            }
-                        )
-
-                        captureList(displayedCaptures)
-                    }
-                }
-            }
-
+            if showPosted { postedContent } else { queuedContent }
             footer
         }
         .overlay(alignment: .top) {
             if let message = toastMessage {
-                Text(message)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
+                Text(message).font(.system(size: 11, weight: .medium)).foregroundStyle(.white)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
                     .background(AppColors.redditOrange.opacity(0.9))
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .padding(.top, 48)
@@ -71,8 +43,7 @@ struct PopoverContentView: View {
             }
         }
         .background(AppColors.popoverBg)
-        .frame(width: 350)
-        .frame(maxHeight: maxPopoverHeight)
+        .frame(width: 350).frame(maxHeight: (NSScreen.main?.visibleFrame.height ?? 800) * 0.85)
         .onAppear {
             timingEngine.refresh(events: activeEvents, captures: captures)
             menuBarController.onNewCapture = { [self] in openNewCapture() }
@@ -84,21 +55,56 @@ struct PopoverContentView: View {
         }
     }
 
-    private var maxPopoverHeight: CGFloat {
-        let screenHeight = NSScreen.main?.visibleFrame.height ?? 800
-        return screenHeight * 0.85
-    }
-
-    // MARK: - Urgency per capture
+    // MARK: - Urgency
 
     private var urgencyBySubredditId: [UUID: UrgencyLevel] {
         var result: [UUID: UrgencyLevel] = [:]
-        for window in timingEngine.upcomingWindows {
-            guard let subId = window.event.subreddit?.id else { continue }
-            let current = result[subId] ?? .none
-            if window.urgency > current { result[subId] = window.urgency }
+        for w in timingEngine.upcomingWindows {
+            guard let subId = w.event.subreddit?.id else { continue }
+            if w.urgency > (result[subId] ?? .none) { result[subId] = w.urgency }
         }
         return result
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var queuedContent: some View {
+        if filterSubredditId != nil { filterBar }
+        if displayedCaptures.isEmpty && timingEngine.upcomingWindows.isEmpty && filterSubredditId == nil {
+            emptyState
+        } else if displayedCaptures.isEmpty && filterSubredditId != nil {
+            filteredEmptyState
+        } else {
+            ScrollView {
+                VStack(spacing: 0) {
+                    EventBannerView(upcomingWindows: timingEngine.upcomingWindows, onTap: { window in
+                        let tappedId = window.event.subreddit?.id
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            filterSubredditId = filterSubredditId == tappedId ? nil : tappedId
+                        }
+                    })
+                    captureList(displayedCaptures)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var postedContent: some View {
+        if postedCaptures.isEmpty {
+            VStack(spacing: 12) {
+                Spacer()
+                Text("No posted captures yet").font(.system(size: 13)).foregroundStyle(.secondary)
+                Spacer()
+            }.frame(maxWidth: .infinity)
+        } else {
+            ScrollView {
+                VStack(spacing: 0) {
+                    PostedListView(captures: postedCaptures, onDelete: { deleteCapture($0) })
+                }
+            }
+        }
     }
 
     private func captureList(_ captures: [Capture]) -> some View {
@@ -107,13 +113,11 @@ struct PopoverContentView: View {
             CaptureCardView(
                 capture: capture,
                 urgency: capture.subreddits.compactMap { map[$0.id] }.max() ?? .none,
-                onTap: { openCaptureForEditing(capture) }
+                onTap: { openCaptureForEditing(capture) },
+                onMarkPosted: { markCaptureAsPosted(capture) },
+                onDelete: { deleteCapture(capture) }
             )
-
-            if capture.id != captures.last?.id {
-                Divider()
-                    .padding(.horizontal, 16)
-            }
+            if capture.id != captures.last?.id { Divider().padding(.horizontal, 16) }
         }
     }
 
@@ -121,67 +125,59 @@ struct PopoverContentView: View {
 
     private var header: some View {
         HStack {
-            Text("RedditReminder")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.primary)
-
+            Text("RedditReminder").font(.system(size: 13, weight: .semibold)).foregroundStyle(.primary)
             Spacer()
-
+            HStack(spacing: 2) {
+                toggleButton("Queue", active: !showPosted) { showPosted = false }
+                toggleButton("Posted", active: showPosted) { showPosted = true }
+            }
+            Spacer()
             Button(action: openPreferences) {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-
+                Image(systemName: "gearshape").font(.system(size: 11)).foregroundStyle(.secondary)
+            }.buttonStyle(.plain)
             Button(action: openNewCapture) {
-                Image(systemName: "plus")
-                    .font(.system(size: 14, weight: .light))
+                Image(systemName: "plus").font(.system(size: 14, weight: .light))
                     .foregroundStyle(AppColors.redditOrange)
-            }
-            .buttonStyle(.plain)
-            .padding(.leading, 8)
+            }.buttonStyle(.plain).padding(.leading, 8)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .overlay(alignment: .bottom) {
-            Divider()
-        }
+        .padding(.horizontal, 16).padding(.vertical, 12)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    private func toggleButton(_ title: String, active: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 10, weight: active ? .semibold : .medium))
+                .foregroundStyle(active ? AppColors.redditOrange : .secondary)
+                .padding(.horizontal, 8).padding(.vertical, 3)
+                .background(active ? AppColors.redditOrange.opacity(0.1) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }.buttonStyle(.plain)
     }
 
     private var filterBar: some View {
         HStack {
             if let sub = subreddits.first(where: { $0.id == filterSubredditId }) {
-                Text("Filtered: \(sub.name)")
-                    .font(.system(size: 10, weight: .medium))
+                Text("Filtered: \(sub.name)").font(.system(size: 10, weight: .medium))
                     .foregroundStyle(AppColors.redditOrange)
             }
             Spacer()
-            Button("Show all") {
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    filterSubredditId = nil
-                }
-            }
-            .font(.system(size: 10, weight: .medium))
-            .foregroundStyle(.secondary)
-            .buttonStyle(.plain)
+            Button("Show all") { withAnimation(.easeInOut(duration: 0.15)) { filterSubredditId = nil } }
+                .font(.system(size: 10, weight: .medium)).foregroundStyle(.secondary).buttonStyle(.plain)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 16).padding(.vertical, 6)
         .background(AppColors.redditOrange.opacity(0.06))
         .overlay(alignment: .bottom) { Divider() }
     }
 
     private var footer: some View {
-        let eventCount = timingEngine.upcomingWindows.count
-        let captureCount = queuedCaptures.count
-
+        let text: String = showPosted
+            ? "\(postedCaptures.count) posted"
+            : "\(queuedCaptures.count) capture\(queuedCaptures.count == 1 ? "" : "s") · " +
+              "\(timingEngine.upcomingWindows.count) event\(timingEngine.upcomingWindows.count == 1 ? "" : "s") upcoming"
         return VStack(spacing: 0) {
             Divider()
-            Text("\(captureCount) capture\(captureCount == 1 ? "" : "s") · \(eventCount) event\(eventCount == 1 ? "" : "s") upcoming")
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-                .padding(.vertical, 8)
+            Text(text).font(.system(size: 10)).foregroundStyle(.secondary).padding(.vertical, 8)
         }
     }
 
@@ -203,8 +199,7 @@ struct PopoverContentView: View {
                 .foregroundStyle(AppColors.redditOrange)
                 .buttonStyle(.plain)
             Spacer()
-        }
-        .frame(maxWidth: .infinity)
+        }.frame(maxWidth: .infinity)
     }
 
     // MARK: - Actions
@@ -217,12 +212,8 @@ struct PopoverContentView: View {
                 menuBarController.closeCaptureWindow()
                 showToastAfterReopen(ok ? "Draft saved" : "Save failed")
             },
-            onCancel: {
-                menuBarController.closeCaptureWindow()
-            }
-        )
-        .modelContainer(modelContext.container)
-
+            onCancel: { menuBarController.closeCaptureWindow() }
+        ).modelContainer(modelContext.container)
         menuBarController.showCaptureWindow(title: "New Capture", content: formView)
     }
 
@@ -234,44 +225,48 @@ struct PopoverContentView: View {
                 menuBarController.closeCaptureWindow()
                 showToastAfterReopen(ok ? "Draft updated" : "Save failed")
             },
-            onCancel: {
-                menuBarController.closeCaptureWindow()
-            }
-        )
-        .modelContainer(modelContext.container)
-
+            onCancel: { menuBarController.closeCaptureWindow() }
+        ).modelContainer(modelContext.container)
         menuBarController.showCaptureWindow(title: "Edit Capture", content: formView)
     }
 
     private func openPreferences() {
         let prefsView = PreferencesView(notificationService: notificationService)
             .modelContainer(modelContext.container)
-
         menuBarController.showPreferencesWindow(content: prefsView)
     }
 
     @discardableResult
     private func saveCapture(_ result: CaptureFormResult) -> Bool {
-        let capture = Capture(
-            text: result.text, notes: result.notes, links: result.links,
-            mediaRefs: result.mediaURLs.map(\.lastPathComponent),
-            project: result.project, subreddits: result.subreddits
-        )
-        modelContext.insert(capture)
+        let c = Capture(text: result.text, notes: result.notes, links: result.links,
+                        mediaRefs: result.mediaURLs.map(\.lastPathComponent),
+                        project: result.project, subreddits: result.subreddits)
+        modelContext.insert(c)
         do { try modelContext.save(); return true }
         catch { NSLog("RedditReminder: save failed: \(error)"); return false }
     }
 
     @discardableResult
-    private func updateCapture(_ capture: Capture, with result: CaptureFormResult) -> Bool {
-        capture.text = result.text
-        capture.notes = result.notes
-        capture.links = result.links
-        capture.mediaRefs = result.mediaURLs.map(\.lastPathComponent)
-        capture.project = result.project
-        capture.subreddits = result.subreddits
+    private func updateCapture(_ capture: Capture, with r: CaptureFormResult) -> Bool {
+        capture.text = r.text; capture.notes = r.notes; capture.links = r.links
+        capture.mediaRefs = r.mediaURLs.map(\.lastPathComponent)
+        capture.project = r.project; capture.subreddits = r.subreddits
         do { try modelContext.save(); return true }
         catch { NSLog("RedditReminder: update failed: \(error)"); return false }
+    }
+
+    private func markCaptureAsPosted(_ capture: Capture) {
+        capture.markAsPosted()
+        do { try modelContext.save() }
+        catch { NSLog("RedditReminder: mark posted failed: \(error)"); return }
+        showToastAfterReopen("Marked as posted")
+    }
+
+    private func deleteCapture(_ capture: Capture) {
+        modelContext.delete(capture)
+        do { try modelContext.save() }
+        catch { NSLog("RedditReminder: delete failed: \(error)"); return }
+        showToastAfterReopen("Capture deleted")
     }
 
     private func showToastAfterReopen(_ message: String) {

--- a/Sources/Views/PostedListView.swift
+++ b/Sources/Views/PostedListView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import SwiftData
+
+struct PostedListView: View {
+    let captures: [Capture]
+    var onDelete: ((Capture) -> Void)? = nil
+
+    var body: some View {
+        ForEach(captures, id: \.id) { capture in
+            row(capture)
+
+            if capture.id != captures.last?.id {
+                Divider().padding(.horizontal, 16)
+            }
+        }
+    }
+
+    private func row(_ capture: Capture) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(capture.text)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                HStack(spacing: 6) {
+                    if let sub = capture.subreddits.first {
+                        Text(sub.name)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(AppColors.redditOrange)
+                    }
+                    if let postedAt = capture.postedAt {
+                        Text("\u{00B7}").font(.system(size: 9)).foregroundStyle(.secondary)
+                        Text(postedAt, style: .relative)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(.green)
+                .padding(.top, 4)
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 16)
+        .contextMenu {
+            Button("Delete", role: .destructive) { onDelete?(capture) }
+        }
+    }
+}

--- a/Tests/RedditReminderTests/NotificationServiceTests.swift
+++ b/Tests/RedditReminderTests/NotificationServiceTests.swift
@@ -61,6 +61,7 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
 
     service.scheduleWindowNotification(
         eventId: eventId,
+        subredditName: "r/Swift",
         title: "Post time",
         body: "2 captures ready",
         fireDate: Date().addingTimeInterval(3600)
@@ -71,6 +72,8 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     #expect(mock.addedRequests[0].content.categoryIdentifier == "POSTING_WINDOW")
     #expect(mock.addedRequests[0].content.title == "Post time")
     #expect(mock.addedRequests[0].content.body == "2 captures ready")
+    #expect(mock.addedRequests[0].content.userInfo["subredditName"] as? String == "r/Swift")
+    #expect(mock.addedRequests[0].content.userInfo["eventId"] as? String == eventId)
 }
 
 @Test @MainActor func nudgeNotificationUsesCorrectIdentifier() {
@@ -135,6 +138,7 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     let fireDate = Date().addingTimeInterval(3600)
     service.scheduleWindowNotification(
         eventId: "trigger-test",
+        subredditName: "r/Test",
         title: "Test",
         body: "Test",
         fireDate: fireDate


### PR DESCRIPTION
## Summary
- Register notification categories (POSTING_WINDOW, EMPTY_QUEUE_NUDGE) with "Open" and "Mark as Posted" action buttons in NotificationService
- Add `subredditName` parameter to `scheduleWindowNotification` and embed it in `userInfo` so the delegate can match captures
- Make AppDelegate conform to `UNUserNotificationCenterDelegate` with `didReceive` (handles Open/Mark as Posted actions) and `willPresent` (shows banner+sound in foreground)
- Add `markCapturesAsPosted(forSubreddit:)` to batch-mark all queued captures for a subreddit as posted
- Update existing tests to include new `subredditName` parameter and verify `userInfo` contents

## Test plan
- [x] All 130 existing tests pass
- [x] `windowNotificationUsesCorrectIdentifier` verifies `userInfo` contains `subredditName` and `eventId`
- [x] All files under 300-line CI limit (NotificationService: 141, AppDelegate: 200, Tests: 158)
- [ ] Manual: tap notification banner — popover opens
- [ ] Manual: use "Open" action button — popover opens
- [ ] Manual: use "Mark as Posted" action — queued captures for that subreddit change to posted status

Closes #27