### PR TITLE
Harden QA fixture defaults

### DIFF
--- a/Sources/Utilities/QAFixtures.swift
+++ b/Sources/Utilities/QAFixtures.swift
@@ -3,8 +3,8 @@ import SwiftData
 
 enum QAFixtures {
   @MainActor
-  static func seed(context: ModelContext) {
-    clearAll(context: context)
+  static func seed(context: ModelContext, defaults: UserDefaults = .standard) {
+    clearAll(context: context, defaults: defaults)
 
     // 4 subreddits — some with peak overrides, some without
     let sideProject = Subreddit(name: "r/SideProject", sortOrder: 0)
@@ -133,7 +133,7 @@ enum QAFixtures {
     context.insert(farOut)
 
     // Seed default project preference
-    UserDefaults.standard.set(project.id.uuidString, forKey: SettingsKey.defaultProjectId)
+    defaults.set(project.id.uuidString, forKey: SettingsKey.defaultProjectId)
 
     do {
       try context.save()
@@ -144,14 +144,14 @@ enum QAFixtures {
   }
 
   @MainActor
-  static func clearAll(context: ModelContext) {
+  static func clearAll(context: ModelContext, defaults: UserDefaults = .standard) {
     do {
       try context.delete(model: Capture.self)
       try context.delete(model: SubredditEvent.self)
       try context.delete(model: Project.self)
       try context.delete(model: Subreddit.self)
       try context.save()
-      UserDefaults.standard.removeObject(forKey: SettingsKey.defaultProjectId)
+      defaults.removeObject(forKey: SettingsKey.defaultProjectId)
       NSLog("RedditReminder: all data cleared")
     } catch {
       NSLog("RedditReminder: failed to clear data: \(error)")

--- a/Tests/RedditReminderTests/EdgeCaseTests.swift
+++ b/Tests/RedditReminderTests/EdgeCaseTests.swift
@@ -11,6 +11,21 @@ private func makeContainer() throws -> ModelContainer {
     )
 }
 
+private struct TemporaryDefaults {
+    let defaults: UserDefaults
+    let suiteName: String
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+private func makeTemporaryDefaults() -> TemporaryDefaults {
+    let suiteName = "EdgeCaseTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    return TemporaryDefaults(defaults: defaults, suiteName: suiteName)
+}
+
 // MARK: - DefaultSubreddits seeding
 
 @Test @MainActor func seedIfEmptyInsertsDefaults() throws {
@@ -168,22 +183,31 @@ private func makeContainer() throws -> ModelContainer {
 @Test @MainActor func qaFixturesSeedCreatesExpectedData() throws {
     let container = try makeContainer()
     let context = ModelContext(container)
+    let temporaryDefaults = makeTemporaryDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
 
-    QAFixtures.seed(context: context)
+    QAFixtures.seed(context: context, defaults: defaults)
 
     #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 4)
     #expect(try context.fetchCount(FetchDescriptor<Project>()) == 3)
     #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 8)
     #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 3)
+    #expect(defaults.string(forKey: SettingsKey.defaultProjectId) != nil)
 }
 
 @Test @MainActor func qaFixturesClearAllOnEmptyDoesNotCrash() throws {
     let container = try makeContainer()
     let context = ModelContext(container)
+    let temporaryDefaults = makeTemporaryDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    defaults.set("project-id", forKey: SettingsKey.defaultProjectId)
 
-    QAFixtures.clearAll(context: context)
+    QAFixtures.clearAll(context: context, defaults: defaults)
 
     #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 0)
+    #expect(defaults.object(forKey: SettingsKey.defaultProjectId) == nil)
 }
 
 // MARK: - Model defaults


### PR DESCRIPTION
## Summary
- inject UserDefaults into QAFixtures seed/clear helpers while keeping .standard as the app default
- isolate QA fixture tests from UserDefaults.standard
- assert QA fixture default-project preference writes and clears through the injected suite

## Headless verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- git diff --check
- find Sources -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true

GUI QA skipped because it opens the menu-bar UI.