### PR TITLE
Cover project persistence actions

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
 		0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E228CA7B8C32C3669A85 /* BackupMappers.swift */; };
 		1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */; };
+		12B7E4C8F9AB781325FFC21F /* ProjectPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */; };
 		130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */; };
 		14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
@@ -40,6 +41,7 @@
 		59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1122ADEB6045619C303C31 /* MediaStore.swift */; };
 		5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */; };
 		5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */; };
+		5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */; };
 		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
@@ -119,9 +121,11 @@
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
 		599273192FBCFDD93D1241B0 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPersistenceActions.swift; sourceTree = "<group>"; };
 		5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditRow.swift; sourceTree = "<group>"; };
 		5DB4E56FCDA7A1CB1F24566D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditEvent.swift; sourceTree = "<group>"; };
+		654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPersistenceActionsTests.swift; sourceTree = "<group>"; };
 		65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralTabView.swift; sourceTree = "<group>"; };
 		6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStore.swift; sourceTree = "<group>"; };
 		6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
@@ -191,6 +195,7 @@
 				E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */,
 				9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */,
 				3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */,
+				654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */,
 				A6A9BB4582DA895A6C18C321 /* ResourcePackagingTests.swift */,
 				4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */,
 				0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */,
@@ -211,6 +216,7 @@
 				4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */,
 				8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */,
 				56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */,
+				5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */,
 				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
 			);
@@ -425,6 +431,7 @@
 				9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */,
 				AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */,
 				7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */,
+				5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */,
 				14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */,
 				041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */,
 				CCE3B3D5EE4B39D55222CA19 /* ResourcePackagingTests.swift in Sources */,
@@ -474,6 +481,7 @@
 				3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,
+				12B7E4C8F9AB781325FFC21F /* ProjectPersistenceActions.swift in Sources */,
 				73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */,
 				17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */,
 				FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */,

--- a/Sources/Utilities/ProjectPersistenceActions.swift
+++ b/Sources/Utilities/ProjectPersistenceActions.swift
@@ -1,0 +1,91 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum ProjectPersistenceActions {
+    static func normalizedName(_ name: String) -> String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func isNameAvailable(_ name: String, projects: [Project], excluding: Project? = nil) -> Bool {
+        guard let trimmed = normalizedName(name) else { return false }
+        return !projects.contains {
+            $0.id != excluding?.id && $0.name.caseInsensitiveCompare(trimmed) == .orderedSame
+        }
+    }
+
+    @discardableResult
+    static func addProject(
+        named name: String,
+        projects: [Project],
+        modelContext: ModelContext
+    ) -> Project? {
+        guard let trimmed = normalizedName(name),
+              isNameAvailable(trimmed, projects: projects) else { return nil }
+
+        let project = Project(name: trimmed)
+        modelContext.insert(project)
+        do {
+            try modelContext.save()
+            return project
+        } catch {
+            NSLog("RedditReminder: add project failed: \(error)")
+            modelContext.delete(project)
+            return nil
+        }
+    }
+
+    @discardableResult
+    static func renameProject(
+        _ project: Project,
+        to name: String,
+        projects: [Project],
+        modelContext: ModelContext
+    ) -> Bool {
+        guard let trimmed = normalizedName(name),
+              isNameAvailable(trimmed, projects: projects, excluding: project) else { return false }
+
+        let oldName = project.name
+        project.name = trimmed
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            NSLog("RedditReminder: rename project failed: \(error)")
+            project.name = oldName
+            return false
+        }
+    }
+
+    @discardableResult
+    static func setArchived(
+        _ project: Project,
+        archived: Bool,
+        modelContext: ModelContext
+    ) -> Bool {
+        let oldValue = project.archived
+        project.archived = archived
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            NSLog("RedditReminder: archive toggle failed: \(error)")
+            project.archived = oldValue
+            return false
+        }
+    }
+
+    @discardableResult
+    static func deleteProject(_ project: Project, modelContext: ModelContext) -> Bool {
+        modelContext.delete(project)
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            NSLog("RedditReminder: delete project failed: \(error)")
+            modelContext.rollback()
+            return false
+        }
+    }
+}

