### PR TITLE
fix: contain media refs

### DIFF
--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -54,6 +54,7 @@ final class MediaStore {
   }
 
   func loadImage(captureId: UUID, ref: String) -> NSImage? {
+    guard isValidMediaRef(ref) else { return nil }
     let url = rootDir
       .appendingPathComponent(captureId.uuidString)
       .appendingPathComponent(ref)
@@ -61,6 +62,7 @@ final class MediaStore {
   }
 
   func loadThumbnail(captureId: UUID, ref: String) -> NSImage? {
+    guard isValidMediaRef(ref) else { return nil }
     let url = rootDir
       .appendingPathComponent(captureId.uuidString)
       .appendingPathComponent("thumbnails")
@@ -82,10 +84,12 @@ final class MediaStore {
   }
 
   func exists(captureId: UUID, ref: String) -> Bool {
-    fm.fileExists(atPath: mediaURL(captureId: captureId, ref: ref).path)
+    guard isValidMediaRef(ref) else { return false }
+    return fm.fileExists(atPath: mediaURL(captureId: captureId, ref: ref).path)
   }
 
   func delete(captureId: UUID, ref: String) {
+    guard isValidMediaRef(ref) else { return }
     for url in [mediaURL(captureId: captureId, ref: ref), thumbnailURL(captureId: captureId, ref: ref)] {
       do {
         try fm.removeItem(at: url)
@@ -144,6 +148,15 @@ final class MediaStore {
       index += 1
     }
     return candidate
+  }
+
+  private func isValidMediaRef(_ ref: String) -> Bool {
+    !ref.isEmpty &&
+      ref != "." &&
+      ref != ".." &&
+      !ref.contains("/") &&
+      !ref.contains("\\") &&
+      URL(fileURLWithPath: ref).lastPathComponent == ref
   }
 
   private func pngData(from image: NSImage) -> Data? {

--- a/Tests/RedditReminderTests/MediaStoreTests.swift
+++ b/Tests/RedditReminderTests/MediaStoreTests.swift
@@ -128,6 +128,31 @@ import AppKit
   }
 }
 
+@Test func invalidMediaRefsDoNotLoadOrExist() throws {
+  let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let store = MediaStore(rootDir: rootDir)
+  let captureId = UUID()
+
+  #expect(store.loadImage(captureId: captureId, ref: "../outside.png") == nil)
+  #expect(store.loadThumbnail(captureId: captureId, ref: "nested/outside.png") == nil)
+  #expect(!store.exists(captureId: captureId, ref: ""))
+  #expect(!store.exists(captureId: captureId, ref: ".."))
+}
+
+@Test func deleteIgnoresInvalidMediaRefs() throws {
+  let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let store = MediaStore(rootDir: rootDir)
+  let image = createTestImage(width: 100, height: 100)
+  let captureId = UUID()
+  let otherCaptureId = UUID()
+  let otherRef = try store.save(image: image, captureId: otherCaptureId, fileName: "other.png")
+
+  store.delete(captureId: captureId, ref: "../\(otherCaptureId.uuidString)/\(otherRef)")
+
+  #expect(store.loadImage(captureId: otherCaptureId, ref: otherRef) != nil)
+  #expect(store.loadThumbnail(captureId: otherCaptureId, ref: otherRef) != nil)
+}
+
 private func createTestImage(width: Int, height: Int) -> NSImage {
   let image = NSImage(size: NSSize(width: width, height: height))
   image.lockFocus()


### PR DESCRIPTION
## Summary
- reject empty, nested, backslash, and traversal-style media refs at the MediaStore boundary
- prevent invalid refs from loading, existing, or deleting files outside the intended capture directory
- add regression tests for invalid media refs and cross-capture delete containment

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
