### PR TITLE
Split popover chrome views

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		5F6AEF6B669D52EA62900F1A /* PopoverTimingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319AF7913AB415361A12500A /* PopoverTimingPresentationTests.swift */; };
 		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
+		690C38B0C986D2C9B9F268D5 /* PopoverChromeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
 		6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */; };
 		70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */; };
@@ -183,6 +184,7 @@
 		C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentActions.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
 		D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsPersistenceTests.swift; sourceTree = "<group>"; };
+		E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverChromeViews.swift; sourceTree = "<group>"; };
 		E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePersistenceActions.swift; sourceTree = "<group>"; };
 		E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarControllerTests.swift; sourceTree = "<group>"; };
 		EA35E25161F731ACAB85FE8C /* PopoverTimingPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverTimingPresentation.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 				ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */,
 				CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */,
 				4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */,
+				E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */,
 				C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */,
 				BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */,
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
@@ -532,6 +535,7 @@
 				5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */,
 				C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */,
 				03D259AE4EF62D35955D2D09 /* PopoverCaptureFiltering.swift in Sources */,
+				690C38B0C986D2C9B9F268D5 /* PopoverChromeViews.swift in Sources */,
 				A45C2634E04FC8E88CD17018 /* PopoverContentActions.swift in Sources */,
 				F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,

