### PR TITLE
Cover subreddit persistence actions

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
 		26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */; };
 		2D0134DEC22382048A22922F /* AppRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3769CC097D084C4E6DD34081 /* AppRuntime.swift */; };
+		2E04156554C7A2C39EF726A4 /* SubredditPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */; };
+		347F4FD54749869424F5CD6C /* SubredditPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */; };
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
@@ -118,6 +120,7 @@
 		4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubreddits.swift; sourceTree = "<group>"; };
 		4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksSection.swift; sourceTree = "<group>"; };
 		4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngine.swift; sourceTree = "<group>"; };
+		542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActions.swift; sourceTree = "<group>"; };
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
 		599273192FBCFDD93D1241B0 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
@@ -130,6 +133,7 @@
 		6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStore.swift; sourceTree = "<group>"; };
 		6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
 		726D903A97B808C6ED572BCA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActionsTests.swift; sourceTree = "<group>"; };
 		787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderApp.swift; sourceTree = "<group>"; };
 		83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineIntegrationTests.swift; sourceTree = "<group>"; };
 		8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
@@ -200,6 +204,7 @@
 				4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */,
 				0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */,
 				A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */,
+				75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */,
 				83759C43598ADF749158FAAD /* TimingEngineIntegrationTests.swift */,
 				B727389070814347602E1AB3 /* TimingEngineTests.swift */,
 			);
@@ -219,6 +224,7 @@
 				5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */,
 				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
+				542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -436,6 +442,7 @@
 				041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */,
 				CCE3B3D5EE4B39D55222CA19 /* ResourcePackagingTests.swift in Sources */,
 				2214090DA72A5B5AF58F6658 /* SubredditPeakTimeTests.swift in Sources */,
+				347F4FD54749869424F5CD6C /* SubredditPersistenceActionsTests.swift in Sources */,
 				D61EED608BA7889DFA0AA4C2 /* TimingEngineIntegrationTests.swift in Sources */,
 				24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */,
 			);
@@ -489,6 +496,7 @@
 				130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */,
 				35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */,
 				19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */,
+				2E04156554C7A2C39EF726A4 /* SubredditPersistenceActions.swift in Sources */,
 				4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */,
 				1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */,
 			);

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -52,6 +52,8 @@ enum SubredditName {
     case invalidCharacters
     case tooShort
     case tooLong
+    case duplicate
+    case saveFailed
 
     var message: String {
       switch self {
@@ -63,6 +65,10 @@ enum SubredditName {
         return "Subreddit names must be at least \(SubredditName.minLength) characters."
       case .tooLong:
         return "Subreddit names must be \(SubredditName.maxLength) characters or fewer."
+      case .duplicate:
+        return "That subreddit is already in your list."
+      case .saveFailed:
+        return "Could not save subreddit."
       }
     }
   }

--- a/Sources/Utilities/SubredditPersistenceActions.swift
+++ b/Sources/Utilities/SubredditPersistenceActions.swift
@@ -1,0 +1,122 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum SubredditPersistenceActions {
+    static func isNameAvailable(_ name: String, subreddits: [Subreddit]) -> Bool {
+        !subreddits.contains {
+            $0.name.caseInsensitiveCompare(name) == .orderedSame
+        }
+    }
+
+    static func canAdd(_ input: String, subreddits: [Subreddit]) -> Bool {
+        guard let name = SubredditName.normalizedName(input) else { return false }
+        return isNameAvailable(name, subreddits: subreddits)
+    }
+
+    @discardableResult
+    static func addSubreddit(
+        named input: String,
+        subreddits: [Subreddit],
+        modelContext: ModelContext,
+        heuristicsStore: HeuristicsStore,
+        defaultLeadTimeMinutes: Int
+    ) -> Result<Subreddit, SubredditName.ValidationError> {
+        let normalized = SubredditName.normalize(input)
+        guard case .success(let name) = normalized else {
+            if case .failure(let error) = normalized { return .failure(error) }
+            return .failure(.empty)
+        }
+        guard isNameAvailable(name, subreddits: subreddits) else {
+            return .failure(.duplicate)
+        }
+
+        let nextOrder = (subreddits.map(\.sortOrder).max() ?? -1) + 1
+        let subreddit = Subreddit(name: name, sortOrder: nextOrder)
+        modelContext.insert(subreddit)
+        do {
+            try modelContext.save()
+            try heuristicsStore.syncGeneratedEvents(
+                for: subreddit,
+                context: modelContext,
+                defaultLeadTimeMinutes: defaultLeadTimeMinutes
+            )
+            return .success(subreddit)
+        } catch {
+            NSLog("RedditReminder: add subreddit failed: \(error)")
+            modelContext.delete(subreddit)
+            return .failure(.saveFailed)
+        }
+    }
+
+    @discardableResult
+    static func savePendingChanges(
+        subreddits: [Subreddit],
+        modelContext: ModelContext,
+        heuristicsStore: HeuristicsStore,
+        defaultLeadTimeMinutes: Int
+    ) -> Bool {
+        guard modelContext.hasChanges else { return true }
+        do {
+            try modelContext.save()
+            try heuristicsStore.syncGeneratedEvents(
+                for: subreddits,
+                context: modelContext,
+                defaultLeadTimeMinutes: defaultLeadTimeMinutes
+            )
+            return true
+        } catch {
+            NSLog("RedditReminder: save pending changes failed: \(error)")
+            return false
+        }
+    }
+
+    @discardableResult
+    static func deleteSubreddit(
+        _ subreddit: Subreddit,
+        modelContext: ModelContext,
+        notificationService: NotificationService
+    ) -> Bool {
+        for event in subreddit.events {
+            notificationService.cancelNotifications(eventId: event.id.uuidString)
+        }
+        modelContext.delete(subreddit)
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            NSLog("RedditReminder: delete subreddit failed: \(error)")
+            modelContext.rollback()
+            return false
+        }
+    }
+
+    @discardableResult
+    static func reorder(
+        source: Subreddit,
+        target: Subreddit,
+        subreddits: [Subreddit],
+        modelContext: ModelContext
+    ) -> Bool {
+        guard source.id != target.id,
+              let fromIndex = subreddits.firstIndex(where: { $0.id == source.id }),
+              let toIndex = subreddits.firstIndex(where: { $0.id == target.id }) else { return false }
+
+        var reordered = subreddits
+        let item = reordered.remove(at: fromIndex)
+        reordered.insert(item, at: toIndex)
+
+        for (index, subreddit) in reordered.enumerated() {
+            subreddit.sortOrder = index
+        }
+
+        do {
+            try modelContext.save()
+            return true
+        } catch {
+            modelContext.rollback()
+            NSLog("RedditReminder: failed to save subreddit reorder: \(error)")
+            return false
+        }
+    }
+}

