### PR TITLE
Test capture media persistence actions

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
 		8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB005E503FDAD90271DB0AE /* EventBannerView.swift */; };
 		9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */; };
+		94CF7D2C65A9A2F6CCABCA92 /* CapturePersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */; };
 		9B6DE864F7F9D78BE7B6CA54 /* BackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6975993534B39BF8DEB32E /* BackupService.swift */; };
 		A45C2634E04FC8E88CD17018 /* PopoverContentActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */; };
 		AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */; };
@@ -67,6 +68,7 @@
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
 		F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */; };
 		FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
+		FF7560E040B2D7B3297B2AAB /* CapturePersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */; };
 		FFBC4E3EB895C7668654877B /* CRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -83,6 +85,7 @@
 /* Begin PBXFileReference section */
 		04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSubredditPicker.swift; sourceTree = "<group>"; };
 		050BB3D18ECE13E70E7CED42 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePersistenceActionsTests.swift; sourceTree = "<group>"; };
 		07A63D3714291E8917CA1694 /* PopoverContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentView.swift; sourceTree = "<group>"; };
 		0972EE8B384E16C0A49F8555 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
@@ -140,6 +143,7 @@
 		BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSectionView.swift; sourceTree = "<group>"; };
 		C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentActions.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
+		E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePersistenceActions.swift; sourceTree = "<group>"; };
 		E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarControllerTests.swift; sourceTree = "<group>"; };
 		EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceTests.swift; sourceTree = "<group>"; };
 		F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTests.swift; sourceTree = "<group>"; };
@@ -168,6 +172,7 @@
 				EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */,
 				FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */,
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
+				06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */,
 				BCDF7C9AE7CE03536B3CF9FF /* CRUDTests.swift */,
 				F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */,
 				409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */,
@@ -190,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */,
+				E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */,
 				5DB4E56FCDA7A1CB1F24566D /* Constants.swift */,
 				4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */,
 				8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */,
@@ -377,6 +383,7 @@
 				FFBC4E3EB895C7668654877B /* CRUDTests.swift in Sources */,
 				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
 				1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */,
+				94CF7D2C65A9A2F6CCABCA92 /* CapturePersistenceActionsTests.swift in Sources */,
 				B104E0E65566B8E4EFDFE190 /* EdgeCaseTests.swift in Sources */,
 				BA3B263D9D03FA844568F913 /* EventSourceSummaryTests.swift in Sources */,
 				5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */,
@@ -407,6 +414,7 @@
 				E3F5BC123C653EDC86231434 /* CaptureHelpers.swift in Sources */,
 				632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */,
 				458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */,
+				FF7560E040B2D7B3297B2AAB /* CapturePersistenceActions.swift in Sources */,
 				396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */,
 				4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */,
 				6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */,

