### PR TITLE
Extract popover timing presentation

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */; };
 		2C6F6A5981CBCEC7CE258964 /* BackupSettingsPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */; };
 		2D0134DEC22382048A22922F /* AppRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3769CC097D084C4E6DD34081 /* AppRuntime.swift */; };
+		2D2A3ADE0E9F1C8BE10A948A /* PopoverTimingPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA35E25161F731ACAB85FE8C /* PopoverTimingPresentation.swift */; };
 		2E04156554C7A2C39EF726A4 /* SubredditPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */; };
 		347F4FD54749869424F5CD6C /* SubredditPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
@@ -46,6 +47,7 @@
 		5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */; };
 		5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */; };
 		5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */; };
+		5F6AEF6B669D52EA62900F1A /* PopoverTimingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319AF7913AB415361A12500A /* PopoverTimingPresentationTests.swift */; };
 		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
@@ -115,6 +117,7 @@
 		288C13F7511FB37215593E12 /* CaptureMediaSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSelection.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		319AF7913AB415361A12500A /* PopoverTimingPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverTimingPresentationTests.swift; sourceTree = "<group>"; };
 		3769CC097D084C4E6DD34081 /* AppRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntime.swift; sourceTree = "<group>"; };
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
 		3BDDF7799BF55CF7FFC730BA /* peak-times.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "peak-times.json"; sourceTree = "<group>"; };
@@ -175,6 +178,7 @@
 		D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsPersistenceTests.swift; sourceTree = "<group>"; };
 		E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePersistenceActions.swift; sourceTree = "<group>"; };
 		E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarControllerTests.swift; sourceTree = "<group>"; };
+		EA35E25161F731ACAB85FE8C /* PopoverTimingPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverTimingPresentation.swift; sourceTree = "<group>"; };
 		EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceTests.swift; sourceTree = "<group>"; };
 		F2B476048A63AF84F93F85A4 /* EdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTests.swift; sourceTree = "<group>"; };
 		FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpersTests.swift; sourceTree = "<group>"; };
@@ -216,6 +220,7 @@
 				9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */,
 				3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */,
 				5CEA78C5D7E701E78352BF98 /* PopoverCaptureFilteringTests.swift */,
+				319AF7913AB415361A12500A /* PopoverTimingPresentationTests.swift */,
 				654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */,
 				A6A9BB4582DA895A6C18C321 /* ResourcePackagingTests.swift */,
 				4B3E99F0F230325C051A02E1 /* RRuleEdgeCaseTests.swift */,
@@ -240,6 +245,7 @@
 				8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */,
 				56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */,
 				8C930E623DE20A82D94D4B3A /* PopoverCaptureFiltering.swift */,
+				EA35E25161F731ACAB85FE8C /* PopoverTimingPresentation.swift */,
 				5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */,
 				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
@@ -461,6 +467,7 @@
 				AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */,
 				7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */,
 				E91A5DDE67643B2D081C9340 /* PopoverCaptureFilteringTests.swift in Sources */,
+				5F6AEF6B669D52EA62900F1A /* PopoverTimingPresentationTests.swift in Sources */,
 				5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */,
 				14304111A5BCA18BADD782F8 /* RRuleEdgeCaseTests.swift in Sources */,
 				041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */,
@@ -513,6 +520,7 @@
 				A45C2634E04FC8E88CD17018 /* PopoverContentActions.swift in Sources */,
 				F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
+				2D2A3ADE0E9F1C8BE10A948A /* PopoverTimingPresentation.swift in Sources */,
 				3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,

