### PR TITLE
Harden channels lead-time setting

### DIFF
--- a/Sources/Views/ChannelsView.swift
+++ b/Sources/Views/ChannelsView.swift
@@ -12,6 +12,7 @@ struct ChannelsTabView: View {
     @State private var newSubredditName = ""
     @State private var nameValidationMessage: String?
     @State private var draggingSubreddit: Subreddit?
+    @AppStorage(SettingsKey.defaultLeadTimeMinutes) private var defaultLeadTimeMinutes: Int = 60
 
     var body: some View {
         VStack(spacing: 0) {
@@ -123,10 +124,6 @@ struct ChannelsTabView: View {
             modelContext: modelContext,
             notificationService: notificationService
         )
-    }
-
-    private var defaultLeadTimeMinutes: Int {
-        UserDefaults.standard.object(forKey: SettingsKey.defaultLeadTimeMinutes) as? Int ?? 60
     }
 
 }


### PR DESCRIPTION
## Summary
- replace the direct UserDefaults.standard read in ChannelsTabView with @AppStorage
- keep channel add/sync behavior aligned with the shared default lead-time setting used by preferences

## Headless verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- git diff --check
- find Sources -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true

GUI QA skipped because it opens the menu-bar UI.