--- a/Sources/Views/ChannelsView.swift
+++ b/Sources/Views/ChannelsView.swift
@@ -82,40 +82,23 @@ struct ChannelsTabView: View {
     }
 
     private var canAdd: Bool {
-        guard let name = SubredditName.normalizedName(newSubredditName) else { return false }
-        return isNameAvailable(name)
-    }
-
-    private func isNameAvailable(_ name: String) -> Bool {
-        !subreddits.contains(where: { $0.name.lowercased() == name.lowercased() })
+        SubredditPersistenceActions.canAdd(newSubredditName, subreddits: subreddits)
     }
 
     private func addSubreddit() {
-        let normalized = SubredditName.normalize(newSubredditName)
-        guard case .success(let name) = normalized else {
-            if case .failure(let error) = normalized {
-                nameValidationMessage = error.message
-            }
-            return
+        switch SubredditPersistenceActions.addSubreddit(
+            named: newSubredditName,
+            subreddits: subreddits,
+            modelContext: modelContext,
+            heuristicsStore: heuristicsStore,
+            defaultLeadTimeMinutes: defaultLeadTimeMinutes
+        ) {
+        case .success:
+            newSubredditName = ""
+            nameValidationMessage = nil
+        case .failure(let error):
+            nameValidationMessage = error.message
         }
-        guard isNameAvailable(name) else {
-            nameValidationMessage = "That subreddit is already in your list."
-            return
-        }
-        let nextOrder = (subreddits.map(\.sortOrder).max() ?? -1) + 1
-        let sub = Subreddit(name: name, sortOrder: nextOrder)
-        modelContext.insert(sub)
-        do {
-            try modelContext.save()
-            try syncGeneratedEvents(for: sub)
-        }
-        catch {
-            NSLog("RedditReminder: add subreddit failed: \(error)")
-            modelContext.delete(sub)
-            return
-        }
-        newSubredditName = ""
-        nameValidationMessage = nil
     }
 
     private func toggleExpanded(_ sub: Subreddit) {
@@ -126,39 +109,24 @@ struct ChannelsTabView: View {
     }
 
     private func savePendingChanges() {
-        guard modelContext.hasChanges else { return }
-        do {
-            try modelContext.save()
-            try heuristicsStore.syncGeneratedEvents(
-                for: subreddits,
-                context: modelContext,
-                defaultLeadTimeMinutes: defaultLeadTimeMinutes
-            )
-        }
-        catch { NSLog("RedditReminder: save pending changes failed: \(error)") }
+        SubredditPersistenceActions.savePendingChanges(
+            subreddits: subreddits,
+            modelContext: modelContext,
+            heuristicsStore: heuristicsStore,
+            defaultLeadTimeMinutes: defaultLeadTimeMinutes
+        )
     }
 
     private func deleteSubreddit(_ sub: Subreddit) {
-        for event in sub.events {
-            notificationService.cancelNotifications(eventId: event.id.uuidString)
-        }
-        modelContext.delete(sub)
-        do { try modelContext.save() }
-        catch {
-            NSLog("RedditReminder: delete subreddit failed: \(error)")
-            modelContext.rollback()
-        }
+        SubredditPersistenceActions.deleteSubreddit(
+            sub,
+            modelContext: modelContext,
+            notificationService: notificationService
+        )
     }
 
     private var defaultLeadTimeMinutes: Int {
         UserDefaults.standard.object(forKey: SettingsKey.defaultLeadTimeMinutes) as? Int ?? 60
     }
 
-    private func syncGeneratedEvents(for sub: Subreddit) throws {
-        try heuristicsStore.syncGeneratedEvents(
-            for: sub,
-            context: modelContext,
-            defaultLeadTimeMinutes: defaultLeadTimeMinutes
-        )
-    }
 }

--- a/Sources/Views/SubredditRow.swift
+++ b/Sources/Views/SubredditRow.swift
@@ -220,22 +220,12 @@ struct SubredditDropDelegate: DropDelegate {
 
     func dropEntered(info: DropInfo) {
         guard let source = dragging, source.id != target.id else { return }
-        guard let fromIndex = subreddits.firstIndex(where: { $0.id == source.id }),
-              let toIndex = subreddits.firstIndex(where: { $0.id == target.id }) else { return }
-
-        var reordered = subreddits
-        let item = reordered.remove(at: fromIndex)
-        reordered.insert(item, at: toIndex)
-
-        for (i, sub) in reordered.enumerated() {
-            sub.sortOrder = i
-        }
-        do {
-            try modelContext.save()
-        } catch {
-            modelContext.rollback()
-            NSLog("RedditReminder: failed to save subreddit reorder: \(error)")
-        }
+        SubredditPersistenceActions.reorder(
+            source: source,
+            target: target,
+            subreddits: subreddits,
+            modelContext: modelContext
+        )
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {

--- a/Tests/RedditReminderTests/SubredditPersistenceActionsTests.swift
+++ b/Tests/RedditReminderTests/SubredditPersistenceActionsTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import SwiftData
+import Testing
+import UserNotifications
+@testable import RedditReminder
+
+private final class RecordingSubredditNotificationCenter: NotificationCenterProtocol, @unchecked Sendable {
+    private(set) var removedIdentifiers: [[String]] = []
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { true }
+    func add(_ request: UNNotificationRequest, withCompletionHandler handler: (@Sendable (Error?) -> Void)?) {}
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        removedIdentifiers.append(identifiers)
+    }
+    func removeAllPendingNotificationRequests() {}
+    func getAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
+}
+
+private func makeSubredditActionsContainer() throws -> ModelContainer {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+        for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
+        configurations: config
+    )
+}
+
+@Test @MainActor func subredditCanAddRejectsInvalidAndDuplicateNames() {
+    let existing = Subreddit(name: "r/SwiftUI")
+
+    #expect(!SubredditPersistenceActions.canAdd("bad name", subreddits: [existing]))
+    #expect(!SubredditPersistenceActions.canAdd("swiftui", subreddits: [existing]))
+    #expect(SubredditPersistenceActions.canAdd("macOS", subreddits: [existing]))
+}
+
+@Test @MainActor func addSubredditPersistsNormalizedNameAndSortOrder() throws {
+    let container = try makeSubredditActionsContainer()
+    let context = ModelContext(container)
+    let existing = Subreddit(name: "r/Existing", sortOrder: 4)
+    context.insert(existing)
+    try context.save()
+
+    let store = HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
+    let result = SubredditPersistenceActions.addSubreddit(
+        named: "  TestSub  ",
+        subreddits: [existing],
+        modelContext: context,
+        heuristicsStore: store,
+        defaultLeadTimeMinutes: 30
+    )
+
+    guard case .success(let subreddit) = result else {
+        Issue.record("Expected subreddit to be added")
+        return
+    }
+    #expect(subreddit.name == "r/TestSub")
+    #expect(subreddit.sortOrder == 5)
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 2)
+}
+
+@Test @MainActor func addSubredditRejectsDuplicateName() throws {
+    let container = try makeSubredditActionsContainer()
+    let context = ModelContext(container)
+    let existing = Subreddit(name: "r/SwiftUI")
+    context.insert(existing)
+    try context.save()
+
+    let store = HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
+    let result = SubredditPersistenceActions.addSubreddit(
+        named: "swiftui",
+        subreddits: [existing],
+        modelContext: context,
+        heuristicsStore: store,
+        defaultLeadTimeMinutes: 60
+    )
+
+    #expect(result == .failure(.duplicate))
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 1)
+}
+
+@Test @MainActor func addSubredditSyncsGeneratedPeakEvents() throws {
+    let container = try makeSubredditActionsContainer()
+    let context = ModelContext(container)
+    let store = HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
+    store.setOverride(for: "r/TestSub", peakDays: ["mon"], peakHoursUtc: [14, 15])
+
+    let result = SubredditPersistenceActions.addSubreddit(
+        named: "TestSub",
+        subreddits: [],
+        modelContext: context,
+        heuristicsStore: store,
+        defaultLeadTimeMinutes: 45
+    )
+
+    guard case .success(let subreddit) = result else {
+        Issue.record("Expected subreddit to be added")
+        return
+    }
+
+    let events = try context.fetch(FetchDescriptor<SubredditEvent>())
+    #expect(events.count == 2)
+    #expect(events.allSatisfy { $0.isGeneratedFromHeuristics })
+    #expect(events.allSatisfy { $0.subreddit?.id == subreddit.id })
+    #expect(Set(events.compactMap(\.recurrenceHour)) == [14, 15])
+    #expect(events.allSatisfy { $0.reminderLeadMinutes == 45 })
+}
+
+@Test @MainActor func savePendingChangesPersistsPeakOverrideAndResyncsGeneratedEvents() throws {
+    let container = try makeSubredditActionsContainer()
+    let context = ModelContext(container)
+    let subreddit = Subreddit(name: "r/TestSub")
+    context.insert(subreddit)
+    try context.save()
+
+    let store = HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
+    subreddit.peakDaysOverride = ["tue"]
+    subreddit.peakHoursUtcOverride = [9]
+
+    let ok = SubredditPersistenceActions.savePendingChanges(
+        subreddits: [subreddit],
+        modelContext: context,
+        heuristicsStore: store,
+        defaultLeadTimeMinutes: 20
+    )
+
+    let events = try context.fetch(FetchDescriptor<SubredditEvent>())
+    #expect(ok)
+    #expect(events.count == 1)
+    #expect(events[0].rrule == "FREQ=WEEKLY;BYDAY=TU")
+    #expect(events[0].recurrenceHour == 9)
+    #expect(events[0].reminderLeadMinutes == 20)
+}
+
+@Test @MainActor func deleteSubredditCancelsEventNotificationsAndDeletesEvents() throws {
+    let container = try makeSubredditActionsContainer()
+    let context = ModelContext(container)
+    let center = RecordingSubredditNotificationCenter()
+    let service = NotificationService(center: center)
+    let subreddit = Subreddit(name: "r/Test")
+    let event = SubredditEvent(name: "Peak", subreddit: subreddit, oneOffDate: Date().addingTimeInterval(3600))
+    context.insert(subreddit)
+    context.insert(event)
+    try context.save()
+    let eventId = event.id.uuidString
+
+    let ok = SubredditPersistenceActions.deleteSubreddit(
+        subreddit,
+        modelContext: context,
+        notificationService: service
+    )
+
+    #expect(ok)
+    #expect(center.removedIdentifiers.count == 1)
+    #expect(center.removedIdentifiers[0].contains("window-\(eventId)"))
+    #expect(center.removedIdentifiers[0].contains("nudge-\(eventId)"))
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 0)
+    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 0)
+}
+
+@Test @MainActor func reorderSubredditsPersistsSequentialSortOrder() throws {
+    let container = try makeSubredditActionsContainer()
+    let context = ModelContext(container)
+    let first = Subreddit(name: "r/A", sortOrder: 0)
+    let second = Subreddit(name: "r/B", sortOrder: 1)
+    let third = Subreddit(name: "r/C", sortOrder: 2)
+    for subreddit in [first, second, third] {
+        context.insert(subreddit)
+    }
+    try context.save()
+
+    let ok = SubredditPersistenceActions.reorder(
+        source: third,
+        target: first,
+        subreddits: [first, second, third],
+        modelContext: context
+    )
+
+    #expect(ok)
+    #expect(third.sortOrder == 0)
+    #expect(first.sortOrder == 1)
+    #expect(second.sortOrder == 2)
+}


### PR DESCRIPTION
## Summary
- extract subreddit add/save/delete/reorder persistence from SwiftUI views into SubredditPersistenceActions
- reuse normalized subreddit validation for duplicate/save errors surfaced in the UI
- add tests for add, duplicate rejection, generated peak-event sync, pending-change save, delete notification cancellation, and reorder persistence

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- ./scripts/qa.sh
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME }' {} \;