### PR TITLE
refactor: narrow media store url helpers

### DIFF
--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -70,13 +70,13 @@ final class MediaStore {
     return NSImage(contentsOf: url)
   }
 
-  func mediaURL(captureId: UUID, ref: String) -> URL {
+  private func mediaURL(captureId: UUID, ref: String) -> URL {
     rootDir
       .appendingPathComponent(captureId.uuidString)
       .appendingPathComponent(ref)
   }
 
-  func thumbnailURL(captureId: UUID, ref: String) -> URL {
+  private func thumbnailURL(captureId: UUID, ref: String) -> URL {
     rootDir
       .appendingPathComponent(captureId.uuidString)
       .appendingPathComponent("thumbnails")


### PR DESCRIPTION
## Summary
- make raw media URL helper methods private to `MediaStore`
- keep external media access routed through validated load/exist/delete APIs

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
