### PR TITLE
fix: menu shortcuts and QA script rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-.PHONY: build test install install-login clean generate qa
+.PHONY: build build-debug test install install-debug clean generate qa
 
 APP_NAME := RedditReminder
 PROJ := $(APP_NAME).xcodeproj
 BUILD_DIR := build
 INSTALL_DIR := $(HOME)/Applications
 LABEL := com.neonwatty.$(APP_NAME)
+
+# Copy the built .app into INSTALL_DIR.  $(1) = configuration name (Release | Debug)
+define copy_app
+	mkdir -p $(INSTALL_DIR)
+	rm -rf $(INSTALL_DIR)/$(APP_NAME).app
+	cp -R $(BUILD_DIR)/Build/Products/$(1)/$(APP_NAME).app $(INSTALL_DIR)/
+endef
 
 generate:
 	xcodegen generate
@@ -15,6 +22,12 @@ build: generate
 	  -configuration Release -destination 'platform=macOS' \
 	  -derivedDataPath $(BUILD_DIR)
 
+build-debug: generate
+	xcodebuild build \
+	  -project $(PROJ) -scheme $(APP_NAME) \
+	  -configuration Debug -destination 'platform=macOS' \
+	  -derivedDataPath $(BUILD_DIR)
+
 test: generate
 	xcodebuild test \
 	  -project $(PROJ) -scheme $(APP_NAME) \
@@ -22,9 +35,7 @@ test: generate
 	  -derivedDataPath $(BUILD_DIR)
 
 install: build
-	mkdir -p $(INSTALL_DIR)
-	rm -rf $(INSTALL_DIR)/$(APP_NAME).app
-	cp -R $(BUILD_DIR)/Build/Products/Release/$(APP_NAME).app $(INSTALL_DIR)/
+	$(call copy_app,Release)
 	@if [ -f "$(HOME)/Library/LaunchAgents/$(LABEL).plist" ]; then \
 	  echo "LaunchAgent detected -- restarting managed instance"; \
 	  launchctl kickstart -k "gui/$$(id -u)/$(LABEL)"; \
@@ -32,7 +43,10 @@ install: build
 	  open $(INSTALL_DIR)/$(APP_NAME).app; \
 	fi
 
-qa: install
+install-debug: build-debug
+	$(call copy_app,Debug)
+
+qa: install-debug
 	./scripts/qa.sh
 
 clean:

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -7,51 +7,51 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0212354E124DB25DE1283B6C /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */; };
 		041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */; };
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
+		1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */; };
 		14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */; };
-		AA22BB33CC44DD55EE660001 /* CaptureHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA22BB33CC44DD55EE660002 /* CaptureHelpers.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
 		1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */; };
-		AA11BB22CC33DD44EE550001 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE550002 /* CaptureSubredditPicker.swift */; };
-		AA11BB22CC33DD44EE550003 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE550004 /* CaptureLinksSection.swift */; };
-		AA11BB22CC33DD44EE550005 /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */; };
-		EE55FF66AA77BB88CC990001 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE55FF66AA77BB88CC990002 /* MarkdownPreviewView.swift */; };
 		19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */; };
 		1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */; };
-		AA22BB33CC44DD55EE660003 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA22BB33CC44DD55EE660004 /* CaptureHelpersTests.swift */; };
 		1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */; };
 		1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */; };
 		2214090DA72A5B5AF58F6658 /* SubredditPeakTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */; };
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
+		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
+		3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */; };
 		3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0972EE8B384E16C0A49F8555 /* AppDelegate.swift */; };
 		42EF49CDAB403FE9D2C36047 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BB3D18ECE13E70E7CED42 /* NotificationService.swift */; };
+		458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */; };
 		474176ACD33799B0C433D8C5 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A523CACB82BF88E46FD3E /* MenuBarController.swift */; };
 		4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */; };
 		4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975C23592B958F445105973E /* CaptureWindowView.swift */; };
 		4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599273192FBCFDD93D1241B0 /* Project.swift */; };
-		CC33DD44EE55FF66AA770001 /* ProjectsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */; };
 		55E73142A5F438F0600FF8F2 /* LinkChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0A7A7AAA2C09449780FF4F /* LinkChipView.swift */; };
 		5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */; };
 		59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1122ADEB6045619C303C31 /* MediaStore.swift */; };
 		5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */; };
-		DD44EE55FF66AA77BB880001 /* OnboardingEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD44EE55FF66AA77BB880002 /* OnboardingEmptyView.swift */; };
+		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
 		70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */; };
