### PR TITLE
Add custom shortcut recorder

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */; };
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
 		1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */; };
+		130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */; };
 		14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
 		1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */; };
@@ -56,6 +57,7 @@
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
+		F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */; };
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
 		F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */; };
 		FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
@@ -111,6 +113,7 @@
 		8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
 		88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		975C23592B958F445105973E /* CaptureWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureWindowView.swift; sourceTree = "<group>"; };
 		9FA306067C4690F4D1CDAC2D /* Subreddit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subreddit.swift; sourceTree = "<group>"; };
 		9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
@@ -122,6 +125,7 @@
 		B338E8D9C979B250564A392E /* QAFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAFixtures.swift; sourceTree = "<group>"; };
 		B58A523CACB82BF88E46FD3E /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		B727389070814347602E1AB3 /* TimingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineTests.swift; sourceTree = "<group>"; };
+		BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentEmptyStates.swift; sourceTree = "<group>"; };
 		BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRUDTests.swift; sourceTree = "<group>"; };
 		C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentActions.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
@@ -248,10 +252,12 @@
 				CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */,
 				4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */,
 				C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */,
+				BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */,
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
 				1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */,
 				28906380DECDA56AD0DDE325 /* PreferencesView.swift */,
 				1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */,
+				90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */,
 				5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */,
 			);
 			path = Views;
@@ -396,6 +402,7 @@
 				5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */,
 				C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */,
 				A45C2634E04FC8E88CD17018 /* PopoverContentActions.swift in Sources */,
+				F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
 				3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
@@ -404,6 +411,7 @@
 				17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */,
 				FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */,
 				1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */,