--- a/Sources/Views/PopoverChromeViews.swift
+++ b/Sources/Views/PopoverChromeViews.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct PopoverToastView: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(AppColors.redditOrange.opacity(0.9))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.top, 48)
+            .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}
+
+struct PopoverHeaderView: View {
+    @Binding var showPosted: Bool
+    let onOpenPreferences: () -> Void
+    let onNewCapture: () -> Void
+
+    var body: some View {
+        HStack {
+            Text("RedditReminder")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+            Spacer()
+            HStack(spacing: 2) {
+                toggleButton("Queue", active: !showPosted) { showPosted = false }
+                toggleButton("Posted", active: showPosted) { showPosted = true }
+            }
+            Spacer()
+            Button(action: onOpenPreferences) {
+                Image(systemName: "gearshape").font(.system(size: 11)).foregroundStyle(.secondary)
+            }.buttonStyle(.plain)
+            Button(action: onNewCapture) {
+                Image(systemName: "plus").font(.system(size: 14, weight: .light))
+                    .foregroundStyle(AppColors.redditOrange)
+            }.buttonStyle(.plain).padding(.leading, 8)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    private func toggleButton(_ title: String, active: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 10, weight: active ? .semibold : .medium))
+                .foregroundStyle(active ? AppColors.redditOrange : .secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(active ? AppColors.redditOrange.opacity(0.1) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }.buttonStyle(.plain)
+    }
+}
+
+struct PopoverSearchBarView: View {
+    @Binding var searchText: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+            TextField("Search captures", text: $searchText)
+                .font(.system(size: 11))
+                .textFieldStyle(.plain)
+            if !searchText.isEmpty {
+                Button(action: { searchText = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(.quaternary.opacity(0.25))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+}
+
+struct PopoverFilterBarView: View {
+    let subredditName: String?
+    let onClear: () -> Void
+
+    var body: some View {
+        HStack {
+            if let subredditName {
+                Text("Filtered: \(subredditName)")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(AppColors.redditOrange)
+            }
+            Spacer()
+            Button("Show all", action: onClear)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(AppColors.redditOrange.opacity(0.06))
+        .overlay(alignment: .bottom) { Divider() }
+    }
+}
+
+struct PopoverFooterView: View {
+    let text: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            Text(text)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 8)
+        }
+    }
+}

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -43,12 +43,7 @@ struct PopoverContentView: View {
         }
         .overlay(alignment: .top) {
             if let message = toastMessage {
-                Text(message).font(.system(size: 11, weight: .medium)).foregroundStyle(.white)
-                    .padding(.horizontal, 12).padding(.vertical, 6)
-                    .background(AppColors.redditOrange.opacity(0.9))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .padding(.top, 48)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                PopoverToastView(message: message)
             }
         }
         .background(AppColors.popoverBg)
@@ -155,76 +150,24 @@ struct PopoverContentView: View {
     // MARK: - Header / Footer / Empty states
 
     private var header: some View {
-        HStack {
-            Text("RedditReminder").font(.system(size: 13, weight: .semibold)).foregroundStyle(.primary)
-            Spacer()
-            HStack(spacing: 2) {
-                toggleButton("Queue", active: !showPosted) { showPosted = false }
-                toggleButton("Posted", active: showPosted) { showPosted = true }
-            }
-            Spacer()
-            Button(action: openPreferences) {
-                Image(systemName: "gearshape").font(.system(size: 11)).foregroundStyle(.secondary)
-            }.buttonStyle(.plain)
-            Button(action: openNewCapture) {
-                Image(systemName: "plus").font(.system(size: 14, weight: .light))
-                    .foregroundStyle(AppColors.redditOrange)
-            }.buttonStyle(.plain).padding(.leading, 8)
-        }
-        .padding(.horizontal, 16).padding(.vertical, 12)
-        .overlay(alignment: .bottom) { Divider() }
-    }
-
-    private func toggleButton(_ title: String, active: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 10, weight: active ? .semibold : .medium))
-                .foregroundStyle(active ? AppColors.redditOrange : .secondary)
-                .padding(.horizontal, 8).padding(.vertical, 3)
-                .background(active ? AppColors.redditOrange.opacity(0.1) : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-        }.buttonStyle(.plain)
+        PopoverHeaderView(
+            showPosted: $showPosted,
+            onOpenPreferences: openPreferences,
+            onNewCapture: openNewCapture
+        )
     }
 
     private var searchBar: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-            TextField("Search captures", text: $searchText)
-                .font(.system(size: 11))
-                .textFieldStyle(.plain)
-            if !searchText.isEmpty {
-                Button(action: { searchText = "" }) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(.quaternary.opacity(0.25))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .overlay(alignment: .bottom) { Divider() }
+        PopoverSearchBarView(searchText: $searchText)
     }
 
     private var filterBar: some View {
-        HStack {
-            if let sub = subreddits.first(where: { $0.id == filterSubredditId }) {
-                Text("Filtered: \(sub.name)").font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(AppColors.redditOrange)
+        PopoverFilterBarView(
+            subredditName: subreddits.first(where: { $0.id == filterSubredditId })?.name,
+            onClear: {
+                withAnimation(.easeInOut(duration: 0.15)) { filterSubredditId = nil }
             }
-            Spacer()
-            Button("Show all") { withAnimation(.easeInOut(duration: 0.15)) { filterSubredditId = nil } }
-                .font(.system(size: 10, weight: .medium)).foregroundStyle(.secondary).buttonStyle(.plain)
-        }
-        .padding(.horizontal, 16).padding(.vertical, 6)
-        .background(AppColors.redditOrange.opacity(0.06))
-        .overlay(alignment: .bottom) { Divider() }
+        )
     }
 
     private var footer: some View {
@@ -234,10 +177,7 @@ struct PopoverContentView: View {
             postedCaptureCount: postedCaptures.count,
             upcomingEventCount: timingEngine.upcomingWindows.count
         )
-        return VStack(spacing: 0) {
-            Divider()
-            Text(text).font(.system(size: 10)).foregroundStyle(.secondary).padding(.vertical, 8)
-        }
+        return PopoverFooterView(text: text)
     }
 
     // Actions live in PopoverContentActions.swift.


### PR DESCRIPTION
## Summary
- Move popover toast, header, search bar, filter bar, and footer chrome into focused SwiftUI components
- Keep PopoverContentView focused on state, query data, and list/content composition
- Reduce PopoverContentView from 244 to 184 lines

## Headless verification
- xcodegen generate
- git diff --check
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- find Sources -name '*.swift' -exec awk 'END { if (NR > 300) print FILENAME ": " NR " lines" }' {} \;

GUI QA was intentionally skipped because it opens the menu-bar UI.