### PR TITLE
Require exact global shortcut modifier matches

### DIFF
--- a/Sources/Utilities/KeyboardShortcuts.swift
+++ b/Sources/Utilities/KeyboardShortcuts.swift
@@ -83,6 +83,10 @@ struct KeyboardShortcutConfig: Equatable, Sendable {
     "\(modifierDisplay(for: normalized(modifiers)))\(key)"
   }
 
+  func matches(keyCode candidateKeyCode: Int64, flags: CGEventFlags) -> Bool {
+    candidateKeyCode == keyCode && Self.normalized(flags) == modifiers
+  }
+
   private static func normalized(_ modifiers: CGEventFlags) -> CGEventFlags {
     var normalized: CGEventFlags = []
     for mask in allModifierMasks where modifiers.contains(mask) {
@@ -216,7 +220,7 @@ final class GlobalShortcut {
     let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
 
     let config = state.withLock { $0.config }
-    if keyCode == config.keyCode && flags.contains(config.modifiers) {
+    if config.matches(keyCode: keyCode, flags: flags) {
       let handler = state.withLock { $0.handler }
       if let handler {
         Task { @MainActor in handler() }

--- a/Tests/RedditReminderTests/MenuBarControllerTests.swift
+++ b/Tests/RedditReminderTests/MenuBarControllerTests.swift
@@ -76,6 +76,36 @@ struct MenuBarControllerTests {
         #expect(allValid)
     }
 
+    @Test func shortcutMatchesExactKeyAndModifiers() {
+        let shortcut = KeyboardShortcutConfig.custom(
+            keyCode: 35,
+            modifiers: [.maskCommand, .maskAlternate],
+            keyDisplay: "P"
+        )
+
+        #expect(shortcut.matches(keyCode: 35, flags: [.maskCommand, .maskAlternate]))
+    }
+
+    @Test func shortcutRejectsExtraShortcutModifiers() {
+        let shortcut = KeyboardShortcutConfig.custom(
+            keyCode: 35,
+            modifiers: [.maskCommand, .maskAlternate],
+            keyDisplay: "P"
+        )
+
+        #expect(!shortcut.matches(keyCode: 35, flags: [.maskCommand, .maskAlternate, .maskShift]))
+    }
+
+    @Test func shortcutRejectsWrongKeyCode() {
+        let shortcut = KeyboardShortcutConfig.custom(
+            keyCode: 35,
+            modifiers: [.maskCommand, .maskAlternate],
+            keyDisplay: "P"
+        )
+
+        #expect(!shortcut.matches(keyCode: 36, flags: [.maskCommand, .maskAlternate]))
+    }
+
     @Test func initialBadgeCountIsZero() {
         let controller = MenuBarController()
         #expect(controller.badgeCount == 0)


### PR DESCRIPTION
## Summary
- add a pure shortcut matching helper that normalizes modifier flags
- require exact configured shortcut modifiers before the event tap fires
- cover exact match, extra modifier rejection, and wrong-key rejection

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build -only-testing:RedditReminderTests/MenuBarControllerTests
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME }' {} \;
- ./scripts/qa.sh (first run had accessibility automation failures around Preferences/popover; immediate rerun passed all 20 checks)