--- a/Sources/Utilities/CapturePersistenceActions.swift
+++ b/Sources/Utilities/CapturePersistenceActions.swift
@@ -1,0 +1,119 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum CapturePersistenceActions {
+    @discardableResult
+    static func saveCapture(
+        _ result: CaptureFormResult,
+        modelContext: ModelContext,
+        mediaStore: MediaStore,
+        onCaptureChanged: @MainActor () -> Void = {}
+    ) -> Bool {
+        let capture = Capture(
+            text: result.text,
+            notes: result.notes,
+            links: result.links,
+            mediaRefs: [],
+            project: result.project,
+            subreddits: result.subreddits
+        )
+        modelContext.insert(capture)
+
+        do {
+            capture.mediaRefs = try saveMediaFiles(result.mediaURLs, captureId: capture.id, mediaStore: mediaStore)
+            try modelContext.save()
+            onCaptureChanged()
+            return true
+        } catch {
+            mediaStore.deleteAll(captureId: capture.id)
+            modelContext.delete(capture)
+            NSLog("RedditReminder: save failed: \(error)")
+            return false
+        }
+    }
+
+    @discardableResult
+    static func updateCapture(
+        _ capture: Capture,
+        with result: CaptureFormResult,
+        modelContext: ModelContext,
+        mediaStore: MediaStore,
+        onCaptureChanged: @MainActor () -> Void = {}
+    ) -> Bool {
+        var newlySavedRefs: [String] = []
+        if !result.mediaURLs.isEmpty {
+            do {
+                newlySavedRefs = try saveMediaFiles(result.mediaURLs, captureId: capture.id, mediaStore: mediaStore)
+            } catch {
+                NSLog("RedditReminder: media update failed: \(error)")
+                return false
+            }
+        }
+
+        capture.text = result.text
+        capture.notes = result.notes
+        capture.links = result.links
+
+        let removedRefs = Set(result.removedMediaRefs)
+        if !removedRefs.isEmpty {
+            capture.mediaRefs.removeAll { removedRefs.contains($0) }
+        }
+
+        capture.mediaRefs.append(contentsOf: newlySavedRefs)
+        capture.project = result.project
+        capture.subreddits = result.subreddits
+
+        do {
+            try modelContext.save()
+            deleteMediaRefs(Array(removedRefs), captureId: capture.id, mediaStore: mediaStore)
+            onCaptureChanged()
+            return true
+        } catch {
+            NSLog("RedditReminder: update failed: \(error)")
+            deleteMediaRefs(newlySavedRefs, captureId: capture.id, mediaStore: mediaStore)
+            modelContext.rollback()
+            return false
+        }
+    }
+
+    static func deleteCapture(
+        _ capture: Capture,
+        modelContext: ModelContext,
+        mediaStore: MediaStore,
+        onCaptureChanged: @MainActor () -> Void = {}
+    ) throws {
+        let captureId = capture.id
+        modelContext.delete(capture)
+
+        do {
+            try modelContext.save()
+        } catch {
+            NSLog("RedditReminder: delete failed: \(error)")
+            modelContext.rollback()
+            throw error
+        }
+
+        mediaStore.deleteAll(captureId: captureId)
+        onCaptureChanged()
+    }
+
+    static func saveMediaFiles(_ urls: [URL], captureId: UUID, mediaStore: MediaStore) throws -> [String] {
+        var refs: [String] = []
+        do {
+            for url in urls {
+                refs.append(try mediaStore.saveFile(at: url, captureId: captureId))
+            }
+            return refs
+        } catch {
+            deleteMediaRefs(refs, captureId: captureId, mediaStore: mediaStore)
+            throw error
+        }
+    }
+
+    private static func deleteMediaRefs(_ refs: [String], captureId: UUID, mediaStore: MediaStore) {
+        for ref in refs {
+            mediaStore.delete(captureId: captureId, ref: ref)
+        }
+    }
+}

