### PR TITLE
test: stabilize timing refresh tests

### DIFF
--- a/Sources/Services/TimingEngine.swift
+++ b/Sources/Services/TimingEngine.swift
@@ -52,8 +52,7 @@ final class TimingEngine {
         return nil
     }
 
-    func refresh(events: [SubredditEvent], captures: [Capture]) {
-        let now = Date()
+    func refresh(events: [SubredditEvent], captures: [Capture], now: Date = Date()) {
         let horizon = now.addingTimeInterval(24 * 3600)
 
         // Pre-index: count queued captures per subreddit ID once,

--- a/Tests/RedditReminderTests/ModelEdgeCaseTests.swift
+++ b/Tests/RedditReminderTests/ModelEdgeCaseTests.swift
@@ -3,6 +3,8 @@ import Testing
 import SwiftData
 @testable import RedditReminder
 
+private let edgeCaseNow = Date(timeIntervalSince1970: 1_700_000_000)
+
 @Test func degenerateEventIsNotRecurring() {
     let sub = Subreddit(name: "r/Test")
     let event = SubredditEvent(name: "Empty", subreddit: sub)
@@ -23,7 +25,7 @@ import SwiftData
     let event = SubredditEvent(name: "Empty", subreddit: sub)
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [])
+    engine.refresh(events: [event], captures: [], now: edgeCaseNow)
     #expect(engine.upcomingWindows.isEmpty)
 }
 

--- a/Tests/RedditReminderTests/TimingEngineRefreshTests.swift
+++ b/Tests/RedditReminderTests/TimingEngineRefreshTests.swift
@@ -2,9 +2,11 @@ import Foundation
 import Testing
 @testable import RedditReminder
 
+private let refreshNow = Date(timeIntervalSince1970: 1_700_000_000)
+
 @Test @MainActor func refreshWithNoEventsProducesEmpty() {
     let engine = TimingEngine()
-    engine.refresh(events: [], captures: [])
+    engine.refresh(events: [], captures: [], now: refreshNow)
     #expect(engine.upcomingWindows.isEmpty)
 }
 
@@ -13,11 +15,11 @@ import Testing
     let event = SubredditEvent(
         name: "Soon",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(3600)
+        oneOffDate: refreshNow.addingTimeInterval(3600)
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [])
+    engine.refresh(events: [event], captures: [], now: refreshNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows[0].matchingCaptureCount == 0)
@@ -28,17 +30,17 @@ import Testing
     let active = SubredditEvent(
         name: "Active",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(3600)
+        oneOffDate: refreshNow.addingTimeInterval(3600)
     )
     let inactive = SubredditEvent(
         name: "Inactive",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(7200),
+        oneOffDate: refreshNow.addingTimeInterval(7200),
         isActive: false
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [active, inactive], captures: [])
+    engine.refresh(events: [active, inactive], captures: [], now: refreshNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows[0].event.name == "Active")
@@ -49,16 +51,16 @@ import Testing
     let within = SubredditEvent(
         name: "Within",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(12 * 3600)
+        oneOffDate: refreshNow.addingTimeInterval(12 * 3600)
     )
     let beyond = SubredditEvent(
         name: "Beyond",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(25 * 3600)
+        oneOffDate: refreshNow.addingTimeInterval(25 * 3600)
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [within, beyond], captures: [])
+    engine.refresh(events: [within, beyond], captures: [], now: refreshNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows[0].event.name == "Within")
@@ -69,11 +71,11 @@ import Testing
     let expired = SubredditEvent(
         name: "Expired",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(-3600)
+        oneOffDate: refreshNow.addingTimeInterval(-3600)
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [expired], captures: [])
+    engine.refresh(events: [expired], captures: [], now: refreshNow)
 
     #expect(engine.upcomingWindows.isEmpty)
 }
@@ -83,14 +85,14 @@ import Testing
     let event = SubredditEvent(
         name: "Orphan",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(3600)
+        oneOffDate: refreshNow.addingTimeInterval(3600)
     )
     event.subreddit = nil
 
     let capture = Capture(text: "Has captures", subreddits: [sub])
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [capture])
+    engine.refresh(events: [event], captures: [capture], now: refreshNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows[0].matchingCaptureCount == 0)
@@ -101,16 +103,16 @@ import Testing
     let oneOff = SubredditEvent(
         name: "Launch Day",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(6 * 3600)
+        oneOffDate: refreshNow.addingTimeInterval(6 * 3600)
     )
     let alsoOneOff = SubredditEvent(
         name: "Second Event",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(12 * 3600)
+        oneOffDate: refreshNow.addingTimeInterval(12 * 3600)
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [oneOff, alsoOneOff], captures: [])
+    engine.refresh(events: [oneOff, alsoOneOff], captures: [], now: refreshNow)
 
     #expect(engine.upcomingWindows.count == 2)
 }
