### PR TITLE
fix: clear stale shortcut values

### DIFF
--- a/Sources/Utilities/KeyboardShortcutConfig.swift
+++ b/Sources/Utilities/KeyboardShortcutConfig.swift
@@ -64,6 +64,10 @@ struct KeyboardShortcutConfig: Equatable, Sendable {
       defaults.set(Int(config.keyCode), forKey: SettingsKey.globalShortcutKeyCode)
       defaults.set(Int(config.modifiers.rawValue), forKey: SettingsKey.globalShortcutModifiers)
       defaults.set(config.display, forKey: SettingsKey.globalShortcutDisplay)
+    } else {
+      defaults.removeObject(forKey: SettingsKey.globalShortcutKeyCode)
+      defaults.removeObject(forKey: SettingsKey.globalShortcutModifiers)
+      defaults.removeObject(forKey: SettingsKey.globalShortcutDisplay)
     }
     defaults.set(config.identifier, forKey: SettingsKey.globalShortcutIdentifier)
   }

--- a/Tests/RedditReminderTests/MenuBarControllerTests.swift
+++ b/Tests/RedditReminderTests/MenuBarControllerTests.swift
@@ -25,6 +25,24 @@ struct MenuBarControllerTests {
         defaults.removePersistentDomain(forName: suiteName)
     }
 
+    @Test func shortcutPresetClearsStaleCustomValues() {
+        let suiteName = "ShortcutTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let custom = KeyboardShortcutConfig.custom(
+            keyCode: 35,
+            modifiers: [.maskCommand, .maskAlternate],
+            keyDisplay: "P"
+        )
+
+        KeyboardShortcutConfig.save(custom, to: defaults)
+        KeyboardShortcutConfig.save(KeyboardShortcutConfig.presets[1], to: defaults)
+
+        #expect(defaults.object(forKey: SettingsKey.globalShortcutKeyCode) == nil)
+        #expect(defaults.object(forKey: SettingsKey.globalShortcutModifiers) == nil)
+        #expect(defaults.object(forKey: SettingsKey.globalShortcutDisplay) == nil)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
     @Test func shortcutInvalidStoredIdentifierFallsBackToDefault() {
         let suiteName = "ShortcutTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Summary
- clear stored custom shortcut key code, modifiers, and display when saving a preset shortcut
- prevent stale custom shortcut values from leaking into settings snapshots/backups after switching back to a preset
- add regression coverage for custom-to-preset persistence cleanup

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