--- a/Sources/Views/PopoverContentActions.swift
+++ b/Sources/Views/PopoverContentActions.swift
@@ -40,65 +40,23 @@ extension PopoverContentView {
 
     @discardableResult
     func saveCapture(_ result: CaptureFormResult) -> Bool {
-        let c = Capture(text: result.text, notes: result.notes, links: result.links,
-                        mediaRefs: [],
-                        project: result.project, subreddits: result.subreddits)
-        modelContext.insert(c)
-        do {
-            c.mediaRefs = try saveMediaFiles(result.mediaURLs, captureId: c.id)
-            try modelContext.save()
-            onCaptureChanged()
-            return true
-        } catch {
-            mediaStore.deleteAll(captureId: c.id)
-            modelContext.delete(c)
-            NSLog("RedditReminder: save failed: \(error)")
-            return false
-        }
+        CapturePersistenceActions.saveCapture(
+            result,
+            modelContext: modelContext,
+            mediaStore: mediaStore,
+            onCaptureChanged: onCaptureChanged
+        )
     }
 
     @discardableResult
     func updateCapture(_ capture: Capture, with r: CaptureFormResult) -> Bool {
-        capture.text = r.text; capture.notes = r.notes; capture.links = r.links
-        let removedRefs = Set(r.removedMediaRefs)
-        if !removedRefs.isEmpty {
-            capture.mediaRefs.removeAll { removedRefs.contains($0) }
-        }
-
-        var newlySavedRefs: [String] = []
-        if !r.mediaURLs.isEmpty {
-            do {
-                for url in r.mediaURLs {
-                    let ref = try mediaStore.saveFile(at: url, captureId: capture.id)
-                    newlySavedRefs.append(ref)
-                    capture.mediaRefs.append(ref)
-                }
-            } catch {
-                NSLog("RedditReminder: media update failed: \(error)")
-                for ref in newlySavedRefs {
-                    mediaStore.delete(captureId: capture.id, ref: ref)
-                }
-                modelContext.rollback()
-                return false
-            }
-        }
-        capture.project = r.project
-        capture.subreddits = r.subreddits
-        do {
-            try modelContext.save()
-            for ref in removedRefs {
-                mediaStore.delete(captureId: capture.id, ref: ref)
-            }
-            onCaptureChanged()
-            return true
-        } catch {
-            NSLog("RedditReminder: update failed: \(error)")
-            for ref in newlySavedRefs {
-                mediaStore.delete(captureId: capture.id, ref: ref)
-            }
-            modelContext.rollback()
-            return false
-        }
+        CapturePersistenceActions.updateCapture(
+            capture,
+            with: r,
+            modelContext: modelContext,
+            mediaStore: mediaStore,
+            onCaptureChanged: onCaptureChanged
+        )
     }
 
     func markCaptureAsPosted(_ capture: Capture) {
@@ -126,32 +84,22 @@ extension PopoverContentView {
     }
 
     func deleteCapture(_ capture: Capture) {
-        let captureId = capture.id
-        modelContext.delete(capture)
-        do { try modelContext.save() } catch {
-            NSLog("RedditReminder: delete failed: \(error)")
-            modelContext.rollback()
+        do {
+            try CapturePersistenceActions.deleteCapture(
+                capture,
+                modelContext: modelContext,
+                mediaStore: mediaStore,
+                onCaptureChanged: onCaptureChanged
+            )
+        } catch {
             showToastAfterReopen("Delete failed")
             return
         }
-        mediaStore.deleteAll(captureId: captureId)
-        onCaptureChanged()
         showToastAfterReopen("Capture deleted")
     }
 
     func saveMediaFiles(_ urls: [URL], captureId: UUID) throws -> [String] {
-        var refs: [String] = []
-        do {
-            for url in urls {
-                refs.append(try mediaStore.saveFile(at: url, captureId: captureId))
-            }
-            return refs
-        } catch {
-            for ref in refs {
-                mediaStore.delete(captureId: captureId, ref: ref)
-            }
-            throw error
-        }
+        try CapturePersistenceActions.saveMediaFiles(urls, captureId: captureId, mediaStore: mediaStore)
     }
 
     func showToastAfterReopen(_ message: String) {

--- a/Tests/RedditReminderTests/CapturePersistenceActionsTests.swift
+++ b/Tests/RedditReminderTests/CapturePersistenceActionsTests.swift
@@ -1,0 +1,177 @@
+import AppKit
+import Foundation
+import SwiftData
+import Testing
+@testable import RedditReminder
+
+private func makeCapturePersistenceContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
+        configurations: config
+    )
+}
+
+@Test @MainActor func saveCapturePersistsMediaRefsAndSignalsChange() throws {
+    let container = try makeCapturePersistenceContainer()
+    let context = ModelContext(container)
+    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+    let subreddit = Subreddit(name: "r/SwiftUI")
+    context.insert(subreddit)
+    try context.save()
+
+    let sourceURL = try writeTestImage(named: "draft.png")
+    defer { try? FileManager.default.removeItem(at: sourceURL) }
+    var changeCount = 0
+
+    let ok = CapturePersistenceActions.saveCapture(
+        CaptureFormResult(
+            text: "Draft",
+            notes: "Notes",
+            links: ["https://example.com"],
+            project: nil,
+            subreddits: [subreddit],
+            mediaURLs: [sourceURL]
+        ),
+        modelContext: context,
+        mediaStore: mediaStore,
+        onCaptureChanged: { changeCount += 1 }
+    )
+
+    let captures = try context.fetch(FetchDescriptor<Capture>())
+    #expect(ok)
+    #expect(changeCount == 1)
+    #expect(captures.count == 1)
+    #expect(captures[0].mediaRefs.count == 1)
+    #expect(captures[0].mediaRefs[0].hasSuffix("draft.png"))
+    #expect(mediaStore.loadImage(captureId: captures[0].id, ref: captures[0].mediaRefs[0]) != nil)
+}
+
+@Test @MainActor func updateCaptureRemovesDeletedMediaAfterSave() throws {
+    let container = try makeCapturePersistenceContainer()
+    let context = ModelContext(container)
+    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+    let subreddit = Subreddit(name: "r/macOS")
+    let capture = Capture(text: "Old", subreddits: [subreddit])
+    context.insert(subreddit)
+    context.insert(capture)
+    let first = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "first.png")
+    let second = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "second.png")
+    capture.mediaRefs = [first, second]
+    try context.save()
+
+    let ok = CapturePersistenceActions.updateCapture(
+        capture,
+        with: CaptureFormResult(
+            text: "Updated",
+            notes: nil,
+            links: [],
+            project: nil,
+            subreddits: [subreddit],
+            mediaURLs: [],
+            removedMediaRefs: [first]
+        ),
+        modelContext: context,
+        mediaStore: mediaStore
+    )
+
+    #expect(ok)
+    #expect(capture.text == "Updated")
+    #expect(capture.mediaRefs == [second])
+    #expect(mediaStore.loadImage(captureId: capture.id, ref: first) == nil)
+    #expect(mediaStore.loadThumbnail(captureId: capture.id, ref: first) == nil)
+    #expect(mediaStore.loadImage(captureId: capture.id, ref: second) != nil)
+}
+
+@Test @MainActor func updateCaptureRollsBackNewMediaWhenLaterFileFails() throws {
+    let container = try makeCapturePersistenceContainer()
+    let context = ModelContext(container)
+    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+    let subreddit = Subreddit(name: "r/Swift")
+    let capture = Capture(text: "Original", mediaRefs: [], subreddits: [subreddit])
+    context.insert(subreddit)
+    context.insert(capture)
+    try context.save()
+
+    let validURL = try writeTestImage(named: "valid.png")
+    let invalidURL = try writeTextFile(named: "bad.txt")
+    defer {
+        try? FileManager.default.removeItem(at: validURL)
+        try? FileManager.default.removeItem(at: invalidURL)
+    }
+
+    let ok = CapturePersistenceActions.updateCapture(
+        capture,
+        with: CaptureFormResult(
+            text: "Changed",
+            notes: nil,
+            links: [],
+            project: nil,
+            subreddits: [subreddit],
+            mediaURLs: [validURL, invalidURL]
+        ),
+        modelContext: context,
+        mediaStore: mediaStore
+    )
+
+    #expect(!ok)
+    #expect(capture.text == "Original")
+    #expect(capture.mediaRefs.isEmpty)
+    #expect(mediaStore.loadImage(captureId: capture.id, ref: validURL.lastPathComponent) == nil)
+    #expect(mediaStore.loadThumbnail(captureId: capture.id, ref: validURL.lastPathComponent) == nil)
+}
+
+@Test @MainActor func deleteCaptureRemovesPersistedMedia() throws {
+    let container = try makeCapturePersistenceContainer()
+    let context = ModelContext(container)
+    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+    let capture = Capture(text: "Delete me")
+    context.insert(capture)
+    let ref = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "delete.png")
+    capture.mediaRefs = [ref]
+    try context.save()
+    let captureId = capture.id
+    var changeCount = 0
+
+    try CapturePersistenceActions.deleteCapture(
+        capture,
+        modelContext: context,
+        mediaStore: mediaStore,
+        onCaptureChanged: { changeCount += 1 }
+    )
+
+    #expect(changeCount == 1)
+    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 0)
+    #expect(mediaStore.loadImage(captureId: captureId, ref: ref) == nil)
+    #expect(mediaStore.loadThumbnail(captureId: captureId, ref: ref) == nil)
+}
+
+private func temporaryMediaRoot() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+}
+
+private func writeTestImage(named fileName: String) throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+    guard let tiff = testImage().tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiff),
+          let png = bitmap.representation(using: .png, properties: [:]) else {
+        throw MediaError.encodingFailed
+    }
+    try png.write(to: url)
+    return url
+}
+
+private func writeTextFile(named fileName: String) throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+    try "not media".write(to: url, atomically: true, encoding: .utf8)
+    return url
+}
+
+private func testImage() -> NSImage {
+    let image = NSImage(size: NSSize(width: 64, height: 64))
+    image.lockFocus()
+    NSColor.systemOrange.setFill()
+    NSRect(x: 0, y: 0, width: 64, height: 64).fill()
+    image.unlockFocus()
+    return image
+}


### PR DESCRIPTION
## Summary
- extract capture save/update/delete persistence into a testable utility
- keep media file writes ahead of model mutation during capture updates so invalid media does not dirty the in-memory capture
- add SwiftData + file-system tests for media save, remove, rollback, and delete paths

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- ./scripts/qa.sh