### PR TITLE
refactor: InputFieldStyle modifier, rename uniqueness, local isDragOver

### DIFF
--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -34,6 +34,26 @@ enum SettingsKey {
   static let nudgeWhenEmpty = "nudgeWhenEmpty"
 }
 
+struct InputFieldStyle: ViewModifier {
+  var cornerRadius: CGFloat = 8
+
+  func body(content: Content) -> some View {
+    content
+      .background(.quaternary.opacity(0.3))
+      .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+      .overlay(
+        RoundedRectangle(cornerRadius: cornerRadius)
+          .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+      )
+  }
+}
+
+extension View {
+  func inputFieldStyle(cornerRadius: CGFloat = 8) -> some View {
+    modifier(InputFieldStyle(cornerRadius: cornerRadius))
+  }
+}
+
 enum MediaConstants {
   static let thumbnailMaxSize: CGFloat = 200
   static let supportedImageTypes = ["png", "jpg", "jpeg", "gif"]

--- a/Sources/Views/CaptureMediaSection.swift
+++ b/Sources/Views/CaptureMediaSection.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CaptureMediaSection: View {
     @Binding var droppedFiles: [URL]
-    @Binding var isDragOver: Bool
+    @State private var isDragOver: Bool = false
 
     var body: some View {
         VStack(spacing: 8) {

--- a/Sources/Views/CaptureSubredditPicker.swift
+++ b/Sources/Views/CaptureSubredditPicker.swift
@@ -42,12 +42,7 @@ struct CaptureSubredditPicker: View {
             }
             .font(.system(size: 12))
             .padding(8)
-            .background(.quaternary.opacity(0.3))
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-            )
+            .inputFieldStyle()
         }
         .menuStyle(.borderlessButton)
     }

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -21,7 +21,6 @@ struct CaptureWindowView: View {
     @State private var links: [String] = []
     @State private var newLinkText: String = ""
     @State private var droppedFiles: [URL] = []
-    @State private var isDragOver: Bool = false
     @State private var showPreview: Bool = false
 
     var body: some View {
@@ -66,12 +65,7 @@ struct CaptureWindowView: View {
                                     .frame(minHeight: 72)
                                     .scrollContentBackground(.hidden)
                                     .padding(8)
-                                    .background(.quaternary.opacity(0.3))
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 8)
-                                            .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                                    )
+                                    .inputFieldStyle()
                             }
                         }
                     }
@@ -93,12 +87,7 @@ struct CaptureWindowView: View {
                         .labelsHidden()
                         .font(.system(size: 12))
                         .padding(4)
-                        .background(.quaternary.opacity(0.3))
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                        )
+                        .inputFieldStyle()
                     }
 
                     fieldSection("NOTES", optional: true) {
@@ -106,12 +95,7 @@ struct CaptureWindowView: View {
                             .font(.system(size: 12))
                             .textFieldStyle(.plain)
                             .padding(8)
-                            .background(.quaternary.opacity(0.3))
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                            )
+                            .inputFieldStyle()
                     }
 
                     fieldSection("LINKS") {
@@ -119,7 +103,7 @@ struct CaptureWindowView: View {
                     }
 
                     fieldSection("MEDIA") {
-                        CaptureMediaSection(droppedFiles: $droppedFiles, isDragOver: $isDragOver)
+                        CaptureMediaSection(droppedFiles: $droppedFiles)
                     }
                 }
                 .padding(16)

--- a/Sources/Views/ChannelsView.swift
+++ b/Sources/Views/ChannelsView.swift
@@ -18,12 +18,7 @@ struct ChannelsTabView: View {
                     .font(.system(size: 11))
                     .textFieldStyle(.plain)
                     .padding(7)
-                    .background(.quaternary.opacity(0.3))
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                    )
+                    .inputFieldStyle(cornerRadius: 6)
                     .onSubmit { addSubreddit() }
 
                 Button(action: addSubreddit) {

--- a/Sources/Views/MarkdownPreviewView.swift
+++ b/Sources/Views/MarkdownPreviewView.swift
@@ -17,12 +17,7 @@ struct MarkdownPreviewView: View {
                     .padding(8)
             }
         }
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-        )
+        .inputFieldStyle()
     }
 
     private func renderMarkdown(_ input: String) -> AttributedString? {

--- a/Sources/Views/ProjectsTabView.swift
+++ b/Sources/Views/ProjectsTabView.swift
@@ -23,12 +23,7 @@ struct ProjectsTabView: View {
                 .font(.system(size: 11))
                 .textFieldStyle(.plain)
                 .padding(7)
-                .background(.quaternary.opacity(0.3))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
-                )
+                .inputFieldStyle(cornerRadius: 6)
                 .onSubmit { addProject() }
 
             Button(action: addProject) {
@@ -167,9 +162,15 @@ struct ProjectsTabView: View {
     }
 
     private var canAdd: Bool {
-        let trimmed = newProjectName.trimmingCharacters(in: .whitespacesAndNewlines)
+        isNameAvailable(newProjectName)
+    }
+
+    private func isNameAvailable(_ name: String, excluding: Project? = nil) -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
-        return !projects.contains(where: { $0.name.lowercased() == trimmed.lowercased() })
+        return !projects.contains(where: {
+            $0.id != excluding?.id && $0.name.lowercased() == trimmed.lowercased()
+        })
     }
 
     private func addProject() {
@@ -193,7 +194,7 @@ struct ProjectsTabView: View {
 
     private func finishEditing(_ project: Project) {
         let trimmed = editName.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
+        if !trimmed.isEmpty, isNameAvailable(trimmed, excluding: project) {
             let oldName = project.name
             project.name = trimmed
             do { try modelContext.save() }


### PR DESCRIPTION
## Summary

- **InputFieldStyle ViewModifier**: Extract the repeated 3-modifier bordered-input pattern (`.background(.quaternary.opacity(0.3))` + `.clipShape(RoundedRectangle)` + `.overlay(stroke)`) into a reusable `.inputFieldStyle(cornerRadius:)` modifier. Replaces 7 occurrences across 6 files. Supports configurable corner radius (default 8, some fields use 6).
- **Rename uniqueness enforcement**: `ProjectsTabView.finishEditing` now checks `isNameAvailable(_:excluding:)` — previously only `canAdd` prevented duplicate names, so renaming a project to an existing name was allowed.
- **Local isDragOver**: Move `isDragOver` from `@Binding` to local `@State` in `CaptureMediaSection` since the parent (`CaptureWindowView`) never reads it. Removes the unnecessary state and binding from the parent.

Net: -10 lines across 7 files.

## Test plan

- [x] All 150 tests pass
- [x] Build succeeds
- [x] All files under 300-line CI limit
- [ ] Verify input field styling is visually unchanged across capture form, channels, projects
- [ ] Verify renaming a project to an existing name is rejected (keeps old name)
- [ ] Verify drag-and-drop still highlights the media drop zone