### PR TITLE
Add backup import and export

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0212354E124DB25DE1283B6C /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */; };
 		041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */; };
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
+		0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E228CA7B8C32C3669A85 /* BackupMappers.swift */; };
 		1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */; };
 		130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */; };
 		14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */; };
@@ -21,6 +22,7 @@
 		1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */; };
 		2214090DA72A5B5AF58F6658 /* SubredditPeakTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */; };
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
+		26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
 		3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */; };
@@ -39,12 +41,14 @@
 		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
+		6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */; };
 		70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */; };
 		73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */; };
 		7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */; };
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
 		8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB005E503FDAD90271DB0AE /* EventBannerView.swift */; };
 		9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */; };
+		9B6DE864F7F9D78BE7B6CA54 /* BackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6975993534B39BF8DEB32E /* BackupService.swift */; };
 		A45C2634E04FC8E88CD17018 /* PopoverContentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */; };
 		AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */; };
 		B104E0E65566B8E4EFDFE190 /* EdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */; };
@@ -84,6 +88,7 @@
 		18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureFormResult.swift; sourceTree = "<group>"; };
 		1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostedListView.swift; sourceTree = "<group>"; };
 		1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsTabView.swift; sourceTree = "<group>"; };
+		1F6975993534B39BF8DEB32E /* BackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupService.swift; sourceTree = "<group>"; };
 		20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
 		274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsTimezoneTests.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
@@ -115,6 +120,7 @@
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		975C23592B958F445105973E /* CaptureWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureWindowView.swift; sourceTree = "<group>"; };
+		9884E228CA7B8C32C3669A85 /* BackupMappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMappers.swift; sourceTree = "<group>"; };
 		9FA306067C4690F4D1CDAC2D /* Subreddit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subreddit.swift; sourceTree = "<group>"; };
 		9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureCardView.swift; sourceTree = "<group>"; };
@@ -127,9 +133,11 @@
 		B727389070814347602E1AB3 /* TimingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineTests.swift; sourceTree = "<group>"; };
 		BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentEmptyStates.swift; sourceTree = "<group>"; };
 		BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRUDTests.swift; sourceTree = "<group>"; };
+		BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSectionView.swift; sourceTree = "<group>"; };
 		C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentActions.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
 		E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarControllerTests.swift; sourceTree = "<group>"; };
+		EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceTests.swift; sourceTree = "<group>"; };
 		F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTests.swift; sourceTree = "<group>"; };
 		FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpersTests.swift; sourceTree = "<group>"; };
 		FB0A7A7AAA2C09449780FF4F /* LinkChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkChipView.swift; sourceTree = "<group>"; };
@@ -153,6 +161,7 @@
 			isa = PBXGroup;
 			children = (
 				4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */,
+				EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */,
 				FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */,
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
 				BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */,
@@ -217,6 +226,8 @@
 		CA0B3150AF380004775B2CAF /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				9884E228CA7B8C32C3669A85 /* BackupMappers.swift */,
+				1F6975993534B39BF8DEB32E /* BackupService.swift */,
 				6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */,
 				AE1122ADEB6045619C303C31 /* MediaStore.swift */,
 				B58A523CACB82BF88E46FD3E /* MenuBarController.swift */,
@@ -238,6 +249,7 @@
 		EE2AEE0CFEFFFEF4F88FBA15 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */,
 				A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */,
 				4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */,
 				6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */,
@@ -355,6 +367,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */,
+				6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */,
 				FFBC4E3EB895C7668654877B /* CRUDTests.swift in Sources */,
 				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
 				1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */,
@@ -378,6 +391,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */,
+				0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */,
+				26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */,
+				9B6DE864F7F9D78BE7B6CA54 /* BackupService.swift in Sources */,
 				F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */,
 				1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */,
 				6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */,

