### PR TITLE
fix: validate capture links

### DIFF
--- a/Sources/Utilities/CaptureHelpers.swift
+++ b/Sources/Utilities/CaptureHelpers.swift
@@ -6,9 +6,17 @@ enum CaptureHelpers {
     static func normalizeLink(_ input: String) -> String? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://")
-            ? trimmed
-            : "https://\(trimmed)"
+        guard trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return nil }
+
+        let candidate = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard let url = URL(string: candidate),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host != nil,
+              url.user == nil,
+              url.password == nil else { return nil }
+
+        return candidate
     }
 
     /// Validates that a capture form has the minimum required fields.

--- a/Tests/RedditReminderTests/CaptureHelpersTests.swift
+++ b/Tests/RedditReminderTests/CaptureHelpersTests.swift
@@ -33,6 +33,20 @@ import SwiftData
     #expect(CaptureHelpers.normalizeLink("reddit.com/r/SwiftUI") == "https://reddit.com/r/SwiftUI")
 }
 
+@Test func normalizeLinkRejectsUnsupportedSchemes() {
+    #expect(CaptureHelpers.normalizeLink("ftp://example.com/file.zip") == nil)
+    #expect(CaptureHelpers.normalizeLink("mailto:test@example.com") == nil)
+}
+
+@Test func normalizeLinkRejectsInternalWhitespace() {
+    #expect(CaptureHelpers.normalizeLink("https://example.com/bad path") == nil)
+    #expect(CaptureHelpers.normalizeLink("bad domain.com") == nil)
+}
+
+@Test func normalizeLinkRejectsMissingHost() {
+    #expect(CaptureHelpers.normalizeLink("https://") == nil)
+}
+
 // MARK: - canSave
 
 @Test func canSaveRequiresNonEmptyTextAndSubreddits() {


### PR DESCRIPTION
## Summary
- reject malformed capture links with internal whitespace or a missing host
- reject unsupported schemes and userinfo-style malformed inputs
- add focused coverage for invalid schemes, whitespace, and missing-host links

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