+				130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */,
 				35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */,
 				19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */,
 				4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */,

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -32,8 +32,11 @@ enum SettingsKey {
   static let defaultProjectId = "defaultProjectId"
   static let defaultLeadTimeMinutes = "defaultLeadTimeMinutes"
   static let notificationsEnabled = "notificationsEnabled"
-  static let nudgeWhenEmpty = "nudgeWhenEmpty"
-  static let globalShortcutIdentifier = "globalShortcutIdentifier"
+    static let nudgeWhenEmpty = "nudgeWhenEmpty"
+    static let globalShortcutIdentifier = "globalShortcutIdentifier"
+    static let globalShortcutKeyCode = "globalShortcutKeyCode"
+    static let globalShortcutModifiers = "globalShortcutModifiers"
+    static let globalShortcutDisplay = "globalShortcutDisplay"
 }
 
 enum SettingsOptions {

--- a/Sources/Utilities/KeyboardShortcuts.swift
+++ b/Sources/Utilities/KeyboardShortcuts.swift
@@ -4,13 +4,15 @@ import Carbon.HIToolbox
 import os
 
 struct KeyboardShortcutConfig: Equatable, Sendable {
+  static let customIdentifier = "custom"
+
   let identifier: String
   let keyCode: Int64
   let modifiers: CGEventFlags
   let display: String
 
   var isValid: Bool {
-    keyCode >= 0 && Self.validModifierMasks.contains { modifiers.contains($0) }
+    keyCode >= 0 && Self.requiredModifierMasks.contains { modifiers.contains($0) }
   }
 
   static let defaultShortcut = KeyboardShortcutConfig(
@@ -45,14 +47,66 @@ struct KeyboardShortcutConfig: Equatable, Sendable {
   static func load(from defaults: UserDefaults = .standard) -> KeyboardShortcutConfig {
     let identifier = defaults.string(forKey: SettingsKey.globalShortcutIdentifier)
       ?? defaultShortcut.identifier
+    if identifier == customIdentifier,
+       defaults.object(forKey: SettingsKey.globalShortcutKeyCode) != nil,
+       defaults.object(forKey: SettingsKey.globalShortcutModifiers) != nil {
+      let config = KeyboardShortcutConfig(
+        identifier: customIdentifier,
+        keyCode: Int64(defaults.integer(forKey: SettingsKey.globalShortcutKeyCode)),
+        modifiers: CGEventFlags(rawValue: UInt64(defaults.integer(forKey: SettingsKey.globalShortcutModifiers))),
+        display: defaults.string(forKey: SettingsKey.globalShortcutDisplay) ?? "Custom"
+      )
+      return config.isValid ? config : defaultShortcut
+    }
     return presets.first { $0.identifier == identifier && $0.isValid } ?? defaultShortcut
   }
 
   static func save(_ config: KeyboardShortcutConfig, to defaults: UserDefaults = .standard) {
+    if config.identifier == customIdentifier {
+      defaults.set(Int(config.keyCode), forKey: SettingsKey.globalShortcutKeyCode)
+      defaults.set(Int(config.modifiers.rawValue), forKey: SettingsKey.globalShortcutModifiers)
+      defaults.set(config.display, forKey: SettingsKey.globalShortcutDisplay)
+    }
     defaults.set(config.identifier, forKey: SettingsKey.globalShortcutIdentifier)
   }
 
-  private static let validModifierMasks: [CGEventFlags] = [
+  static func custom(keyCode: Int64, modifiers: CGEventFlags, keyDisplay: String) -> KeyboardShortcutConfig {
+    KeyboardShortcutConfig(
+      identifier: customIdentifier,
+      keyCode: keyCode,
+      modifiers: normalized(modifiers),
+      display: display(modifiers: modifiers, key: keyDisplay)
+    )
+  }
+
+  static func display(modifiers: CGEventFlags, key: String) -> String {
+    "\(modifierDisplay(for: normalized(modifiers)))\(key)"
+  }
+
+  private static func normalized(_ modifiers: CGEventFlags) -> CGEventFlags {
+    var normalized: CGEventFlags = []
+    for mask in allModifierMasks where modifiers.contains(mask) {
+      normalized.insert(mask)
+    }
+    return normalized
+  }
+
+  private static func modifierDisplay(for modifiers: CGEventFlags) -> String {
+    var parts: [String] = []
+    if modifiers.contains(.maskControl) { parts.append("⌃") }
+    if modifiers.contains(.maskAlternate) { parts.append("⌥") }
+    if modifiers.contains(.maskShift) { parts.append("⇧") }
+    if modifiers.contains(.maskCommand) { parts.append("⌘") }
+    return parts.joined()
+  }
+
+  private static let requiredModifierMasks: [CGEventFlags] = [
+    .maskCommand,
+    .maskControl,
+    .maskAlternate
+  ]
+
+  private static let allModifierMasks: [CGEventFlags] = [
     .maskCommand,
     .maskControl,
     .maskAlternate,

--- a/Sources/Utilities/QAFixtures.swift
+++ b/Sources/Utilities/QAFixtures.swift
@@ -127,7 +127,8 @@ enum QAFixtures {
     let farOut = SubredditEvent(
       name: "macOS Weekly",
       subreddit: macOS,
-      oneOffDate: Calendar.current.date(byAdding: .day, value: 7, to: Date())  // +7d → none (no dot)
+      // +7d -> none (no dot)
+      oneOffDate: Calendar.current.date(byAdding: .day, value: 7, to: Date())
     )
     context.insert(farOut)
 

--- a/Sources/Views/GeneralTabView.swift
+++ b/Sources/Views/GeneralTabView.swift
@@ -4,25 +4,14 @@ import SwiftData
 struct GeneralTabView: View {
     @AppStorage(SettingsKey.defaultLeadTimeMinutes) private var defaultLeadTimeMinutes: Int = 60
     @AppStorage(SettingsKey.defaultProjectId) private var defaultProjectId: String = ""
-    @AppStorage(SettingsKey.globalShortcutIdentifier) private var globalShortcutIdentifier: String =
-        KeyboardShortcutConfig.defaultShortcut.identifier
+    @State private var shortcutConfig = KeyboardShortcutConfig.load()
 
     @Query(sort: \Project.name) private var projects: [Project]
 
     var body: some View {
         Form {
             Section("Keyboard Shortcut") {
-                Picker("Toggle popover", selection: $globalShortcutIdentifier) {
-                    ForEach(KeyboardShortcutConfig.presets, id: \.identifier) { shortcut in
-                        Text(shortcut.display).tag(shortcut.identifier)
-                    }
-                }
-                .font(.system(size: 12))
-
-                Button("Reset to Default") {
-                    globalShortcutIdentifier = KeyboardShortcutConfig.defaultShortcut.identifier
-                }
-                .font(.system(size: 11))
+                ShortcutRecorderView(config: $shortcutConfig)
             }
 
             Section("Defaults") {
@@ -55,6 +44,12 @@ struct GeneralTabView: View {
         }
         .formStyle(.grouped)
         .padding(8)
+        .onAppear {
+            shortcutConfig = KeyboardShortcutConfig.load()
+        }
+        .onChange(of: shortcutConfig) { _, newValue in
+            KeyboardShortcutConfig.save(newValue)
+        }
     }
 
     private static func leadTimeLabel(_ minutes: Int) -> String {

--- a/Sources/Views/PopoverContentEmptyStates.swift
+++ b/Sources/Views/PopoverContentEmptyStates.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+extension PopoverContentView {
+  var emptyState: some View {
+    OnboardingEmptyView(onNewCapture: openNewCapture)
+  }
+
+  var filteredEmptyState: some View {
+    VStack(spacing: 10) {
+      Spacer()
+      Image(systemName: "tray")
+        .font(.system(size: 20))
+        .foregroundStyle(.tertiary)
+      Text("No captures for this subreddit")
+        .font(.system(size: 12))
+        .foregroundStyle(.secondary)
+      Button("+ New Capture", action: openNewCapture)
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(AppColors.redditOrange)
+        .buttonStyle(.plain)
+      Spacer()
+    }.frame(maxWidth: .infinity)
+  }
+}

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -268,26 +268,5 @@ struct PopoverContentView: View {
         }
     }
 
-    private var emptyState: some View {
-        OnboardingEmptyView(onNewCapture: openNewCapture)
-    }
-
-    private var filteredEmptyState: some View {
-        VStack(spacing: 10) {
-            Spacer()
-            Image(systemName: "tray")
-                .font(.system(size: 20))
-                .foregroundStyle(.tertiary)
-            Text("No captures for this subreddit")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-            Button("+ New Capture", action: openNewCapture)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(AppColors.redditOrange)
-                .buttonStyle(.plain)
-            Spacer()
-        }.frame(maxWidth: .infinity)
-    }
-
     // Actions live in PopoverContentActions.swift.
 }

--- a/Sources/Views/ShortcutRecorderView.swift
+++ b/Sources/Views/ShortcutRecorderView.swift
@@ -1,0 +1,156 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+struct ShortcutRecorderView: View {
+  @Binding var config: KeyboardShortcutConfig
+
+  @State private var isRecording = false
+  @State private var validationMessage: String?
+
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 6) {
+      HStack {
+        Text("Toggle popover")
+          .font(.system(size: 12))
+        Spacer()
+        Button(isRecording ? "Press shortcut" : config.display) {
+          validationMessage = nil
+          isRecording.toggle()
+        }
+        .font(.system(size: 12))
+        .monospacedDigit()
+        .frame(minWidth: 116)
+
+        Button("Reset") {
+          validationMessage = nil
+          isRecording = false
+          config = .defaultShortcut
+        }
+        .font(.system(size: 11))
+      }
+
+      if let validationMessage {
+        Text(validationMessage)
+          .font(.system(size: 11))
+          .foregroundStyle(.secondary)
+      }
+    }
+    .background {
+      if isRecording {
+        ShortcutKeyCaptureView { event in
+          record(event)
+        }
+        .frame(width: 0, height: 0)
+      }
+    }
+  }
+
+  private func record(_ event: NSEvent) {
+    guard event.keyCode != UInt16(kVK_Escape) else {
+      isRecording = false
+      validationMessage = nil
+      return
+    }
+
+    let keyDisplay = Self.keyDisplay(for: event)
+    let next = KeyboardShortcutConfig.custom(
+      keyCode: Int64(event.keyCode),
+      modifiers: event.modifierFlags.cgEventFlags,
+      keyDisplay: keyDisplay
+    )
+
+    guard next.isValid else {
+      validationMessage = "Use Command, Control, or Option with a key."
+      return
+    }
+
+    config = next
+    validationMessage = nil
+    isRecording = false
+  }
+
+  private static func keyDisplay(for event: NSEvent) -> String {
+    if let special = specialKeyDisplay[event.keyCode] {
+      return special
+    }
+
+    let characters = event.charactersIgnoringModifiers?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .uppercased()
+    return characters?.isEmpty == false ? characters! : "Key \(event.keyCode)"
+  }
+
+  private static let specialKeyDisplay: [UInt16: String] = [
+    UInt16(kVK_Space): "Space",
+    UInt16(kVK_Return): "Return",
+    UInt16(kVK_Tab): "Tab",
+    UInt16(kVK_Delete): "Delete",
+    UInt16(kVK_ForwardDelete): "Forward Delete",
+    UInt16(kVK_Escape): "Escape",
+    UInt16(kVK_LeftArrow): "←",
+    UInt16(kVK_RightArrow): "→",
+    UInt16(kVK_UpArrow): "↑",
+    UInt16(kVK_DownArrow): "↓",
+    UInt16(kVK_F1): "F1",
+    UInt16(kVK_F2): "F2",
+    UInt16(kVK_F3): "F3",
+    UInt16(kVK_F4): "F4",
+    UInt16(kVK_F5): "F5",
+    UInt16(kVK_F6): "F6",
+    UInt16(kVK_F7): "F7",
+    UInt16(kVK_F8): "F8",
+    UInt16(kVK_F9): "F9",
+    UInt16(kVK_F10): "F10",
+    UInt16(kVK_F11): "F11",
+    UInt16(kVK_F12): "F12",
+  ]
+}
+
+private struct ShortcutKeyCaptureView: NSViewRepresentable {
+  let onKeyDown: (NSEvent) -> Void
+
+  func makeNSView(context: Context) -> KeyCaptureNSView {
+    KeyCaptureNSView(onKeyDown: onKeyDown)
+  }
+
+  func updateNSView(_ nsView: KeyCaptureNSView, context: Context) {
+    nsView.onKeyDown = onKeyDown
+    nsView.window?.makeFirstResponder(nsView)
+  }
+
+  final class KeyCaptureNSView: NSView {
+    var onKeyDown: (NSEvent) -> Void
+
+    init(onKeyDown: @escaping (NSEvent) -> Void) {
+      self.onKeyDown = onKeyDown
+      super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+      nil
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      window?.makeFirstResponder(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+      onKeyDown(event)
+    }
+  }
+}
+
+extension NSEvent.ModifierFlags {
+  fileprivate var cgEventFlags: CGEventFlags {
+    var flags: CGEventFlags = []
+    if contains(.command) { flags.insert(.maskCommand) }
+    if contains(.control) { flags.insert(.maskControl) }
+    if contains(.option) { flags.insert(.maskAlternate) }
+    if contains(.shift) { flags.insert(.maskShift) }
+    return flags
+  }
+}

--- a/Tests/RedditReminderTests/MenuBarControllerTests.swift
+++ b/Tests/RedditReminderTests/MenuBarControllerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import AppKit
 @testable import RedditReminder
 
 @Suite(.serialized)
@@ -31,6 +32,43 @@ struct MenuBarControllerTests {
 
         #expect(KeyboardShortcutConfig.load(from: defaults) == .defaultShortcut)
         defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test func shortcutPersistsCustomConfig() {
+        let suiteName = "ShortcutTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let shortcut = KeyboardShortcutConfig.custom(
+            keyCode: 35,
+            modifiers: [.maskCommand, .maskAlternate],
+            keyDisplay: "P"
+        )
+
+        KeyboardShortcutConfig.save(shortcut, to: defaults)
+
+        #expect(KeyboardShortcutConfig.load(from: defaults) == shortcut)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test func shortcutInvalidCustomConfigFallsBackToDefault() {
+        let suiteName = "ShortcutTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(KeyboardShortcutConfig.customIdentifier, forKey: SettingsKey.globalShortcutIdentifier)
+        defaults.set(35, forKey: SettingsKey.globalShortcutKeyCode)
+        defaults.set(Int(CGEventFlags.maskShift.rawValue), forKey: SettingsKey.globalShortcutModifiers)
+        defaults.set("⇧P", forKey: SettingsKey.globalShortcutDisplay)
+
+        #expect(KeyboardShortcutConfig.load(from: defaults) == .defaultShortcut)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test func shortcutCustomDisplayOrdersModifiersConsistently() {
+        let shortcut = KeyboardShortcutConfig.custom(
+            keyCode: 35,
+            modifiers: [.maskCommand, .maskShift, .maskAlternate],
+            keyDisplay: "P"
+        )
+
+        #expect(shortcut.display == "⌥⇧⌘P")
     }
 
     @Test func shortcutPresetsAreValid() {


### PR DESCRIPTION
## Summary
- replace the preset-only shortcut picker with a recorder control in General settings
- persist custom shortcut key code, modifiers, and display label
- add tests for custom shortcut save/load, invalid fallback, and display ordering
- keep popover source under the file-size gate by moving empty states into a small extension

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME ": ": NR ": lines" }' {} \;