### PR TITLE
Show generated event sources

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
 		26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
+		39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */; };
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
 		3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */; };
 		3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0972EE8B384E16C0A49F8555 /* AppDelegate.swift */; };
@@ -54,6 +55,7 @@
 		B104E0E65566B8E4EFDFE190 /* EdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */; };
 		B3807D895E708C33AAA6D242 /* HeuristicsTimezoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */; };
 		B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28906380DECDA56AD0DDE325 /* PreferencesView.swift */; };
+		BA3B263D9D03FA844568F913 /* EventSourceSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */; };
 		C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */; };
 		CC6A10A2CEA907B520EEE2F3 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */; };
 		D61EED608BA7889DFA0AA4C2 /* TimingEngineIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */; };
@@ -95,6 +97,7 @@
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
+		409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummaryTests.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleEdgeCaseTests.swift; sourceTree = "<group>"; };
 		4CB005E503FDAD90271DB0AE /* EventBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBannerView.swift; sourceTree = "<group>"; };
@@ -117,6 +120,7 @@
 		83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineIntegrationTests.swift; sourceTree = "<group>"; };
 		8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
 		88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
+		8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummary.swift; sourceTree = "<group>"; };
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		975C23592B958F445105973E /* CaptureWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureWindowView.swift; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
 				BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */,
 				F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */,
+				409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */,
 				560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */,
 				274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */,
 				20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */,
@@ -187,6 +192,7 @@
 				8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */,
 				5DB4E56FCDA7A1CB1F24566D /* Constants.swift */,
 				4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */,
+				8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */,
 				56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */,
 				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
@@ -372,6 +378,7 @@
 				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
 				1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */,
 				B104E0E65566B8E4EFDFE190 /* EdgeCaseTests.swift in Sources */,
+				BA3B263D9D03FA844568F913 /* EventSourceSummaryTests.swift in Sources */,
 				5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */,
 				B3807D895E708C33AAA6D242 /* HeuristicsTimezoneTests.swift in Sources */,
 				70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */,
@@ -406,6 +413,7 @@
 				81C26D97123D840A9130AF7E /* Constants.swift in Sources */,
 				F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */,
 				8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */,
+				39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */,
 				0212354E124DB25DE1283B6C /* FlowLayout.swift in Sources */,
 				0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */,
 				EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */,

--- a/Sources/Utilities/EventSourceSummary.swift
+++ b/Sources/Utilities/EventSourceSummary.swift
@@ -1,0 +1,25 @@
+struct EventSourceSummary: Equatable {
+    let manualCount: Int
+    let generatedCount: Int
+
+    var hasEvents: Bool {
+        manualCount > 0 || generatedCount > 0
+    }
+
+    var compactLabel: String {
+        guard hasEvents else { return "no events" }
+        return [
+            manualCount > 0 ? "\(manualCount) manual" : nil,
+            generatedCount > 0 ? "\(generatedCount) auto" : nil,
+        ]
+        .compactMap { $0 }
+        .joined(separator: " · ")
+    }
+
+    static func active(events: [SubredditEvent]) -> EventSourceSummary {
+        EventSourceSummary(
+            manualCount: events.filter { $0.isActive && !$0.isGeneratedFromHeuristics }.count,
+            generatedCount: events.filter { $0.isActive && $0.isGeneratedFromHeuristics }.count
+        )
+    }
+}