--- a/Sources/Services/BackupMappers.swift
+++ b/Sources/Services/BackupMappers.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+extension BackupProject {
+    init(project: Project) {
+        self.init(
+            id: project.id,
+            name: project.name,
+            projectDescription: project.projectDescription,
+            color: project.color,
+            archived: project.archived,
+            createdAt: project.createdAt
+        )
+    }
+}
+
+extension BackupSubreddit {
+    init(subreddit: Subreddit) {
+        self.init(
+            id: subreddit.id,
+            name: subreddit.name,
+            sortOrder: subreddit.sortOrder,
+            peakDaysOverride: subreddit.peakDaysOverride,
+            peakHoursUtcOverride: subreddit.peakHoursUtcOverride
+        )
+    }
+}
+
+extension BackupSubredditEvent {
+    init(event: SubredditEvent) {
+        self.init(
+            id: event.id,
+            name: event.name,
+            subredditId: event.subreddit?.id,
+            rrule: event.rrule,
+            oneOffDate: event.oneOffDate,
+            recurrenceHour: event.recurrenceHour,
+            recurrenceMinute: event.recurrenceMinute,
+            recurrenceTimeZoneIdentifier: event.recurrenceTimeZoneIdentifier,
+            reminderLeadMinutes: event.reminderLeadMinutes,
+            isActive: event.isActive,
+            isGeneratedFromHeuristics: event.isGeneratedFromHeuristics,
+            generationKey: event.generationKey
+        )
+    }
+}
+
+extension BackupCapture {
+    init(capture: Capture) {
+        self.init(
+            id: capture.id,
+            text: capture.text,
+            notes: capture.notes,
+            links: capture.links,
+            mediaRefs: capture.mediaRefs,
+            status: capture.status,
+            createdAt: capture.createdAt,
+            postedAt: capture.postedAt,
+            projectId: capture.project?.id,
+            subredditIds: capture.subreddits.map(\.id)
+        )
+    }
+}

