### PR TITLE
Harden capture default project setting

### DIFF
--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -24,6 +24,7 @@ struct CaptureWindowView: View {
     @State private var existingMediaRefs: [String] = []
     @State private var removedMediaRefs: [String] = []
     @State private var showPreview: Bool = false
+    @AppStorage(SettingsKey.defaultProjectId) private var defaultProjectId: String = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -195,8 +196,7 @@ struct CaptureWindowView: View {
     private func populateFromMode() {
         switch mode {
         case .create:
-            if let defaultId = UserDefaults.standard.string(forKey: SettingsKey.defaultProjectId),
-               let uuid = UUID(uuidString: defaultId) {
+            if let uuid = UUID(uuidString: defaultProjectId) {
                 selectedProject = projects.first { $0.id == uuid }
             }
         case .edit(let capture):


### PR DESCRIPTION
## Summary
- replace the direct UserDefaults.standard default-project read in CaptureWindowView with @AppStorage
- keep new capture project preselection aligned with the shared preferences setting

## Headless verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- git diff --check
- find Sources -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true

GUI QA skipped because it opens the menu-bar UI.