+		73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */; };
 		7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */; };
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
-		7F1A2B3C4D5E6F7890ABCDE1 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A2B3C4D5E6F7890ABCDE2 /* FlowLayout.swift */; };
 		8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB005E503FDAD90271DB0AE /* EventBannerView.swift */; };
 		9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */; };
 		AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */; };
 		B104E0E65566B8E4EFDFE190 /* EdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */; };
 		B3807D895E708C33AAA6D242 /* HeuristicsTimezoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */; };
 		B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28906380DECDA56AD0DDE325 /* PreferencesView.swift */; };
+		C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */; };
+		CC6A10A2CEA907B520EEE2F3 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */; };
 		D61EED608BA7889DFA0AA4C2 /* TimingEngineIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */; };
+		E3F5BC123C653EDC86231434 /* CaptureHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */; };
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
-		BB22CC33DD44EE55FF660001 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB22CC33DD44EE55FF660002 /* PostedListView.swift */; };
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
@@ -71,29 +71,27 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSubredditPicker.swift; sourceTree = "<group>"; };
 		050BB3D18ECE13E70E7CED42 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		07A63D3714291E8917CA1694 /* PopoverContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentView.swift; sourceTree = "<group>"; };
-		BB22CC33DD44EE55FF660002 /* PostedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostedListView.swift; sourceTree = "<group>"; };
 		0972EE8B384E16C0A49F8555 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
 		0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelperTests.swift; sourceTree = "<group>"; };
 		18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureFormResult.swift; sourceTree = "<group>"; };
-		AA11BB22CC33DD44EE550002 /* CaptureSubredditPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSubredditPicker.swift; sourceTree = "<group>"; };
-		AA11BB22CC33DD44EE550004 /* CaptureLinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksSection.swift; sourceTree = "<group>"; };
-		AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
+		1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostedListView.swift; sourceTree = "<group>"; };
+		1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsTabView.swift; sourceTree = "<group>"; };
 		20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
 		274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsTimezoneTests.swift; sourceTree = "<group>"; };
-		CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsTabView.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA22BB33CC44DD55EE660004 /* CaptureHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpersTests.swift; sourceTree = "<group>"; };
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleEdgeCaseTests.swift; sourceTree = "<group>"; };
 		4CB005E503FDAD90271DB0AE /* EventBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBannerView.swift; sourceTree = "<group>"; };
-		7F1A2B3C4D5E6F7890ABCDE2 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
+		4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEmptyView.swift; sourceTree = "<group>"; };
 		4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubreddits.swift; sourceTree = "<group>"; };
+		4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksSection.swift; sourceTree = "<group>"; };
 		4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngine.swift; sourceTree = "<group>"; };
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
@@ -103,27 +101,29 @@
 		614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditEvent.swift; sourceTree = "<group>"; };
 		65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralTabView.swift; sourceTree = "<group>"; };
 		6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStore.swift; sourceTree = "<group>"; };
+		6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
 		726D903A97B808C6ED572BCA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderApp.swift; sourceTree = "<group>"; };
 		83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineIntegrationTests.swift; sourceTree = "<group>"; };
+		8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
+		88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		975C23592B958F445105973E /* CaptureWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureWindowView.swift; sourceTree = "<group>"; };
 		9FA306067C4690F4D1CDAC2D /* Subreddit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subreddit.swift; sourceTree = "<group>"; };
 		9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureCardView.swift; sourceTree = "<group>"; };
 		A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPeakTimeTests.swift; sourceTree = "<group>"; };
+		ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		AE1122ADEB6045619C303C31 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		AEE4E14F7A70E1A66FA994A3 /* Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture.swift; sourceTree = "<group>"; };
-		AA22BB33CC44DD55EE660002 /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
 		B338E8D9C979B250564A392E /* QAFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAFixtures.swift; sourceTree = "<group>"; };
 		B58A523CACB82BF88E46FD3E /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		B727389070814347602E1AB3 /* TimingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineTests.swift; sourceTree = "<group>"; };
 		BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRUDTests.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
-		DD44EE55FF66AA77BB880002 /* OnboardingEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEmptyView.swift; sourceTree = "<group>"; };
 		E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarControllerTests.swift; sourceTree = "<group>"; };
 		F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTests.swift; sourceTree = "<group>"; };
-		EE55FF66AA77BB88CC990002 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
+		FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpersTests.swift; sourceTree = "<group>"; };
 		FB0A7A7AAA2C09449780FF4F /* LinkChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkChipView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -144,7 +144,7 @@
 		465002D9A45996043976CEED /* RedditReminderTests */ = {
 			isa = PBXGroup;
 			children = (
-				AA22BB33CC44DD55EE660004 /* CaptureHelpersTests.swift */,
+				FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */,
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
 				BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */,
 				F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */,
@@ -166,7 +166,7 @@
 		46CC88F14B3721D357AD7FC0 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				AA22BB33CC44DD55EE660002 /* CaptureHelpers.swift */,
+				8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */,
 				5DB4E56FCDA7A1CB1F24566D /* Constants.swift */,
 				4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */,
 				56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */,
@@ -230,22 +230,22 @@
 			isa = PBXGroup;
 			children = (
 				A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */,
-				AA11BB22CC33DD44EE550004 /* CaptureLinksSection.swift */,
-				AA11BB22CC33DD44EE550006 /* CaptureMediaSection.swift */,
-				AA11BB22CC33DD44EE550002 /* CaptureSubredditPicker.swift */,
+				4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */,
+				6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */,
+				04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */,
 				975C23592B958F445105973E /* CaptureWindowView.swift */,
 				09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */,
 				4CB005E503FDAD90271DB0AE /* EventBannerView.swift */,
-				7F1A2B3C4D5E6F7890ABCDE2 /* FlowLayout.swift */,
+				88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */,
 				65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */,
 				FB0A7A7AAA2C09449780FF4F /* LinkChipView.swift */,
-				EE55FF66AA77BB88CC990002 /* MarkdownPreviewView.swift */,
+				ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */,
 				CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */,
-				DD44EE55FF66AA77BB880002 /* OnboardingEmptyView.swift */,
+				4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */,
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
-				BB22CC33DD44EE55FF660002 /* PostedListView.swift */,
+				1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */,
 				28906380DECDA56AD0DDE325 /* PreferencesView.swift */,
-				CC33DD44EE55FF66AA770002 /* ProjectsTabView.swift */,
+				1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */,
 				5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */,
 			);
 			path = Views;
@@ -343,7 +343,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFBC4E3EB895C7668654877B /* CRUDTests.swift in Sources */,
-				AA22BB33CC44DD55EE660003 /* CaptureHelpersTests.swift in Sources */,
+				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
 				1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */,
 				B104E0E65566B8E4EFDFE190 /* EdgeCaseTests.swift in Sources */,
 				5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */,
@@ -368,31 +368,31 @@
 				F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */,
 				1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */,
 				6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */,
-				AA11BB22CC33DD44EE550003 /* CaptureLinksSection.swift in Sources */,
-				AA11BB22CC33DD44EE550005 /* CaptureMediaSection.swift in Sources */,
-				AA11BB22CC33DD44EE550001 /* CaptureSubredditPicker.swift in Sources */,
+				E3F5BC123C653EDC86231434 /* CaptureHelpers.swift in Sources */,
+				632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */,
+				458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */,
+				396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */,
 				4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */,
 				6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */,
 				81C26D97123D840A9130AF7E /* Constants.swift in Sources */,
 				F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */,
 				8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */,
-				7F1A2B3C4D5E6F7890ABCDE1 /* FlowLayout.swift in Sources */,
+				0212354E124DB25DE1283B6C /* FlowLayout.swift in Sources */,
 				0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */,
 				EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */,
 				E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */,
 				55E73142A5F438F0600FF8F2 /* LinkChipView.swift in Sources */,
-				EE55FF66AA77BB88CC990001 /* MarkdownPreviewView.swift in Sources */,
+				CC6A10A2CEA907B520EEE2F3 /* MarkdownPreviewView.swift in Sources */,
 				59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */,
 				474176ACD33799B0C433D8C5 /* MenuBarController.swift in Sources */,
 				42EF49CDAB403FE9D2C36047 /* NotificationService.swift in Sources */,
 				5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */,
-				DD44EE55FF66AA77BB880001 /* OnboardingEmptyView.swift in Sources */,
+				C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
-				BB22CC33DD44EE55FF660001 /* PostedListView.swift in Sources */,
+				3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,
-				CC33DD44EE55FF66AA770001 /* ProjectsTabView.swift in Sources */,
-				AA22BB33CC44DD55EE660001 /* CaptureHelpers.swift in Sources */,
+				73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */,
 				17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */,
 				FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */,
 				1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */,

--- a/Sources/Services/MenuBarController.swift
+++ b/Sources/Services/MenuBarController.swift
@@ -186,11 +186,9 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
         let appMenu = NSMenu()
         let appMenuItem = NSMenuItem()
         appMenuItem.submenu = appMenu
-        appMenu.addItem(
-            withTitle: "Preferences…",
-            action: #selector(handleOpenPreferences),
-            keyEquivalent: ","
-        )
+        let prefsItem = NSMenuItem(title: "Preferences…", action: #selector(handleOpenPreferences), keyEquivalent: ",")
+        prefsItem.target = self
+        appMenu.addItem(prefsItem)
         appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(
             withTitle: "Quit RedditReminder",
@@ -202,21 +200,21 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
         let fileMenu = NSMenu(title: "File")
         let fileMenuItem = NSMenuItem()
         fileMenuItem.submenu = fileMenu
-        fileMenu.addItem(
-            withTitle: "New Capture",
-            action: #selector(handleNewCapture),
-            keyEquivalent: "n"
-        )
+        let newCaptureItem = NSMenuItem(title: "New Capture", action: #selector(handleNewCapture), keyEquivalent: "n")
+        newCaptureItem.target = self
+        fileMenu.addItem(newCaptureItem)
         mainMenu.addItem(fileMenuItem)
 
         NSApp.mainMenu = mainMenu
     }
 
     @objc private func handleNewCapture() {
-        onNewCapture?()
+        guard let action = onNewCapture else { return }
+        action()
     }
 
     @objc private func handleOpenPreferences() {
-        onOpenPreferences?()
+        guard let action = onOpenPreferences else { return }
+        action()
     }
 }

--- a/Tests/RedditReminderTests/MenuBarControllerTests.swift
+++ b/Tests/RedditReminderTests/MenuBarControllerTests.swift
@@ -37,4 +37,31 @@ struct MenuBarControllerTests {
         controller.isPopoverVisible = true
         #expect(controller.isPopoverVisible == true)
     }
+
+    @Test func handleNewCaptureInvokesCallback() {
+        let controller = MenuBarController()
+        var called = false
+        controller.onNewCapture = { called = true }
+        controller.perform(NSSelectorFromString("handleNewCapture"))
+        #expect(called == true)
+    }
+
+    @Test func handleOpenPreferencesInvokesCallback() {
+        let controller = MenuBarController()
+        var called = false
+        controller.onOpenPreferences = { called = true }
+        controller.perform(NSSelectorFromString("handleOpenPreferences"))
+        #expect(called == true)
+    }
+
+    @Test func handleNewCaptureNoOpWhenCallbackNil() {
+        let controller = MenuBarController()
+        // onNewCapture is nil by default — should not crash
+        controller.perform(NSSelectorFromString("handleNewCapture"))
+    }
+
+    @Test func handleOpenPreferencesNoOpWhenCallbackNil() {
+        let controller = MenuBarController()
+        controller.perform(NSSelectorFromString("handleOpenPreferences"))
+    }
 }

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -1,26 +1,21 @@
 #!/usr/bin/env bash
-# RedditReminder QA — automated state-transition tests
+# RedditReminder QA — automated smoke tests for the menu bar popover app
 # Requires: the app to have been built via `make install` first.
 #
-# Uses macOS System Events to click at computed coordinates
-# and verify window width after each sidebar state transition.
+# Uses macOS System Events / AppleScript to interact with the status item,
+# and CGWindowList (via Swift) to detect the popover (which lives at a
+# special window layer not visible to the accessibility API).
 #
-# NOTE: This does NOT test the ⌘⇧R global shortcut — that requires
-# granting Accessibility permission to RedditReminder manually.
+# NOTE: Grant Accessibility permission to your terminal app:
+#   System Settings > Privacy & Security > Accessibility
 
 set -euo pipefail
 
 APP_NAME="RedditReminder"
 APP_PATH="$HOME/Applications/$APP_NAME.app"
-ANIM_WAIT=0.6          # seconds to wait for width animation (0.35s) + margin
-LAUNCH_WAIT=2           # seconds to wait after launch
-
-# Expected widths from SidebarConstants (Sources/Utilities/Constants.swift)
-W_STRIP=24
-W_GLANCE=200
-W_BROWSE=320
-W_CAPTURE=480
-W_SETTINGS=320
+LAUNCH_WAIT=3           # seconds to wait after launch
+ACTION_WAIT=1.5         # seconds to wait after UI action
+WINDOW_WAIT=2.0         # seconds to wait for window to appear
 
 passed=0
 failed=0
@@ -32,87 +27,40 @@ red()   { printf '\033[31m%s\033[0m' "$1"; }
 green() { printf '\033[32m%s\033[0m' "$1"; }
 bold()  { printf '\033[1m%s\033[0m' "$1"; }
 
-get_width() {
-    osascript -e "
-        tell application \"System Events\"
-            tell process \"$APP_NAME\"
-                set {w, h} to size of window 1
-                return w as integer
-            end tell
-        end tell
-    "
-}
-
-click_at_rel() {
-    # Click at a position relative to the window origin.
-    # $1 = AppleScript x expression using winX, winW
-    # $2 = AppleScript y expression using winY, winH
-    local x_expr="$1" y_expr="$2"
-    osascript -e "
-        tell application \"System Events\"
-            tell process \"$APP_NAME\"
-                set {winX, winY} to position of window 1
-                set {winW, winH} to size of window 1
-                click at {$x_expr, $y_expr}
-            end tell
-        end tell
-    " >/dev/null
-    sleep "$ANIM_WAIT"
-}
-
-# Back chevron: top-right of header, fixed offset from window corner
-click_back_chevron() { click_at_rel "winX + winW - 21" "winY + 20"; }
-
-# Strip: full-height Button, click center
-click_strip()        { click_at_rel "winX + (winW / 2)" "winY + (winH / 2)"; }
-
-# "+ New Capture": pinned to bottom with .padding(10)
-click_new_capture()  { click_at_rel "winX + (winW / 2)" "winY + winH - 20"; }
-
-click_cancel() {
-    # Cancel button: use accessibility element lookup rather than
-    # coordinates. Button order within group 1 is empirical — verify
-    # with Accessibility Inspector if the view hierarchy changes.
-    local result
-    result=$(osascript -e "
-        tell application \"System Events\"
-            tell process \"$APP_NAME\"
-                set grp to group 1 of window 1
-                set allBtns to every button of grp
-                if (count of allBtns) >= 2 then
-                    click item 2 of allBtns
-                    return \"clicked\"
-                else
-                    return \"error: only \" & (count of allBtns) & \" buttons found, expected >= 2\"
-                end if
-            end tell
-        end tell
-    ")
-    if [[ "$result" == error:* ]]; then
-        echo ""
-        echo "$(red ERROR): click_cancel: $result" >&2
-        exit 1
-    fi
-    sleep "$ANIM_WAIT"
-}
-
-assert_width() {
+assert_true() {
     local label="$1"
-    local expected="$2"
+    local condition="$2"  # "true" or "false"
     total=$((total + 1))
-    local actual
-    actual=$(get_width) || true
-    if [ -z "$actual" ]; then
-        failed=$((failed + 1))
-        printf "  %-45s $(red FAIL)  (could not read window width)\n" "$label"
-        return
-    fi
-    if [ "$actual" -eq "$expected" ]; then
+    if [ "$condition" = "true" ]; then
         passed=$((passed + 1))
-        printf "  %-45s $(green PASS)  (%dpx)\n" "$label" "$actual"
+        printf "  %-50s $(green PASS)\n" "$label"
     else
         failed=$((failed + 1))
-        printf "  %-45s $(red FAIL)  (expected %dpx, got %dpx)\n" "$label" "$expected" "$actual"
+        printf "  %-50s $(red FAIL)\n" "$label"
+    fi
+}
+
+assert_false() {
+    local label="$1"
+    local condition="$2"  # "true" or "false"
+    if [ "$condition" = "false" ]; then
+        assert_true "$label" "true"
+    else
+        assert_true "$label" "false"
+    fi
+}
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    total=$((total + 1))
+    if [ "$expected" = "$actual" ]; then
+        passed=$((passed + 1))
+        printf "  %-50s $(green PASS)  (%s)\n" "$label" "$actual"
+    else
+        failed=$((failed + 1))
+        printf "  %-50s $(red FAIL)  (expected: %s, got: %s)\n" "$label" "$expected" "$actual"
     fi
 }
 
@@ -120,14 +68,136 @@ assert_running() {
     total=$((total + 1))
     if pgrep -x "$APP_NAME" >/dev/null 2>&1; then
         passed=$((passed + 1))
-        printf "  %-45s $(green PASS)\n" "$1"
+        printf "  %-50s $(green PASS)\n" "$1"
     else
         failed=$((failed + 1))
-        printf "  %-45s $(red FAIL)  (process not found)\n" "$1"
+        printf "  %-50s $(red FAIL)  (process not found)\n" "$1"
         echo ""
         echo "$(red 'ABORT'): App not running. Cannot continue."
         exit 1
     fi
+}
+
+# ─── CGWindowList helpers (Swift) ──────────────────────────────────
+# NSPopover windows are invisible to System Events because they live at
+# window layer 25 (kCGStatusWindowLevel). We use CGWindowListCopyWindowInfo
+# to detect them.
+
+popover_visible() {
+    swift -e '
+import CoreGraphics
+let wl = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] ?? []
+let found = wl.contains { w in
+    (w["kCGWindowOwnerName"] as? String ?? "").contains("RedditReminder") &&
+    (w["kCGWindowLayer"] as? Int ?? 0) == 25 &&
+    (w["kCGWindowIsOnscreen"] as? Bool ?? false)
+}
+print(found ? "true" : "false")
+' 2>/dev/null || echo "false"
+}
+
+# Find a named window owned by RedditReminder and return "width height onscreen"
+named_window_info() {
+    local title="$1"
+    swift -e "
+import CoreGraphics
+let wl = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] ?? []
+for w in wl {
+    let owner = w[\"kCGWindowOwnerName\"] as? String ?? \"\"
+    let name = w[\"kCGWindowName\"] as? String ?? \"\"
+    if owner.contains(\"RedditReminder\") && name == \"$title\" {
+        let bounds = w[\"kCGWindowBounds\"] as? [String: Any] ?? [:]
+        let width = bounds[\"Width\"] as? Int ?? 0
+        let height = bounds[\"Height\"] as? Int ?? 0
+        let onscreen = w[\"kCGWindowIsOnscreen\"] as? Bool ?? false
+        print(\"\(width) \(height) \(onscreen)\")
+        break
+    }
+}
+" 2>/dev/null
+}
+
+named_window_exists() {
+    local info
+    info=$(named_window_info "$1")
+    if [ -n "$info" ]; then
+        local onscreen
+        onscreen=$(echo "$info" | awk '{print $3}')
+        if [ "$onscreen" = "true" ]; then echo "true"; else echo "false"; fi
+    else
+        echo "false"
+    fi
+}
+
+named_window_width() {
+    local info
+    info=$(named_window_info "$1")
+    echo "$info" | awk '{print $1}'
+}
+
+count_named_windows() {
+    local title="$1"
+    swift -e "
+import CoreGraphics
+let wl = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] ?? []
+var count = 0
+for w in wl {
+    let owner = w[\"kCGWindowOwnerName\"] as? String ?? \"\"
+    let name = w[\"kCGWindowName\"] as? String ?? \"\"
+    let onscreen = w[\"kCGWindowIsOnscreen\"] as? Bool ?? false
+    if owner.contains(\"RedditReminder\") && name == \"$title\" && onscreen { count += 1 }
+}
+print(count)
+" 2>/dev/null || echo "0"
+}
+
+# ─── UI interaction helpers ────────────────────────────────────────
+
+# Toggle popover via AXPress on the status bar item
+press_status_item() {
+    if ! osascript -e '
+tell application "System Events"
+    tell process "RedditReminder"
+        perform action "AXPress" of menu bar item 1 of menu bar 2
+    end tell
+end tell
+' >/dev/null 2>&1; then
+        echo "  $(red WARNING): press_status_item failed (is the app running?)" >&2
+    fi
+    sleep "$ACTION_WAIT"
+}
+
+# Click a menu bar menu item: menu_name, item_name
+click_menu_item() {
+    local menu_name="$1"
+    local item_name="$2"
+    if ! osascript -e "
+tell application \"System Events\"
+    tell process \"$APP_NAME\"
+        click menu item \"$item_name\" of menu \"$menu_name\" of menu bar 1
+    end tell
+end tell
+" >/dev/null 2>&1; then
+        echo "  $(red WARNING): click_menu_item '$menu_name' > '$item_name' failed" >&2
+    fi
+    sleep "$WINDOW_WAIT"
+}
+
+# Close a window by title using the close button (button 1)
+close_window() {
+    local title="$1"
+    if ! osascript -e "
+tell application \"System Events\"
+    tell process \"$APP_NAME\"
+        if exists (first window whose title is \"$title\") then
+            click button 1 of (first window whose title is \"$title\")
+        end if
+    end tell
+end tell
+" >/dev/null 2>&1; then
+        echo "  $(red WARNING): close_window '$title' failed" >&2
+    fi
+    sleep "$ACTION_WAIT"
 }
 
 # ─── pre-flight ────────────────────────────────────────────────────
@@ -138,6 +208,29 @@ if ! osascript -e 'tell application "System Events" to return name of first proc
     echo ": Cannot access System Events."
     echo "  Grant Accessibility permission to your terminal app:"
     echo "  System Settings > Privacy & Security > Accessibility"
+    echo ""
+    exit 1
+fi
+
+if [ ! -d "$APP_PATH" ]; then
+    echo ""
+    red "ERROR"
+    echo ": App not found at $APP_PATH"
+    echo "  Run 'make install' first."
+    echo ""
+    exit 1
+fi
+
+# Screen Recording permission is required for CGWindowListCopyWindowInfo
+if ! swift -e '
+import CoreGraphics
+guard let wl = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]], !wl.isEmpty else { exit(1) }
+' 2>/dev/null; then
+    echo ""
+    red "ERROR"
+    echo ": Cannot query window list (CGWindowListCopyWindowInfo)."
+    echo "  Grant Screen Recording permission to your terminal app:"
+    echo "  System Settings > Privacy & Security > Screen Recording"
     echo ""
     exit 1
 fi
@@ -153,106 +246,178 @@ echo "────────────────────────�
 pkill -x "$APP_NAME" 2>/dev/null || true
 sleep 1
 
-# Launch
-echo "  Launching $APP_NAME..."
-open "$APP_PATH"
+# Launch with --seed-qa to populate test fixtures (requires DEBUG build)
+echo "  Launching $APP_NAME with --seed-qa..."
+open "$APP_PATH" --args --seed-qa
 sleep "$LAUNCH_WAIT"
 
-# ─── tests ─────────────────────────────────────────────────────────
+# ─── 1. Launch ─────────────────────────────────────────────────────
 
 echo ""
 bold "1. Launch"
 echo ""
 assert_running "App is running"
-assert_width   "Starts in Glance mode"              "$W_GLANCE"
+
+# Verify popover is NOT open on launch
+vis=$(popover_visible)
+assert_false "Popover closed on launch" "$vis"
+
+# ─── 2. Popover toggle ────────────────────────────────────────────
 
 echo ""
-bold "2. Step down: Glance → Strip"
+bold "2. Popover toggle"
 echo ""
-click_back_chevron
-assert_width   "Back chevron → Strip"                "$W_STRIP"
+
+press_status_item
+vis=$(popover_visible)
+assert_true "AXPress status item → popover opens" "$vis"
+
+press_status_item
+vis=$(popover_visible)
+assert_false "AXPress again → popover closes" "$vis"
+
+# ─── 3. New Capture window (File > New Capture) ───────────────────
 
 echo ""
-bold "3. Expand: Strip → Glance"
+bold "3. New Capture window"
 echo ""
-click_strip
-assert_width   "Click strip → Glance"               "$W_GLANCE"
+
+# Open popover first (triggers PopoverContentView.onAppear which wires up callbacks)
+press_status_item
+sleep 1  # extra time for SwiftUI onAppear to wire callbacks
+
+click_menu_item "File" "New Capture"
+exists=$(named_window_exists "New Capture")
+assert_true "File > New Capture opens window" "$exists"
+
+if [ "$exists" = "true" ]; then
+    w=$(named_window_width "New Capture")
+    assert_eq "Capture window width" "420" "$w"
+
+    close_window "New Capture"
+    exists_after=$(named_window_exists "New Capture")
+    assert_false "Close button dismisses Capture window" "$exists_after"
+fi
+
+# ─── 4. Preferences window ────────────────────────────────────────
 
 echo ""
-bold "4. New Capture: Glance → Capture"
+bold "4. Preferences window"
 echo ""
-click_new_capture
-assert_width   "New Capture → Capture"               "$W_CAPTURE"
+
+# macOS renames "Preferences…" to "Settings…" automatically
+click_menu_item "RedditReminder" "Settings…"
+exists=$(named_window_exists "RedditReminder Preferences")
+assert_true "Settings menu opens Preferences window" "$exists"
+
+if [ "$exists" = "true" ]; then
+    w=$(named_window_width "RedditReminder Preferences")
+    assert_eq "Preferences window width" "500" "$w"
+
+    close_window "RedditReminder Preferences"
+    exists_after=$(named_window_exists "RedditReminder Preferences")
+    assert_false "Close button dismisses Preferences window" "$exists_after"
+fi
+
+# ─── 5. Popover dismisses when windows open ───────────────────────
 
 echo ""
-bold "5. Cancel: Capture → Browse"
+bold "5. Popover auto-dismiss"
 echo ""
-click_cancel
-assert_width   "Cancel → Browse"                     "$W_BROWSE"
+
+# Open popover
+press_status_item
+vis=$(popover_visible)
+assert_true "Popover is open before New Capture" "$vis"
+
+# Open capture window — popover should dismiss
+click_menu_item "File" "New Capture"
+vis=$(popover_visible)
+assert_false "Popover dismissed when Capture opens" "$vis"
+
+close_window "New Capture"
+
+# ─── 6. Capture window reuse ──────────────────────────────────────
 
 echo ""
-bold "6. Step down: Browse → Glance"
+bold "6. Capture window reuse"
 echo ""
-click_back_chevron
-assert_width   "Back chevron → Glance"               "$W_GLANCE"
+
+# Open, close, open again
+click_menu_item "File" "New Capture"
+exists1=$(named_window_exists "New Capture")
+assert_true "First New Capture window opens" "$exists1"
+
+close_window "New Capture"
+
+click_menu_item "File" "New Capture"
+exists2=$(named_window_exists "New Capture")
+assert_true "Second New Capture opens after close" "$exists2"
+
+close_window "New Capture"
+
+# ─── 7. Preferences window reuse ──────────────────────────────────
 
 echo ""
-bold "7. Step down: Glance → Strip"
+bold "7. Preferences window reuse"
 echo ""
-click_back_chevron
-assert_width   "Back chevron → Strip"                "$W_STRIP"
+
+click_menu_item "RedditReminder" "Settings…"
+exists=$(named_window_exists "RedditReminder Preferences")
+assert_true "First Preferences window opens" "$exists"
+
+# Open again — should reuse, not duplicate
+click_menu_item "RedditReminder" "Settings…"
+count=$(count_named_windows "RedditReminder Preferences")
+assert_eq "Only one Preferences window (reuse)" "1" "$count"
+
+close_window "RedditReminder Preferences"
+
+# ─── 8. QA fixtures ───────────────────────────────────────────────
 
 echo ""
-bold "8. Expand + New Capture: Strip → Glance → Capture"
+bold "8. QA fixture data (--seed-qa)"
 echo ""
-click_strip
-assert_width   "Click strip → Glance"               "$W_GLANCE"
-click_new_capture
-assert_width   "New Capture → Capture"               "$W_CAPTURE"
+
+# Open popover and check for content
+press_status_item
+sleep "$ACTION_WAIT"
+
+# The popover content isn't accessible via System Events, but we can
+# verify the capture window shows data by opening a capture for edit.
+# For now, verify the popover opens (implies data loaded and view rendered).
+vis=$(popover_visible)
+assert_true "Popover renders with seeded data" "$vis"
+
+# Close popover
+press_status_item
+
+# ─── 9. Restart persistence ───────────────────────────────────────
 
 echo ""
-bold "9. Full step-down: Capture → Browse → Glance → Strip"
+bold "9. Restart persistence"
 echo ""
-click_back_chevron
-assert_width   "Back chevron → Browse"               "$W_BROWSE"
-click_back_chevron
-assert_width   "Back chevron → Glance"               "$W_GLANCE"
-click_back_chevron
-assert_width   "Back chevron → Strip"                "$W_STRIP"
-
-echo ""
-bold "10. Settings: gear icon"
-echo ""
-# Strip has no header — expand to Glance first so gear icon is visible
-click_strip
-assert_width   "Strip → Glance (header visible)"   "$W_GLANCE"
-# Click gear icon — positioned left side of header
-click_at_rel "winX + 20" "winY + 20"
-assert_width   "Gear icon → Settings"              "$W_SETTINGS"
-
-echo ""
-bold "11. Settings: back → previous state"
-echo ""
-click_back_chevron
-assert_width   "Back from Settings → Glance"        "$W_GLANCE"
-
-echo ""
-bold "12. Restart persistence"
-echo ""
-click_back_chevron  # Glance → Strip
-assert_width   "Pre-restart: Strip"                  "$W_STRIP"
 
 pkill -x "$APP_NAME" 2>/dev/null || true
 sleep 2
 open "$APP_PATH"
-sleep "$LAUNCH_WAIT"
+sleep $((LAUNCH_WAIT + 2))  # extra time for cold start
 
 assert_running "App restarts after kill"
-assert_width   "Restart in Strip mode (persisted)"   "$W_STRIP"
 
-# Restore to Glance for clean state
-click_strip
-assert_width   "Back to Glance"                      "$W_GLANCE"
+# Verify popover still works after restart
+press_status_item
+vis=$(popover_visible)
+assert_true "Popover opens after restart" "$vis"
+
+# Verify menu shortcuts still work after restart
+click_menu_item "File" "New Capture"
+exists=$(named_window_exists "New Capture")
+assert_true "New Capture works after restart" "$exists"
+close_window "New Capture"
+
+# Close popover
+press_status_item
 
 # ─── summary ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Bug fix**: ⌘N (New Capture) and ⌘, (Preferences) menu shortcuts were silently broken — `MenuBarController` isn't in the responder chain, so nil-target menu items never dispatched. Fixed by setting explicit `target: self`.
- **QA rewrite**: Replaced stale sidebar width-transition tests with 20 tests for the current menu bar popover architecture using CGWindowList + AXPress.
- **Build fix**: `make qa` now builds Debug so `--seed-qa` flag is compiled in (was gated behind `#if DEBUG` but built as Release).
- **4 new unit tests**: callback dispatch and nil-callback safety for `handleNewCapture`/`handleOpenPreferences`.

## Test plan
- [x] 154 unit tests pass (`make test`)
- [x] 20 QA automation tests pass (`make qa`)
- [ ] CI passes (build, lint, unit tests, file size check)