--- a/Sources/Services/BackupService.swift
+++ b/Sources/Services/BackupService.swift
@@ -1,0 +1,261 @@
+import Foundation
+import SwiftData
+
+enum BackupError: Error, Equatable, LocalizedError {
+    case unsupportedVersion(Int)
+    case missingRelationship(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedVersion(let version):
+            return "Unsupported backup version \(version)."
+        case .missingRelationship(let id):
+            return "Backup references missing item \(id)."
+        }
+    }
+}
+
+struct AppBackup: Codable, Equatable {
+    var version: Int = 1
+    var exportedAt: Date = Date()
+    var settings: BackupSettings
+    var projects: [BackupProject]
+    var subreddits: [BackupSubreddit]
+    var events: [BackupSubredditEvent]
+    var captures: [BackupCapture]
+}
+
+struct BackupSettings: Codable, Equatable {
+    var defaultProjectId: String?
+    var defaultLeadTimeMinutes: Int?
+    var notificationsEnabled: Bool?
+    var nudgeWhenEmpty: Bool?
+    var globalShortcutIdentifier: String?
+    var globalShortcutKeyCode: Int?
+    var globalShortcutModifiers: Int?
+    var globalShortcutDisplay: String?
+
+    init(
+        defaultProjectId: String? = nil,
+        defaultLeadTimeMinutes: Int? = nil,
+        notificationsEnabled: Bool? = nil,
+        nudgeWhenEmpty: Bool? = nil,
+        globalShortcutIdentifier: String? = nil,
+        globalShortcutKeyCode: Int? = nil,
+        globalShortcutModifiers: Int? = nil,
+        globalShortcutDisplay: String? = nil
+    ) {
+        self.defaultProjectId = defaultProjectId
+        self.defaultLeadTimeMinutes = defaultLeadTimeMinutes
+        self.notificationsEnabled = notificationsEnabled
+        self.nudgeWhenEmpty = nudgeWhenEmpty
+        self.globalShortcutIdentifier = globalShortcutIdentifier
+        self.globalShortcutKeyCode = globalShortcutKeyCode
+        self.globalShortcutModifiers = globalShortcutModifiers
+        self.globalShortcutDisplay = globalShortcutDisplay
+    }
+}
+
+struct BackupProject: Codable, Equatable {
+    var id: UUID
+    var name: String
+    var projectDescription: String?
+    var color: String?
+    var archived: Bool
+    var createdAt: Date
+}
+
+struct BackupSubreddit: Codable, Equatable {
+    var id: UUID
+    var name: String
+    var sortOrder: Int
+    var peakDaysOverride: [String]?
+    var peakHoursUtcOverride: [Int]?
+}
+
+struct BackupSubredditEvent: Codable, Equatable {
+    var id: UUID
+    var name: String
+    var subredditId: UUID?
+    var rrule: String?
+    var oneOffDate: Date?
+    var recurrenceHour: Int?
+    var recurrenceMinute: Int?
+    var recurrenceTimeZoneIdentifier: String?
+    var reminderLeadMinutes: Int
+    var isActive: Bool
+    var isGeneratedFromHeuristics: Bool
+    var generationKey: String?
+}
+
+struct BackupCapture: Codable, Equatable {
+    var id: UUID
+    var text: String
+    var notes: String?
+    var links: [String]
+    var mediaRefs: [String]
+    var status: CaptureStatus
+    var createdAt: Date
+    var postedAt: Date?
+    var projectId: UUID?
+    var subredditIds: [UUID]
+}
+
+@MainActor
+struct BackupService {
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        decoder = JSONDecoder()
+    }
+
+    func exportBackup(from context: ModelContext, defaults: UserDefaults = .standard) throws -> Data {
+        let backup = AppBackup(
+            settings: BackupSettings(
+                defaultProjectId: defaults.string(forKey: SettingsKey.defaultProjectId),
+                defaultLeadTimeMinutes: defaults.object(forKey: SettingsKey.defaultLeadTimeMinutes) as? Int,
+                notificationsEnabled: defaults.object(forKey: SettingsKey.notificationsEnabled) as? Bool,
+                nudgeWhenEmpty: defaults.object(forKey: SettingsKey.nudgeWhenEmpty) as? Bool,
+                globalShortcutIdentifier: defaults.string(forKey: SettingsKey.globalShortcutIdentifier),
+                globalShortcutKeyCode: defaults.object(forKey: SettingsKey.globalShortcutKeyCode) as? Int,
+                globalShortcutModifiers: defaults.object(forKey: SettingsKey.globalShortcutModifiers) as? Int,
+                globalShortcutDisplay: defaults.string(forKey: SettingsKey.globalShortcutDisplay)
+            ),
+            projects: try context.fetch(FetchDescriptor<Project>()).map { BackupProject(project: $0) },
+            subreddits: try context.fetch(FetchDescriptor<Subreddit>()).map { BackupSubreddit(subreddit: $0) },
+            events: try context.fetch(FetchDescriptor<SubredditEvent>()).map { BackupSubredditEvent(event: $0) },
+            captures: try context.fetch(FetchDescriptor<Capture>()).map { BackupCapture(capture: $0) }
+        )
+        return try encoder.encode(backup)
+    }
+
+    func importBackup(
+        from data: Data,
+        into context: ModelContext,
+        defaults: UserDefaults = .standard
+    ) throws {
+        let backup = try decoder.decode(AppBackup.self, from: data)
+        guard backup.version == 1 else { throw BackupError.unsupportedVersion(backup.version) }
+        try validate(backup)
+
+        try clearData(in: context)
+
+        var projectsById: [UUID: Project] = [:]
+        var subredditsById: [UUID: Subreddit] = [:]
+
+        for item in backup.projects {
+            let project = Project(name: item.name, projectDescription: item.projectDescription, color: item.color)
+            project.id = item.id
+            project.archived = item.archived
+            project.createdAt = item.createdAt
+            context.insert(project)
+            projectsById[item.id] = project
+        }
+
+        for item in backup.subreddits {
+            let subreddit = Subreddit(
+                name: item.name,
+                sortOrder: item.sortOrder,
+                peakDaysOverride: item.peakDaysOverride,
+                peakHoursUtcOverride: item.peakHoursUtcOverride
+            )
+            subreddit.id = item.id
+            context.insert(subreddit)
+            subredditsById[item.id] = subreddit
+        }
+
+        for item in backup.events {
+            guard let subredditId = item.subredditId, let subreddit = subredditsById[subredditId] else {
+                throw BackupError.missingRelationship(item.subredditId?.uuidString ?? item.id.uuidString)
+            }
+            let event = SubredditEvent(
+                name: item.name,
+                subreddit: subreddit,
+                rrule: item.rrule,
+                oneOffDate: item.oneOffDate,
+                recurrenceHour: item.recurrenceHour,
+                recurrenceMinute: item.recurrenceMinute,
+                recurrenceTimeZoneIdentifier: item.recurrenceTimeZoneIdentifier,
+                reminderLeadMinutes: item.reminderLeadMinutes,
+                isActive: item.isActive,
+                isGeneratedFromHeuristics: item.isGeneratedFromHeuristics,
+                generationKey: item.generationKey
+            )
+            event.id = item.id
+            context.insert(event)
+        }
+
+        for item in backup.captures {
+            let subreddits = try item.subredditIds.map { id in
+                guard let subreddit = subredditsById[id] else {
+                    throw BackupError.missingRelationship(id.uuidString)
+                }
+                return subreddit
+            }
+            let capture = Capture(
+                text: item.text,
+                notes: item.notes,
+                links: item.links,
+                mediaRefs: item.mediaRefs,
+                project: item.projectId.flatMap { projectsById[$0] },
+                subreddits: subreddits
+            )
+            capture.id = item.id
+            capture.status = item.status
+            capture.createdAt = item.createdAt
+            capture.postedAt = item.postedAt
+            context.insert(capture)
+        }
+
+        applySettings(backup.settings, to: defaults)
+        try context.save()
+    }
+
+    private func clearData(in context: ModelContext) throws {
+        for capture in try context.fetch(FetchDescriptor<Capture>()) { context.delete(capture) }
+        for event in try context.fetch(FetchDescriptor<SubredditEvent>()) { context.delete(event) }
+        for project in try context.fetch(FetchDescriptor<Project>()) { context.delete(project) }
+        for subreddit in try context.fetch(FetchDescriptor<Subreddit>()) { context.delete(subreddit) }
+        try context.save()
+    }
+
+    private func validate(_ backup: AppBackup) throws {
+        let projectIds = Set(backup.projects.map(\.id))
+        let subredditIds = Set(backup.subreddits.map(\.id))
+        for event in backup.events {
+            guard let subredditId = event.subredditId, subredditIds.contains(subredditId) else {
+                throw BackupError.missingRelationship(event.subredditId?.uuidString ?? event.id.uuidString)
+            }
+        }
+        for capture in backup.captures {
+            if let projectId = capture.projectId, !projectIds.contains(projectId) {
+                throw BackupError.missingRelationship(projectId.uuidString)
+            }
+            for subredditId in capture.subredditIds where !subredditIds.contains(subredditId) {
+                throw BackupError.missingRelationship(subredditId.uuidString)
+            }
+        }
+    }
+
+    private func applySettings(_ settings: BackupSettings, to defaults: UserDefaults) {
+        set(settings.defaultProjectId, forKey: SettingsKey.defaultProjectId, defaults: defaults)
+        set(settings.defaultLeadTimeMinutes, forKey: SettingsKey.defaultLeadTimeMinutes, defaults: defaults)
+        set(settings.notificationsEnabled, forKey: SettingsKey.notificationsEnabled, defaults: defaults)
+        set(settings.nudgeWhenEmpty, forKey: SettingsKey.nudgeWhenEmpty, defaults: defaults)
+        set(settings.globalShortcutIdentifier, forKey: SettingsKey.globalShortcutIdentifier, defaults: defaults)
+        set(settings.globalShortcutKeyCode, forKey: SettingsKey.globalShortcutKeyCode, defaults: defaults)
+        set(settings.globalShortcutModifiers, forKey: SettingsKey.globalShortcutModifiers, defaults: defaults)
+        set(settings.globalShortcutDisplay, forKey: SettingsKey.globalShortcutDisplay, defaults: defaults)
+    }
+
+    private func set(_ value: Any?, forKey key: String, defaults: UserDefaults) {
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/Sources/Views/BackupSectionView.swift
+++ b/Sources/Views/BackupSectionView.swift
@@ -1,0 +1,115 @@
+import SwiftData
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct BackupSectionView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var exportDocument: BackupDocument?
+    @State private var isExporting = false
+    @State private var isImporting = false
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
+
+    private let backupService = BackupService()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Button("Export Backup") {
+                    exportBackup()
+                }
+                .font(.system(size: 11))
+
+                Button("Import Backup") {
+                    isImporting = true
+                }
+                .font(.system(size: 11))
+
+                Spacer()
+            }
+
+            if let statusMessage {
+                Text(statusMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+            }
+        }
+        .fileExporter(
+            isPresented: $isExporting,
+            document: exportDocument,
+            contentType: .json,
+            defaultFilename: "RedditReminder Backup"
+        ) { result in
+            handleExportResult(result)
+        }
+        .fileImporter(
+            isPresented: $isImporting,
+            allowedContentTypes: [.json],
+            allowsMultipleSelection: false
+        ) { result in
+            importBackup(result)
+        }
+    }
+
+    private func exportBackup() {
+        do {
+            let data = try backupService.exportBackup(from: modelContext)
+            exportDocument = BackupDocument(data: data)
+            isExporting = true
+            statusMessage = nil
+            errorMessage = nil
+        } catch {
+            errorMessage = "Export failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func importBackup(_ result: Result<[URL], Error>) {
+        do {
+            guard let url = try result.get().first else { return }
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer {
+                if didAccess { url.stopAccessingSecurityScopedResource() }
+            }
+            let data = try Data(contentsOf: url)
+            try backupService.importBackup(from: data, into: modelContext)
+            statusMessage = "Backup imported"
+            errorMessage = nil
+        } catch {
+            errorMessage = "Import failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func handleExportResult(_ result: Result<URL, Error>) {
+        switch result {
+        case .success:
+            statusMessage = "Backup exported"
+            errorMessage = nil
+        case .failure(let error):
+            errorMessage = "Export failed: \(error.localizedDescription)"
+        }
+    }
+}
+
+struct BackupDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+
+    var data: Data
+
+    init(data: Data = Data()) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/Sources/Views/GeneralTabView.swift
+++ b/Sources/Views/GeneralTabView.swift
@@ -41,6 +41,10 @@ struct GeneralTabView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+
+            Section("Backup") {
+                BackupSectionView()
+            }
         }
         .formStyle(.grouped)
         .padding(8)

