### PR TITLE
fix: load shortcuts from delegate defaults

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -76,7 +76,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func registerGlobalShortcut() {
-        let config = KeyboardShortcutConfig.load()
+        let config = shortcutConfigForRegistration()
         guard config != activeShortcutConfig else { return }
         let registered = globalShortcut.register(config: config) { [weak self] in
             MainActor.assumeIsolated {
@@ -89,6 +89,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } else {
             activeShortcutConfig = nil
         }
+    }
+
+    func shortcutConfigForRegistration() -> KeyboardShortcutConfig {
+        KeyboardShortcutConfig.load(from: defaults)
     }
 
     private func startRefreshLoop() {

--- a/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
@@ -181,6 +181,24 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
     #expect(events.allSatisfy { $0.reminderLeadMinutes == 15 })
 }
 
+@Test @MainActor func appDelegateLoadsShortcutConfigFromInjectedDefaults() {
+    let temporaryDefaults = makeTemporaryDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    let shortcut = KeyboardShortcutConfig.presets[1]
+    KeyboardShortcutConfig.save(shortcut, to: defaults)
+
+    let delegate = AppDelegate(
+        menuBarController: MenuBarController(),
+        timingEngine: TimingEngine(),
+        notificationService: NotificationService(center: RecordingNotificationCenter()),
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false),
+        defaults: defaults
+    )
+
+    #expect(delegate.shortcutConfigForRegistration() == shortcut)
+}
+
 private func makeTemporaryDefaults() -> TemporaryDefaults {
     let suiteName = "AppDelegateSchedulingTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Summary
- route AppDelegate shortcut registration through the delegate's injected UserDefaults
- add coverage for shortcut config resolution from injected defaults without installing a global event tap

## Verification
- `xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build`
- `git diff --check`
- Swift file length scan: no files over 220 lines
- Unsafe pattern scan: no hits