@@ -118,13 +120,13 @@ import Testing
 @Test @MainActor func refreshCountsMultiSubredditCapture() {
     let sub1 = Subreddit(name: "r/A")
     let sub2 = Subreddit(name: "r/B")
-    let event1 = SubredditEvent(name: "E1", subreddit: sub1, oneOffDate: Date().addingTimeInterval(3600))
-    let event2 = SubredditEvent(name: "E2", subreddit: sub2, oneOffDate: Date().addingTimeInterval(7200))
+    let event1 = SubredditEvent(name: "E1", subreddit: sub1, oneOffDate: refreshNow.addingTimeInterval(3600))
+    let event2 = SubredditEvent(name: "E2", subreddit: sub2, oneOffDate: refreshNow.addingTimeInterval(7200))
 
     let capture = Capture(text: "Cross-posted", subreddits: [sub1, sub2])
 
     let engine = TimingEngine()
-    engine.refresh(events: [event1, event2], captures: [capture])
+    engine.refresh(events: [event1, event2], captures: [capture], now: refreshNow)
 
     #expect(engine.upcomingWindows.count == 2)
     for window in engine.upcomingWindows {
@@ -134,14 +136,14 @@ import Testing
 
 @Test @MainActor func refreshIgnoresPostedCaptures() {
     let sub = Subreddit(name: "r/Test")
-    let event = SubredditEvent(name: "Post", subreddit: sub, oneOffDate: Date().addingTimeInterval(3600))
+    let event = SubredditEvent(name: "Post", subreddit: sub, oneOffDate: refreshNow.addingTimeInterval(3600))
 
     let queued = Capture(text: "Ready", subreddits: [sub])
     let posted = Capture(text: "Done", subreddits: [sub])
     posted.markAsPosted()
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [queued, posted])
+    engine.refresh(events: [event], captures: [queued, posted], now: refreshNow)
 
     #expect(engine.upcomingWindows[0].matchingCaptureCount == 1)
 }

--- a/Tests/RedditReminderTests/TimingEngineTests.swift
+++ b/Tests/RedditReminderTests/TimingEngineTests.swift
@@ -2,6 +2,8 @@ import Testing
 import Foundation
 @testable import RedditReminder
 
+private let timingRefreshNow = Date(timeIntervalSince1970: 1_700_000_000)
+
 @Test @MainActor func urgencyFromHoursAway() {
     #expect(TimingEngine.urgencyLevel(hoursUntilWindow: 30) == .none)
     #expect(TimingEngine.urgencyLevel(hoursUntilWindow: 18) == .low)
@@ -56,7 +58,7 @@ import Foundation
     let sub1 = Subreddit(name: "r/SideProject")
     let sub2 = Subreddit(name: "r/MacApps")
 
-    let fireDate = Date().addingTimeInterval(6 * 3600)
+    let fireDate = timingRefreshNow.addingTimeInterval(6 * 3600)
     let event = SubredditEvent(name: "Post time", subreddit: sub1, oneOffDate: fireDate)
 
     let queued1 = Capture(text: "Cap 1", subreddits: [sub1])
@@ -65,7 +67,7 @@ import Foundation
     posted.markAsPosted()
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [queued1, queued2, posted])
+    engine.refresh(events: [event], captures: [queued1, queued2, posted], now: timingRefreshNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows.first?.matchingCaptureCount == 2)
@@ -75,13 +77,13 @@ import Foundation
     let sub1 = Subreddit(name: "r/SideProject")
     let sub2 = Subreddit(name: "r/MacApps")
 
-    let fireDate = Date().addingTimeInterval(6 * 3600)
+    let fireDate = timingRefreshNow.addingTimeInterval(6 * 3600)
     let event = SubredditEvent(name: "Post time", subreddit: sub2, oneOffDate: fireDate)
 
     let capture = Capture(text: "Cap 1", subreddits: [sub1])
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [capture])
+    engine.refresh(events: [event], captures: [capture], now: timingRefreshNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows.first?.matchingCaptureCount == 0)
@@ -90,13 +92,13 @@ import Foundation
 @Test @MainActor func refreshSortsWindowsByEventDate() {
     let sub = Subreddit(name: "r/SideProject")
 
-    let later = Date().addingTimeInterval(12 * 3600)
-    let sooner = Date().addingTimeInterval(3 * 3600)
+    let later = timingRefreshNow.addingTimeInterval(12 * 3600)
+    let sooner = timingRefreshNow.addingTimeInterval(3 * 3600)
     let event1 = SubredditEvent(name: "Later", subreddit: sub, oneOffDate: later)
     let event2 = SubredditEvent(name: "Sooner", subreddit: sub, oneOffDate: sooner)
 
     let engine = TimingEngine()
-    engine.refresh(events: [event1, event2], captures: [])
+    engine.refresh(events: [event1, event2], captures: [], now: timingRefreshNow)
 
     #expect(engine.upcomingWindows.count == 2)
     #expect(engine.upcomingWindows[0].event.name == "Sooner")

--- a/Tests/RedditReminderTests/TimingEngineWindowTests.swift
+++ b/Tests/RedditReminderTests/TimingEngineWindowTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import RedditReminder
 
+private let timingWindowNow = Date(timeIntervalSince1970: 1_700_000_000)
+
 @Test @MainActor func nextWindowOneOffPrioritizedOverRRule() {
     let sub = Subreddit(name: "r/Test")
     let futureDate = Date().addingTimeInterval(3600)
@@ -28,16 +30,16 @@ import Testing
     let soon = SubredditEvent(
         name: "Soon",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(0.25 * 3600)
+        oneOffDate: timingWindowNow.addingTimeInterval(0.25 * 3600)
     )
     let later = SubredditEvent(
         name: "Later",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(18 * 3600)
+        oneOffDate: timingWindowNow.addingTimeInterval(18 * 3600)
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [soon, later], captures: [])
+    engine.refresh(events: [soon, later], captures: [], now: timingWindowNow)
 
     let soonWindow = engine.upcomingWindows.first { $0.event.name == "Soon" }
     let laterWindow = engine.upcomingWindows.first { $0.event.name == "Later" }
@@ -47,7 +49,7 @@ import Testing
 
 @Test @MainActor func leadTimeSubtractedFromNotificationFireDate() {
     let sub = Subreddit(name: "r/Test")
-    let eventTime = Date().addingTimeInterval(6 * 3600)
+    let eventTime = timingWindowNow.addingTimeInterval(6 * 3600)
     let event = SubredditEvent(
         name: "With Lead",
         subreddit: sub,
@@ -56,7 +58,7 @@ import Testing
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [])
+    engine.refresh(events: [event], captures: [], now: timingWindowNow)
 
     #expect(engine.upcomingWindows.count == 1)
     let window = engine.upcomingWindows[0]
@@ -67,7 +69,7 @@ import Testing
 
 @Test @MainActor func zeroLeadTimeNotificationFireDateEqualsEventDate() {
     let sub = Subreddit(name: "r/Test")
-    let eventTime = Date().addingTimeInterval(3 * 3600)
+    let eventTime = timingWindowNow.addingTimeInterval(3 * 3600)
     let event = SubredditEvent(
         name: "No Lead",
         subreddit: sub,
@@ -76,7 +78,7 @@ import Testing
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [])
+    engine.refresh(events: [event], captures: [], now: timingWindowNow)
 
     #expect(engine.upcomingWindows.count == 1)
     let window = engine.upcomingWindows[0]
@@ -88,12 +90,12 @@ import Testing
     let event = SubredditEvent(
         name: "FarEvent",
         subreddit: sub,
-        oneOffDate: Date().addingTimeInterval(18 * 3600),
+        oneOffDate: timingWindowNow.addingTimeInterval(18 * 3600),
         reminderLeadMinutes: 120
     )
 
     let engine = TimingEngine()
-    engine.refresh(events: [event], captures: [])
+    engine.refresh(events: [event], captures: [], now: timingWindowNow)
 
     #expect(engine.upcomingWindows.count == 1)
     #expect(engine.upcomingWindows[0].urgency == .low)


### PR DESCRIPTION
## Summary
- let `TimingEngine.refresh` accept an injectable `now` while preserving the production default
- pin refresh-oriented timing tests to fixed reference dates
- reduce boundary flake risk in horizon, urgency, sorting, and notification lead-time assertions

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