--- a/Tests/RedditReminderTests/BackupServiceTests.swift
+++ b/Tests/RedditReminderTests/BackupServiceTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import RedditReminder
+
+private func makeBackupContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
+        configurations: config
+    )
+}
+
+@Test @MainActor func backupRoundTripsDataAndSettings() throws {
+    let sourceContainer = try makeBackupContainer()
+    let sourceContext = ModelContext(sourceContainer)
+    let suiteName = "BackupTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let project = Project(name: "Launch", projectDescription: "Release plan", color: "#FF4500")
+    project.archived = true
+    sourceContext.insert(project)
+
+    let subreddit = Subreddit(
+        name: "r/SwiftUI",
+        sortOrder: 4,
+        peakDaysOverride: ["mon", "fri"],
+        peakHoursUtcOverride: [15, 18]
+    )
+    sourceContext.insert(subreddit)
+
+    let event = SubredditEvent(
+        name: "Weekly thread",
+        subreddit: subreddit,
+        rrule: "FREQ=WEEKLY;BYDAY=MO",
+        recurrenceHour: 15,
+        recurrenceMinute: 30,
+        recurrenceTimeZoneIdentifier: "America/Phoenix",
+        reminderLeadMinutes: 30,
+        isGeneratedFromHeuristics: true,
+        generationKey: "r/SwiftUI:mon:15"
+    )
+    sourceContext.insert(event)
+
+    let capture = Capture(
+        text: "Post draft",
+        notes: "Tighten title",
+        links: ["https://example.com"],
+        mediaRefs: ["image.png"],
+        project: project,
+        subreddits: [subreddit]
+    )
+    capture.markAsPosted()
+    sourceContext.insert(capture)
+    try sourceContext.save()
+
+    defaults.set(project.id.uuidString, forKey: SettingsKey.defaultProjectId)
+    defaults.set(30, forKey: SettingsKey.defaultLeadTimeMinutes)
+    defaults.set(false, forKey: SettingsKey.notificationsEnabled)
+    defaults.set(KeyboardShortcutConfig.customIdentifier, forKey: SettingsKey.globalShortcutIdentifier)
+    defaults.set(35, forKey: SettingsKey.globalShortcutKeyCode)
+
+    let service = BackupService()
+    let data = try service.exportBackup(from: sourceContext, defaults: defaults)
+
+    let destinationContainer = try makeBackupContainer()
+    let destinationContext = ModelContext(destinationContainer)
+    let old = Subreddit(name: "r/Old")
+    destinationContext.insert(old)
+    try destinationContext.save()
+
+    try service.importBackup(from: data, into: destinationContext, defaults: defaults)
+
+    let projects = try destinationContext.fetch(FetchDescriptor<Project>())
+    let subreddits = try destinationContext.fetch(FetchDescriptor<Subreddit>())
+    let events = try destinationContext.fetch(FetchDescriptor<SubredditEvent>())
+    let captures = try destinationContext.fetch(FetchDescriptor<Capture>())
+
+    #expect(projects.count == 1)
+    #expect(projects[0].id == project.id)
+    #expect(projects[0].archived)
+    #expect(subreddits.count == 1)
+    #expect(subreddits[0].peakHoursUtcOverride == [15, 18])
+    #expect(events.count == 1)
+    #expect(events[0].subreddit?.id == subreddit.id)
+    #expect(events[0].isGeneratedFromHeuristics)
+    #expect(captures.count == 1)
+    #expect(captures[0].project?.id == project.id)
+    #expect(captures[0].subreddits.map(\.id) == [subreddit.id])
+    #expect(captures[0].status == .posted)
+    #expect(defaults.string(forKey: SettingsKey.defaultProjectId) == project.id.uuidString)
+    #expect(defaults.integer(forKey: SettingsKey.defaultLeadTimeMinutes) == 30)
+}
+
+@Test @MainActor func backupImportRejectsUnsupportedVersion() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let data = #"{"version":99,"exportedAt":0,"settings":{},"projects":[],"subreddits":[],"events":[],"captures":[]}"#
+        .data(using: .utf8)!
+
+    #expect(throws: BackupError.unsupportedVersion(99)) {
+        try BackupService().importBackup(from: data, into: context)
+    }
+}
+
+@Test @MainActor func backupImportRejectsMissingRelationships() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    context.insert(Subreddit(name: "r/Existing"))
+    try context.save()
+
+    let missing = UUID()
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [],
+        subreddits: [],
+        events: [
+            BackupSubredditEvent(
+                id: UUID(),
+                name: "Broken",
+                subredditId: missing,
+                rrule: nil,
+                oneOffDate: nil,
+                recurrenceHour: nil,
+                recurrenceMinute: nil,
+                recurrenceTimeZoneIdentifier: nil,
+                reminderLeadMinutes: 60,
+                isActive: true,
+                isGeneratedFromHeuristics: false,
+                generationKey: nil
+            )
+        ],
+        captures: []
+    )
+    let data = try JSONEncoder().encode(backup)
+
+    #expect(throws: BackupError.missingRelationship(missing.uuidString)) {
+        try BackupService().importBackup(from: data, into: context)
+    }
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 1)
+}


### PR DESCRIPTION
## Summary
- add JSON backup export for projects, subreddits, subreddit events, captures, and relevant settings
- add replace-style backup import with relationship validation before destructive changes
- add Backup controls to General preferences using macOS file import/export
- cover round-trip backup, unsupported versions, and missing relationship failures with tests

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME ": " NR " lines" }' {} \;
- swift-format lint --recursive Sources Tests