### PR TITLE
Restrict subreddit names to ASCII characters

### DIFF
--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -80,7 +80,7 @@ enum SubredditName {
     guard candidate.count >= minLength else { return .failure(.tooShort) }
     guard candidate.count <= maxLength else { return .failure(.tooLong) }
 
-    let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+    let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
     guard candidate.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
       return .failure(.invalidCharacters)
     }

--- a/Tests/RedditReminderTests/EdgeCaseTests.swift
+++ b/Tests/RedditReminderTests/EdgeCaseTests.swift
@@ -83,6 +83,10 @@ private func makeContainer() throws -> ModelContainer {
     #expect(SubredditName.normalize("bad name") == .failure(.invalidCharacters))
 }
 
+@Test func subredditNameRejectsNonAsciiLetters() {
+    #expect(SubredditName.normalize("café") == .failure(.invalidCharacters))
+}
+
 @Test func subredditNameRejectsTooShort() {
     #expect(SubredditName.normalize("ab") == .failure(.tooShort))
 }


### PR DESCRIPTION
## Summary
- replace Unicode alphanumeric subreddit validation with an explicit ASCII letters/digits/underscore character set
- add a regression test for rejecting non-ASCII subreddit names

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME }' {} \;
- ./scripts/qa.sh