### PR TITLE
Harden backup duplicate ID validation

### DIFF
--- a/Sources/Services/BackupService.swift
+++ b/Sources/Services/BackupService.swift
@@ -115,6 +115,11 @@ struct BackupService {
     }
 
     private func validate(_ backup: AppBackup) throws {
+        try validateUniqueIds(backup.projects.map(\.id))
+        try validateUniqueIds(backup.subreddits.map(\.id))
+        try validateUniqueIds(backup.events.map(\.id))
+        try validateUniqueIds(backup.captures.map(\.id))
+
         let projectIds = Set(backup.projects.map(\.id))
         let subredditIds = Set(backup.subreddits.map(\.id))
         for event in backup.events {
@@ -128,6 +133,15 @@ struct BackupService {
             }
             for subredditId in capture.subredditIds where !subredditIds.contains(subredditId) {
                 throw BackupError.missingRelationship(subredditId.uuidString)
+            }
+        }
+    }
+
+    private func validateUniqueIds(_ ids: [UUID]) throws {
+        var seen: Set<UUID> = []
+        for id in ids {
+            guard seen.insert(id).inserted else {
+                throw BackupError.duplicateId(id.uuidString)
             }
         }
     }

--- a/Sources/Services/BackupTypes.swift
+++ b/Sources/Services/BackupTypes.swift
@@ -3,6 +3,7 @@ import Foundation
 enum BackupError: Error, Equatable, LocalizedError {
     case unsupportedVersion(Int)
     case missingRelationship(String)
+    case duplicateId(String)
 
     var errorDescription: String? {
         switch self {
@@ -10,6 +11,8 @@ enum BackupError: Error, Equatable, LocalizedError {
             return "Unsupported backup version \(version)."
         case .missingRelationship(let id):
             return "Backup references missing item \(id)."
+        case .duplicateId(let id):
+            return "Backup contains duplicate item \(id)."
         }
     }
 }

--- a/Tests/RedditReminderTests/BackupServiceTests.swift
+++ b/Tests/RedditReminderTests/BackupServiceTests.swift
@@ -142,6 +142,80 @@ private func makeBackupContainer() throws -> ModelContainer {
     #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 1)
 }
 
+@Test @MainActor func backupImportRejectsDuplicateProjectIdsBeforeClearingData() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    context.insert(Project(name: "Existing"))
+    try context.save()
+
+    let duplicateId = UUID()
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [
+            BackupProject(
+                id: duplicateId,
+                name: "First",
+                projectDescription: nil,
+                color: nil,
+                archived: false,
+                createdAt: Date()
+            ),
+            BackupProject(
+                id: duplicateId,
+                name: "Second",
+                projectDescription: nil,
+                color: nil,
+                archived: false,
+                createdAt: Date()
+            )
+        ],
+        subreddits: [],
+        events: [],
+        captures: []
+    )
+
+    #expect(throws: BackupError.duplicateId(duplicateId.uuidString)) {
+        try BackupService().importBackup(from: JSONEncoder().encode(backup), into: context)
+    }
+    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 1)
+}
+
+@Test @MainActor func backupImportRejectsDuplicateSubredditIdsBeforeClearingData() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    context.insert(Subreddit(name: "r/Existing"))
+    try context.save()
+
+    let duplicateId = UUID()
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [],
+        subreddits: [
+            BackupSubreddit(
+                id: duplicateId,
+                name: "r/First",
+                sortOrder: 0,
+                peakDaysOverride: nil,
+                peakHoursUtcOverride: nil
+            ),
+            BackupSubreddit(
+                id: duplicateId,
+                name: "r/Second",
+                sortOrder: 1,
+                peakDaysOverride: nil,
+                peakHoursUtcOverride: nil
+            )
+        ],
+        events: [],
+        captures: []
+    )
+
+    #expect(throws: BackupError.duplicateId(duplicateId.uuidString)) {
+        try BackupService().importBackup(from: JSONEncoder().encode(backup), into: context)
+    }
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 1)
+}
+
 @Test @MainActor func backupImportRejectsCaptureMissingProjectBeforeClearingData() throws {
     let container = try makeBackupContainer()
     let context = ModelContext(container)


### PR DESCRIPTION
## Summary
- reject duplicate IDs in backup projects, subreddits, events, and captures before import mutates existing data
- add a localized duplicate-ID backup error
- cover duplicate project/subreddit imports preserving existing data

## Headless verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- git diff --check
- find Sources -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true

GUI QA skipped because it opens the menu-bar UI.