### PR TITLE
Quiet runtime-only logs in tests

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2214090DA72A5B5AF58F6658 /* SubredditPeakTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */; };
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
 		26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */; };
+		2D0134DEC22382048A22922F /* AppRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3769CC097D084C4E6DD34081 /* AppRuntime.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */; };
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
@@ -63,6 +64,7 @@
 		D61EED608BA7889DFA0AA4C2 /* TimingEngineIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */; };
 		E3F5BC123C653EDC86231434 /* CaptureHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */; };
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
+		E9EDB8A89099DE463C304AA7 /* AppRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */; };
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */; };
@@ -89,6 +91,7 @@
 		050BB3D18ECE13E70E7CED42 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePersistenceActionsTests.swift; sourceTree = "<group>"; };
 		07A63D3714291E8917CA1694 /* PopoverContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentView.swift; sourceTree = "<group>"; };
+		07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeTests.swift; sourceTree = "<group>"; };
 		0972EE8B384E16C0A49F8555 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
 		0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelperTests.swift; sourceTree = "<group>"; };
@@ -100,6 +103,7 @@
 		274444AB5DE03A36248F96F2 /* HeuristicsTimezoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsTimezoneTests.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3769CC097D084C4E6DD34081 /* AppRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntime.swift; sourceTree = "<group>"; };
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
 		3BDDF7799BF55CF7FFC730BA /* peak-times.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "peak-times.json"; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
@@ -173,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */,
+				07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */,
 				EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */,
 				FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */,
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
@@ -199,6 +204,7 @@
 		46CC88F14B3721D357AD7FC0 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				3769CC097D084C4E6DD34081 /* AppRuntime.swift */,
 				8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */,
 				E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */,
 				5DB4E56FCDA7A1CB1F24566D /* Constants.swift */,
@@ -405,6 +411,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */,
+				E9EDB8A89099DE463C304AA7 /* AppRuntimeTests.swift in Sources */,
 				6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */,
 				FFBC4E3EB895C7668654877B /* CRUDTests.swift in Sources */,
 				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
@@ -432,6 +439,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */,
+				2D0134DEC22382048A22922F /* AppRuntime.swift in Sources */,
 				0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */,
 				26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */,
 				9B6DE864F7F9D78BE7B6CA54 /* BackupService.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -39,14 +39,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        registerGlobalShortcut()
-        shortcutObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.registerGlobalShortcut()
+        if AppRuntime.shouldRegisterGlobalShortcut() {
+            registerGlobalShortcut()
+            shortcutObserver = NotificationCenter.default.addObserver(
+                forName: UserDefaults.didChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.registerGlobalShortcut()
+                }
             }
         }
 

--- a/Sources/Services/HeuristicsStore.swift
+++ b/Sources/Services/HeuristicsStore.swift
@@ -10,8 +10,10 @@ struct PeakInfo {
 final class HeuristicsStore {
   private var bundled: [String: PeakInfo] = [:]
   private var overrides: [String: PeakInfo] = [:]
+  private let logsMissingResource: Bool
 
-  init(bundle: Bundle = .main) {
+  init(bundle: Bundle = .main, logsMissingResource: Bool = true) {
+    self.logsMissingResource = logsMissingResource
     loadBundled(from: bundle)
   }
 
@@ -122,7 +124,9 @@ final class HeuristicsStore {
 
   private func loadBundled(from bundle: Bundle) {
     guard let url = bundle.url(forResource: "peak-times", withExtension: "json") else {
-      NSLog("RedditReminder: peak-times.json not found in bundle")
+      if logsMissingResource {
+        NSLog("RedditReminder: peak-times.json not found in bundle")
+      }
       return
     }
 

--- a/Sources/Utilities/AppRuntime.swift
+++ b/Sources/Utilities/AppRuntime.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum AppRuntime {
+    static func isRunningUnitTests(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        environment["XCTestConfigurationFilePath"] != nil ||
+            environment["XCTestBundlePath"] != nil
+    }
+
+    static func shouldRegisterGlobalShortcut(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        !isRunningUnitTests(environment: environment)
+    }
+}

--- a/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
@@ -44,7 +44,7 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
         menuBarController: MenuBarController(),
         timingEngine: TimingEngine(),
         notificationService: NotificationService(center: center),
-        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main)
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
     )
     let sub = Subreddit(name: "r/Test")
     let event = SubredditEvent(name: "Peak", subreddit: sub, oneOffDate: Date().addingTimeInterval(3600))
@@ -71,7 +71,7 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
         menuBarController: MenuBarController(),
         timingEngine: TimingEngine(),
         notificationService: NotificationService(center: center),
-        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main)
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
     )
     let sub = Subreddit(name: "r/Test")
     let event = SubredditEvent(name: "Peak", subreddit: sub, oneOffDate: Date().addingTimeInterval(1800))
@@ -100,7 +100,7 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
         menuBarController: MenuBarController(),
         timingEngine: TimingEngine(),
         notificationService: NotificationService(center: center),
-        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main)
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
     )
     let sub = Subreddit(name: "r/Test")
     let stale = SubredditEvent(name: "Too Far", subreddit: sub, oneOffDate: Date().addingTimeInterval(48 * 3600))
@@ -121,7 +121,7 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
         menuBarController: MenuBarController(),
         timingEngine: TimingEngine(),
         notificationService: NotificationService(center: center),
-        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main)
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
     )
 
     await delegate.scheduleNotifications(activeEvents: [], windows: [])

--- a/Tests/RedditReminderTests/AppRuntimeTests.swift
+++ b/Tests/RedditReminderTests/AppRuntimeTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import RedditReminder
+
+@Test func appRuntimeDetectsXCTestConfigurationEnvironment() {
+    #expect(AppRuntime.isRunningUnitTests(environment: [
+        "XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"
+    ]))
+}
+
+@Test func appRuntimeDetectsXCTestBundleEnvironment() {
+    #expect(AppRuntime.isRunningUnitTests(environment: [
+        "XCTestBundlePath": "/tmp/RedditReminderTests.xctest"
+    ]))
+}
+
+@Test func appRuntimeAllowsShortcutRegistrationOutsideTests() {
+    #expect(AppRuntime.shouldRegisterGlobalShortcut(environment: [:]))
+}
+
+@Test func appRuntimeSkipsShortcutRegistrationDuringTests() {
+    #expect(!AppRuntime.shouldRegisterGlobalShortcut(environment: [
+        "XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"
+    ]))
+}

--- a/Tests/RedditReminderTests/HeuristicsTimezoneTests.swift
+++ b/Tests/RedditReminderTests/HeuristicsTimezoneTests.swift
@@ -108,7 +108,7 @@ import Foundation
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     let emptyBundle = Bundle(path: tempDir.path)!
 
-    let store = HeuristicsStore(bundle: emptyBundle)
+    let store = HeuristicsStore(bundle: emptyBundle, logsMissingResource: false)
     let peak = store.peakInfo(for: "r/SideProject")
     #expect(peak == nil) // no bundled data loaded
 }


### PR DESCRIPTION
## Summary
- skip global shortcut event-tap registration when the app is running as the unit-test host
- add AppRuntime tests for XCTest environment detection
- allow tests with intentionally empty heuristic bundles to suppress missing resource logs while preserving production logging

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- captured test log contains no 'failed to create event tap' or 'peak-times.json not found'
- ./scripts/qa.sh (rerun passed all 20 checks after reinstalling debug app)