### PR TITLE
Prune missing media refs on backup import

### DIFF
--- a/Sources/Services/BackupService.swift
+++ b/Sources/Services/BackupService.swift
@@ -135,7 +135,8 @@ struct BackupService {
     func importBackup(
         from data: Data,
         into context: ModelContext,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        mediaStore: MediaStore? = nil
     ) throws {
         let backup = try decoder.decode(AppBackup.self, from: data)
         guard backup.version == 1 else { throw BackupError.unsupportedVersion(backup.version) }
@@ -199,7 +200,7 @@ struct BackupService {
                 text: item.text,
                 notes: item.notes,
                 links: item.links,
-                mediaRefs: item.mediaRefs,
+                mediaRefs: restoredMediaRefs(from: item, mediaStore: mediaStore),
                 project: item.projectId.flatMap { projectsById[$0] },
                 subreddits: subreddits
             )
@@ -238,6 +239,11 @@ struct BackupService {
                 throw BackupError.missingRelationship(subredditId.uuidString)
             }
         }
+    }
+
+    private func restoredMediaRefs(from capture: BackupCapture, mediaStore: MediaStore?) -> [String] {
+        guard let mediaStore else { return capture.mediaRefs }
+        return capture.mediaRefs.filter { mediaStore.exists(captureId: capture.id, ref: $0) }
     }
 
     private func applySettings(_ settings: BackupSettings, to defaults: UserDefaults) {

--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -81,6 +81,10 @@ final class MediaStore {
       .appendingPathComponent(ref)
   }
 
+  func exists(captureId: UUID, ref: String) -> Bool {
+    fm.fileExists(atPath: mediaURL(captureId: captureId, ref: ref).path)
+  }
+
   func delete(captureId: UUID, ref: String) {
     for url in [mediaURL(captureId: captureId, ref: ref), thumbnailURL(captureId: captureId, ref: ref)] {
       do {

--- a/Sources/Views/BackupSectionView.swift
+++ b/Sources/Views/BackupSectionView.swift
@@ -12,6 +12,7 @@ struct BackupSectionView: View {
     @State private var errorMessage: String?
 
     private let backupService = BackupService()
+    private let mediaStore = MediaStore()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -77,7 +78,7 @@ struct BackupSectionView: View {
                 if didAccess { url.stopAccessingSecurityScopedResource() }
             }
             let data = try Data(contentsOf: url)
-            try backupService.importBackup(from: data, into: modelContext)
+            try backupService.importBackup(from: data, into: modelContext, mediaStore: mediaStore)
             statusMessage = "Backup imported"
             errorMessage = nil
         } catch {

--- a/Tests/RedditReminderTests/BackupServiceTests.swift
+++ b/Tests/RedditReminderTests/BackupServiceTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftData
 import Testing
@@ -246,4 +247,110 @@ private func makeBackupContainer() throws -> ModelContainer {
     #expect(defaults.object(forKey: SettingsKey.globalShortcutKeyCode) == nil)
     #expect(defaults.object(forKey: SettingsKey.globalShortcutModifiers) == nil)
     #expect(defaults.object(forKey: SettingsKey.globalShortcutDisplay) == nil)
+}
+
+@Test @MainActor func backupImportDropsMissingMediaRefsWhenMediaStoreProvided() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let subredditId = UUID()
+    let captureId = UUID()
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [],
+        subreddits: [
+            BackupSubreddit(
+                id: subredditId,
+                name: "r/SwiftUI",
+                sortOrder: 0,
+                peakDaysOverride: nil,
+                peakHoursUtcOverride: nil
+            )
+        ],
+        events: [],
+        captures: [
+            BackupCapture(
+                id: captureId,
+                text: "With missing media",
+                notes: nil,
+                links: [],
+                mediaRefs: ["missing.png"],
+                status: .queued,
+                createdAt: Date(),
+                postedAt: nil,
+                projectId: nil,
+                subredditIds: [subredditId]
+            )
+        ]
+    )
+    let mediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+
+    try BackupService().importBackup(
+        from: JSONEncoder().encode(backup),
+        into: context,
+        mediaStore: mediaStore
+    )
+
+    let captures = try context.fetch(FetchDescriptor<Capture>())
+    #expect(captures.count == 1)
+    #expect(captures[0].mediaRefs.isEmpty)
+}
+
+@Test @MainActor func backupImportPreservesExistingMediaRefsWhenMediaStoreProvided() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let subredditId = UUID()
+    let captureId = UUID()
+    let mediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+    let ref = try mediaStore.save(image: backupTestImage(), captureId: captureId, fileName: "present.png")
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [],
+        subreddits: [
+            BackupSubreddit(
+                id: subredditId,
+                name: "r/SwiftUI",
+                sortOrder: 0,
+                peakDaysOverride: nil,
+                peakHoursUtcOverride: nil
+            )
+        ],
+        events: [],
+        captures: [
+            BackupCapture(
+                id: captureId,
+                text: "With present media",
+                notes: nil,
+                links: [],
+                mediaRefs: [ref, "missing.png"],
+                status: .queued,
+                createdAt: Date(),
+                postedAt: nil,
+                projectId: nil,
+                subredditIds: [subredditId]
+            )
+        ]
+    )
+
+    try BackupService().importBackup(
+        from: JSONEncoder().encode(backup),
+        into: context,
+        mediaStore: mediaStore
+    )
+
+    let captures = try context.fetch(FetchDescriptor<Capture>())
+    #expect(captures.count == 1)
+    #expect(captures[0].mediaRefs == [ref])
+}
+
+private func temporaryBackupMediaRoot() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+}
+
+private func backupTestImage() -> NSImage {
+    let image = NSImage(size: NSSize(width: 32, height: 32))
+    image.lockFocus()
+    NSColor.systemBlue.setFill()
+    NSRect(x: 0, y: 0, width: 32, height: 32).fill()
+    image.unlockFocus()
+    return image
 }


### PR DESCRIPTION
## Summary
- add MediaStore.exists for checking restored attachment refs
- let backup import prune mediaRefs that do not exist in the provided media store
- wire the Backup UI import path to pass the app media store
- cover missing-ref pruning and existing-ref preservation

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME }' {} \;
- ./scripts/qa.sh