--- a/Sources/Views/ProjectsTabView.swift
+++ b/Sources/Views/ProjectsTabView.swift
@@ -115,12 +115,11 @@ struct ProjectsTabView: View {
         .contextMenu {
             Button("Rename") { startEditing(project) }
             Button(project.archived ? "Unarchive" : "Archive") {
-                project.archived.toggle()
-                do { try modelContext.save() }
-                catch {
-                    NSLog("RedditReminder: archive toggle failed: \(error)")
-                    project.archived.toggle()
-                }
+                ProjectPersistenceActions.setArchived(
+                    project,
+                    archived: !project.archived,
+                    modelContext: modelContext
+                )
             }
             Divider()
             Button("Delete", role: .destructive) { deleteProject(project) }
@@ -162,29 +161,21 @@ struct ProjectsTabView: View {
     }
 
     private var canAdd: Bool {
-        isNameAvailable(newProjectName)
+        ProjectPersistenceActions.isNameAvailable(newProjectName, projects: projects)
     }
 
     private func isNameAvailable(_ name: String, excluding: Project? = nil) -> Bool {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        return !projects.contains(where: {
-            $0.id != excluding?.id && $0.name.lowercased() == trimmed.lowercased()
-        })
+        ProjectPersistenceActions.isNameAvailable(name, projects: projects, excluding: excluding)
     }
 
     private func addProject() {
-        let trimmed = newProjectName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, canAdd else { return }
-        let project = Project(name: trimmed)
-        modelContext.insert(project)
-        do { try modelContext.save() }
-        catch {
-            NSLog("RedditReminder: add project failed: \(error)")
-            modelContext.delete(project)
-            return
+        if ProjectPersistenceActions.addProject(
+            named: newProjectName,
+            projects: projects,
+            modelContext: modelContext
+        ) != nil {
+            newProjectName = ""
         }
-        newProjectName = ""
     }
 
     private func startEditing(_ project: Project) {
@@ -193,26 +184,17 @@ struct ProjectsTabView: View {
     }
 
     private func finishEditing(_ project: Project) {
-        let trimmed = editName.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty, isNameAvailable(trimmed, excluding: project) {
-            let oldName = project.name
-            project.name = trimmed
-            do { try modelContext.save() }
-            catch {
-                NSLog("RedditReminder: rename project failed: \(error)")
-                project.name = oldName
-            }
-        }
+        ProjectPersistenceActions.renameProject(
+            project,
+            to: editName,
+            projects: projects,
+            modelContext: modelContext
+        )
         editingProject = nil
         editName = ""
     }
 
     private func deleteProject(_ project: Project) {
-        modelContext.delete(project)
-        do { try modelContext.save() }
-        catch {
-            NSLog("RedditReminder: delete project failed: \(error)")
-            modelContext.rollback()
-        }
+        ProjectPersistenceActions.deleteProject(project, modelContext: modelContext)
     }
 }

--- a/Tests/RedditReminderTests/ProjectPersistenceActionsTests.swift
+++ b/Tests/RedditReminderTests/ProjectPersistenceActionsTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import RedditReminder
+
+private func makeProjectActionsContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
+        configurations: config
+    )
+}
+
+@Test @MainActor func projectNameNormalizationTrimsWhitespace() {
+    #expect(ProjectPersistenceActions.normalizedName("  Launch Plan \n") == "Launch Plan")
+}
+
+@Test @MainActor func projectNameNormalizationRejectsBlank() {
+    #expect(ProjectPersistenceActions.normalizedName(" \n\t ") == nil)
+}
+
+@Test @MainActor func projectNameAvailabilityIsCaseInsensitive() {
+    let existing = Project(name: "Launch")
+
+    #expect(!ProjectPersistenceActions.isNameAvailable("launch", projects: [existing]))
+    #expect(!ProjectPersistenceActions.isNameAvailable(" LAUNCH ", projects: [existing]))
+    #expect(ProjectPersistenceActions.isNameAvailable("Roadmap", projects: [existing]))
+}
+
+@Test @MainActor func projectNameAvailabilityAllowsCurrentProjectWhenRenaming() {
+    let existing = Project(name: "Launch")
+
+    #expect(ProjectPersistenceActions.isNameAvailable("launch", projects: [existing], excluding: existing))
+}
+
+@Test @MainActor func addProjectPersistsTrimmedName() throws {
+    let container = try makeProjectActionsContainer()
+    let context = ModelContext(container)
+
+    let project = ProjectPersistenceActions.addProject(
+        named: "  Launch  ",
+        projects: [],
+        modelContext: context
+    )
+
+    let fetched = try context.fetch(FetchDescriptor<Project>())
+    #expect(project != nil)
+    #expect(fetched.map(\.name) == ["Launch"])
+}
+
+@Test @MainActor func addProjectRejectsDuplicateName() throws {
+    let container = try makeProjectActionsContainer()
+    let context = ModelContext(container)
+    let existing = Project(name: "Launch")
+    context.insert(existing)
+    try context.save()
+
+    let project = ProjectPersistenceActions.addProject(
+        named: "launch",
+        projects: [existing],
+        modelContext: context
+    )
+
+    #expect(project == nil)
+    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 1)
+}
+
+@Test @MainActor func renameProjectPersistsTrimmedName() throws {
+    let container = try makeProjectActionsContainer()
+    let context = ModelContext(container)
+    let project = Project(name: "Draft")
+    context.insert(project)
+    try context.save()
+
+    let ok = ProjectPersistenceActions.renameProject(
+        project,
+        to: "  Launch  ",
+        projects: [project],
+        modelContext: context
+    )
+
+    #expect(ok)
+    #expect(project.name == "Launch")
+}
+
+@Test @MainActor func renameProjectRejectsDuplicateName() throws {
+    let container = try makeProjectActionsContainer()
+    let context = ModelContext(container)
+    let first = Project(name: "Launch")
+    let second = Project(name: "Roadmap")
+    context.insert(first)
+    context.insert(second)
+    try context.save()
+
+    let ok = ProjectPersistenceActions.renameProject(
+        second,
+        to: "launch",
+        projects: [first, second],
+        modelContext: context
+    )
+
+    #expect(!ok)
+    #expect(second.name == "Roadmap")
+}
+
+@Test @MainActor func archiveProjectPersistsState() throws {
+    let container = try makeProjectActionsContainer()
+    let context = ModelContext(container)
+    let project = Project(name: "Launch")
+    context.insert(project)
+    try context.save()
+
+    let ok = ProjectPersistenceActions.setArchived(project, archived: true, modelContext: context)
+
+    #expect(ok)
+    #expect(project.archived)
+}
+
+@Test @MainActor func deleteProjectRemovesProjectAndCascadesCaptures() throws {
+    let container = try makeProjectActionsContainer()
+    let context = ModelContext(container)
+    let project = Project(name: "Launch")
+    let capture = Capture(text: "Draft", project: project)
+    context.insert(project)
+    context.insert(capture)
+    try context.save()
+
+    let ok = ProjectPersistenceActions.deleteProject(project, modelContext: context)
+
+    #expect(ok)
+    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 0)
+    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 0)
+}


### PR DESCRIPTION
## Summary
- extract project add/rename/archive/delete persistence into ProjectPersistenceActions
- keep Projects tab behavior wired through the same actions
- add SwiftData tests for name normalization, duplicate rejection, add, rename, archive, and delete cascade behavior

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- ./scripts/qa.sh
- file-size gate