--- a/Sources/Utilities/PopoverTimingPresentation.swift
+++ b/Sources/Utilities/PopoverTimingPresentation.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+enum PopoverTimingPresentation {
+    static func activeEvents(from events: [SubredditEvent]) -> [SubredditEvent] {
+        events.filter(\.isActive)
+    }
+
+    static func captureTimingSignature(from captures: [Capture]) -> [String] {
+        captures.map { capture in
+            let subIds = capture.subreddits.map(\.id.uuidString).sorted().joined(separator: ",")
+            return "\(capture.id.uuidString):\(capture.status.rawValue):\(subIds)"
+        }
+    }
+
+    static func eventTimingSignature(from events: [SubredditEvent]) -> [String] {
+        events.map { event in
+            [
+                event.id.uuidString,
+                event.isActive.description,
+                event.rrule ?? "",
+                event.oneOffDate?.timeIntervalSince1970.description ?? "",
+                event.recurrenceHour?.description ?? "",
+                event.recurrenceMinute?.description ?? "",
+                event.recurrenceTimeZoneIdentifier ?? "",
+                event.reminderLeadMinutes.description,
+                event.subreddit?.id.uuidString ?? ""
+            ].joined(separator: "|")
+        }.sorted()
+    }
+
+    static func subredditTimingSignature(from subreddits: [Subreddit]) -> [String] {
+        subreddits.map { subreddit in
+            [
+                subreddit.id.uuidString,
+                subreddit.peakDaysOverride?.joined(separator: ",") ?? "",
+                subreddit.peakHoursUtcOverride?.map(String.init).joined(separator: ",") ?? ""
+            ].joined(separator: "|")
+        }
+    }
+
+    static func urgencyBySubredditId(from windows: [TimingEngine.UpcomingWindow]) -> [UUID: UrgencyLevel] {
+        var result: [UUID: UrgencyLevel] = [:]
+        for window in windows {
+            guard let subId = window.event.subreddit?.id else { continue }
+            if window.urgency > (result[subId] ?? .none) { result[subId] = window.urgency }
+        }
+        return result
+    }
+
+    static func footerText(
+        showPosted: Bool,
+        queuedCaptureCount: Int,
+        postedCaptureCount: Int,
+        upcomingEventCount: Int
+    ) -> String {
+        if showPosted {
+            return "\(postedCaptureCount) posted"
+        }
+        return "\(queuedCaptureCount) capture\(queuedCaptureCount == 1 ? "" : "s") · " +
+            "\(upcomingEventCount) event\(upcomingEventCount == 1 ? "" : "s") upcoming"
+    }
+}

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -20,7 +20,7 @@ struct PopoverContentView: View {
     @State var toastTask: Task<Void, Never>?
     @State private var showPosted: Bool = false
 
-    private var activeEvents: [SubredditEvent] { allEvents.filter(\.isActive) }
+    private var activeEvents: [SubredditEvent] { PopoverTimingPresentation.activeEvents(from: allEvents) }
     private var queuedCaptures: [Capture] { PopoverCaptureFiltering.queuedCaptures(from: captures) }
     private var postedCaptures: [Capture] { PopoverCaptureFiltering.postedCaptures(from: captures) }
     private var displayedCaptures: [Capture] {
@@ -70,36 +70,15 @@ struct PopoverContentView: View {
     }
 
     private var captureTimingSignature: [String] {
-        captures.map { capture in
-            let subIds = capture.subreddits.map(\.id.uuidString).sorted().joined(separator: ",")
-            return "\(capture.id.uuidString):\(capture.status.rawValue):\(subIds)"
-        }
+        PopoverTimingPresentation.captureTimingSignature(from: captures)
     }
 
     private var eventTimingSignature: [String] {
-        allEvents.map { event in
-            [
-                event.id.uuidString,
-                event.isActive.description,
-                event.rrule ?? "",
-                event.oneOffDate?.timeIntervalSince1970.description ?? "",
-                event.recurrenceHour?.description ?? "",
-                event.recurrenceMinute?.description ?? "",
-                event.recurrenceTimeZoneIdentifier ?? "",
-                event.reminderLeadMinutes.description,
-                event.subreddit?.id.uuidString ?? ""
-            ].joined(separator: "|")
-        }.sorted()
+        PopoverTimingPresentation.eventTimingSignature(from: allEvents)
     }
 
     private var subredditTimingSignature: [String] {
-        subreddits.map { subreddit in
-            [
-                subreddit.id.uuidString,
-                subreddit.peakDaysOverride?.joined(separator: ",") ?? "",
-                subreddit.peakHoursUtcOverride?.map(String.init).joined(separator: ",") ?? ""
-            ].joined(separator: "|")
-        }
+        PopoverTimingPresentation.subredditTimingSignature(from: subreddits)
     }
 
     private func refreshTiming() {
@@ -109,12 +88,7 @@ struct PopoverContentView: View {
     // MARK: - Urgency
 
     private var urgencyBySubredditId: [UUID: UrgencyLevel] {
-        var result: [UUID: UrgencyLevel] = [:]
-        for w in timingEngine.upcomingWindows {
-            guard let subId = w.event.subreddit?.id else { continue }
-            if w.urgency > (result[subId] ?? .none) { result[subId] = w.urgency }
-        }
-        return result
+        PopoverTimingPresentation.urgencyBySubredditId(from: timingEngine.upcomingWindows)
     }
 
     // MARK: - Content
@@ -254,10 +228,12 @@ struct PopoverContentView: View {
     }
 
     private var footer: some View {
-        let text: String = showPosted
-            ? "\(postedCaptures.count) posted"
-            : "\(queuedCaptures.count) capture\(queuedCaptures.count == 1 ? "" : "s") · " +
-              "\(timingEngine.upcomingWindows.count) event\(timingEngine.upcomingWindows.count == 1 ? "" : "s") upcoming"
+        let text = PopoverTimingPresentation.footerText(
+            showPosted: showPosted,
+            queuedCaptureCount: queuedCaptures.count,
+            postedCaptureCount: postedCaptures.count,
+            upcomingEventCount: timingEngine.upcomingWindows.count
+        )
         return VStack(spacing: 0) {
             Divider()
             Text(text).font(.system(size: 10)).foregroundStyle(.secondary).padding(.vertical, 8)

--- a/Tests/RedditReminderTests/PopoverTimingPresentationTests.swift
+++ b/Tests/RedditReminderTests/PopoverTimingPresentationTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import RedditReminder
+
+@Test @MainActor func popoverTimingPresentationFiltersActiveEvents() {
+    let subreddit = Subreddit(name: "r/Swift")
+    let active = SubredditEvent(name: "Active", subreddit: subreddit, oneOffDate: Date().addingTimeInterval(3600))
+    let inactive = SubredditEvent(
+        name: "Inactive",
+        subreddit: subreddit,
+        oneOffDate: Date().addingTimeInterval(3600),
+        isActive: false
+    )
+
+    #expect(PopoverTimingPresentation.activeEvents(from: [active, inactive]).map(\.id) == [active.id])
+}
+
+@Test @MainActor func popoverTimingPresentationCaptureSignatureTracksStatusAndSortedSubreddits() {
+    let swift = Subreddit(name: "r/Swift")
+    let mac = Subreddit(name: "r/macOS")
+    let capture = Capture(text: "Draft", subreddits: [swift, mac])
+    let queuedSignature = PopoverTimingPresentation.captureTimingSignature(from: [capture])[0]
+
+    capture.markAsPosted()
+    let postedSignature = PopoverTimingPresentation.captureTimingSignature(from: [capture])[0]
+
+    #expect(queuedSignature.contains(capture.id.uuidString))
+    #expect(queuedSignature.contains(CaptureStatus.queued.rawValue))
+    #expect(postedSignature.contains(CaptureStatus.posted.rawValue))
+    #expect(queuedSignature != postedSignature)
+    #expect(queuedSignature.contains([swift.id.uuidString, mac.id.uuidString].sorted().joined(separator: ",")))
+}
+
+@Test @MainActor func popoverTimingPresentationEventSignatureSortsAndTracksScheduleFields() {
+    let subreddit = Subreddit(name: "r/Swift")
+    let first = SubredditEvent(
+        name: "First",
+        subreddit: subreddit,
+        rrule: "FREQ=WEEKLY;BYDAY=MO",
+        recurrenceHour: 10,
+        recurrenceMinute: 30,
+        recurrenceTimeZoneIdentifier: "America/Phoenix",
+        reminderLeadMinutes: 15
+    )
+    let second = SubredditEvent(
+        name: "Second",
+        subreddit: subreddit,
+        oneOffDate: Date(timeIntervalSince1970: 100),
+        reminderLeadMinutes: 60,
+        isActive: false
+    )
+
+    let signatures = PopoverTimingPresentation.eventTimingSignature(from: [second, first])
+
+    #expect(signatures == signatures.sorted())
+    #expect(signatures.contains { $0.contains(first.id.uuidString) && $0.contains("FREQ=WEEKLY;BYDAY=MO") })
+    #expect(signatures.contains { $0.contains(second.id.uuidString) && $0.contains("false") })
+}
+
+@Test @MainActor func popoverTimingPresentationSubredditSignatureTracksOverrides() {
+    let subreddit = Subreddit(
+        name: "r/Swift",
+        peakDaysOverride: ["mon", "fri"],
+        peakHoursUtcOverride: [15, 18]
+    )
+
+    let signature = PopoverTimingPresentation.subredditTimingSignature(from: [subreddit])[0]
+
+    #expect(signature.contains(subreddit.id.uuidString))
+    #expect(signature.contains("mon,fri"))
+    #expect(signature.contains("15,18"))
+}
+
+@Test @MainActor func popoverTimingPresentationUsesHighestUrgencyPerSubreddit() {
+    let swift = Subreddit(name: "r/Swift")
+    let mac = Subreddit(name: "r/macOS")
+    let first = SubredditEvent(name: "First", subreddit: swift, oneOffDate: Date().addingTimeInterval(3600))
+    let second = SubredditEvent(name: "Second", subreddit: swift, oneOffDate: Date().addingTimeInterval(7200))
+    let third = SubredditEvent(name: "Third", subreddit: mac, oneOffDate: Date().addingTimeInterval(7200))
+    let windows = [
+        window(event: first, urgency: .low),
+        window(event: second, urgency: .high),
+        window(event: third, urgency: .medium)
+    ]
+
+    let urgency = PopoverTimingPresentation.urgencyBySubredditId(from: windows)
+
+    #expect(urgency[swift.id] == .high)
+    #expect(urgency[mac.id] == .medium)
+}
+
+@Test func popoverTimingPresentationFormatsFooterText() {
+    #expect(PopoverTimingPresentation.footerText(
+        showPosted: false,
+        queuedCaptureCount: 1,
+        postedCaptureCount: 4,
+        upcomingEventCount: 1
+    ) == "1 capture · 1 event upcoming")
+    #expect(PopoverTimingPresentation.footerText(
+        showPosted: false,
+        queuedCaptureCount: 2,
+        postedCaptureCount: 4,
+        upcomingEventCount: 3
+    ) == "2 captures · 3 events upcoming")
+    #expect(PopoverTimingPresentation.footerText(
+        showPosted: true,
+        queuedCaptureCount: 2,
+        postedCaptureCount: 4,
+        upcomingEventCount: 3
+    ) == "4 posted")
+}
+
+@MainActor
+private func window(event: SubredditEvent, urgency: UrgencyLevel) -> TimingEngine.UpcomingWindow {
+    let eventDate = Date().addingTimeInterval(3600)
+    return TimingEngine.UpcomingWindow(
+        event: event,
+        eventDate: eventDate,
+        notificationFireDate: eventDate,
+        urgency: urgency,
+        matchingCaptureCount: 0
+    )
+}


### PR DESCRIPTION
## Summary
- Move popover timing signatures, active-event filtering, urgency mapping, and footer text formatting into PopoverTimingPresentation
- Add direct unit coverage for timing signatures, urgency selection, active events, and footer copy
- Reduce PopoverContentView from 268 to 244 lines

## Headless verification
- xcodegen generate
- git diff --check
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME ": " NR " lines" }' {} \;

GUI QA was intentionally skipped because it opens the menu-bar UI.