### PR TITLE
fix: restrict subreddit url normalization

### DIFF
--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -100,9 +100,9 @@ enum SubredditName {
     if let url = URL(string: trimmed), let host = url.host?.lowercased(),
        host == "reddit.com" || host == "www.reddit.com" || host.hasSuffix(".reddit.com") {
       let components = url.pathComponents.filter { $0 != "/" }
-      if let markerIndex = components.firstIndex(where: { $0.lowercased() == "r" }),
-         components.indices.contains(markerIndex + 1) {
-        trimmed = components[markerIndex + 1]
+      if components.first?.lowercased() == "r",
+         components.indices.contains(1) {
+        trimmed = components[1]
       }
     }
 

--- a/Tests/RedditReminderTests/SubredditNameValidationTests.swift
+++ b/Tests/RedditReminderTests/SubredditNameValidationTests.swift
@@ -13,6 +13,14 @@ import Testing
     #expect(SubredditName.normalizedName("https://www.reddit.com/r/macOS/") == "r/macOS")
 }
 
+@Test func subredditNameNormalizesRedditSubdomainUrl() {
+    #expect(SubredditName.normalizedName("https://old.reddit.com/r/SwiftUI/comments/abc") == "r/SwiftUI")
+}
+
+@Test func subredditNameRejectsNonSubredditRedditUrl() {
+    #expect(SubredditName.normalizedName("https://www.reddit.com/user/r/macOS") == nil)
+}
+
 @Test func subredditNameRejectsSpaces() {
     #expect(SubredditName.normalize("bad name") == .failure(.invalidCharacters))
 }


### PR DESCRIPTION
## Summary
- only extract subreddit names from Reddit URLs whose path starts with `/r/<name>`
- keep subdomain URLs like `old.reddit.com/r/...` supported
- add coverage rejecting unrelated Reddit paths that contain an `r` segment later in the path

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