--- a/Sources/Views/EventBannerView.swift
+++ b/Sources/Views/EventBannerView.swift
@@ -20,15 +20,9 @@ struct EventBannerView: View {
                             .tracking(0.5)
 
                         if let sub = next.event.subreddit {
-                            Text("\(sub.name) — \(next.event.name)")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.primary)
-                                .lineLimit(1)
+                            eventTitle("\(sub.name) — \(next.event.name)", event: next.event)
                         } else {
-                            Text(next.event.name)
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.primary)
-                                .lineLimit(1)
+                            eventTitle(next.event.name, event: next.event)
                         }
 
                         HStack(spacing: 4) {
@@ -77,5 +71,26 @@ struct EventBannerView: View {
 
     private func relativeTime(_ date: Date) -> String {
         Self.relativeDateFormatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func eventTitle(_ title: String, event: SubredditEvent) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+
+            Text(event.isGeneratedFromHeuristics ? "Auto" : "Manual")
+                .font(.system(size: 8, weight: .semibold))
+                .foregroundStyle(event.isGeneratedFromHeuristics ? AppColors.redditOrange : .secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(event.isGeneratedFromHeuristics ? AppColors.redditOrange.opacity(0.10) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(event.isGeneratedFromHeuristics ? AppColors.redditOrange : Color(NSColor.separatorColor), lineWidth: 0.5)
+                )
+        }
     }
 }

--- a/Sources/Views/SubredditRow.swift
+++ b/Sources/Views/SubredditRow.swift
@@ -27,9 +27,14 @@ struct SubredditRow: View {
                             .foregroundStyle(.red)
                             .buttonStyle(.plain)
                     } else {
-                        Text(peakDaysSummary)
-                            .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text(peakDaysSummary)
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                            Text(eventSourceSummary.compactLabel)
+                                .font(.system(size: 9))
+                                .foregroundStyle(eventSourceSummary.generatedCount > 0 ? AppColors.redditOrange : .secondary)
+                        }
                     }
                 }
             }
@@ -51,6 +56,12 @@ struct SubredditRow: View {
                         .foregroundStyle(.secondary)
                         .tracking(0.3)
                     peakHourChips
+
+                    Text("EVENT SOURCES")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .tracking(0.3)
+                    eventSourceChips
 
                     HStack {
                         Spacer()
@@ -136,6 +147,27 @@ struct SubredditRow: View {
         }
     }
 
+    private var eventSourceChips: some View {
+        HStack(spacing: 6) {
+            sourceChip(label: "Manual", count: eventSourceSummary.manualCount, color: .secondary)
+            sourceChip(label: "Auto", count: eventSourceSummary.generatedCount, color: AppColors.redditOrange)
+        }
+    }
+
+    private func sourceChip(label: String, count: Int, color: Color) -> some View {
+        Text("\(count) \(label.lowercased())")
+            .font(.system(size: 10, weight: .medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(count > 0 ? color.opacity(0.10) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(count > 0 ? color : Color(NSColor.separatorColor), lineWidth: 0.5)
+            )
+            .foregroundStyle(count > 0 ? color : .secondary)
+    }
+
     private func toggleHour(_ hour: Int) {
         var hours = sub.peakHoursUtcOverride ?? []
         if hours.contains(hour) {
@@ -168,6 +200,10 @@ struct SubredditRow: View {
 
     private var effectivePeakHours: [Int] {
         sub.peakHoursUtcOverride ?? peakInfo?.peakHoursUtc ?? []
+    }
+
+    private var eventSourceSummary: EventSourceSummary {
+        EventSourceSummary.active(events: sub.events)
     }
 }
 

--- a/Tests/RedditReminderTests/EventSourceSummaryTests.swift
+++ b/Tests/RedditReminderTests/EventSourceSummaryTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import RedditReminder
+
+@Test func eventSourceSummaryCountsOnlyActiveEvents() {
+    let subreddit = Subreddit(name: "r/Test")
+    let manual = SubredditEvent(name: "Manual", subreddit: subreddit)
+    let generated = SubredditEvent(
+        name: "Auto",
+        subreddit: subreddit,
+        isGeneratedFromHeuristics: true,
+        generationKey: "r/Test:mon:12"
+    )
+    let inactiveGenerated = SubredditEvent(
+        name: "Inactive",
+        subreddit: subreddit,
+        isActive: false,
+        isGeneratedFromHeuristics: true,
+        generationKey: "r/Test:tue:12"
+    )
+
+    let summary = EventSourceSummary.active(events: [manual, generated, inactiveGenerated])
+
+    #expect(summary.manualCount == 1)
+    #expect(summary.generatedCount == 1)
+    #expect(summary.compactLabel == "1 manual · 1 auto")
+}
+
+@Test func eventSourceSummaryEmptyLabel() {
+    let summary = EventSourceSummary.active(events: [])
+
+    #expect(summary.hasEvents == false)
+    #expect(summary.compactLabel == "no events")
+}


### PR DESCRIPTION
## Summary
- show active manual/auto event counts on subreddit rows
- add generated/manual badges to upcoming event banners
- add EventSourceSummary coverage for active generated/manual counts

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME ": " NR " lines" }' {} \;