### PR TITLE
test: cover shortcut registration seam

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -13,7 +13,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     var modelContainer: ModelContainer?
 
-    private let globalShortcut = GlobalShortcut()
+    private let globalShortcut: any GlobalShortcutRegistering
     private var refreshTask: Task<Void, Never>?
     private var shortcutObserver: NSObjectProtocol?
     private var activeShortcutConfig: KeyboardShortcutConfig?
@@ -32,13 +32,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         timingEngine: TimingEngine,
         notificationService: NotificationService,
         heuristicsStore: HeuristicsStore,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        globalShortcut: any GlobalShortcutRegistering = GlobalShortcut()
     ) {
         self.menuBarController = menuBarController
         self.timingEngine = timingEngine
         self.notificationService = notificationService
         self.heuristicsStore = heuristicsStore
         self.defaults = defaults
+        self.globalShortcut = globalShortcut
         self.notificationScheduler = NotificationScheduler(notificationService: notificationService, defaults: defaults)
         super.init()
     }
@@ -75,8 +77,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func registerGlobalShortcut() {
-        let config = shortcutConfigForRegistration()
+    func registerGlobalShortcut() {
+        let config = KeyboardShortcutConfig.load(from: defaults)
         guard config != activeShortcutConfig else { return }
         let registered = globalShortcut.register(config: config) { [weak self] in
             MainActor.assumeIsolated {
@@ -89,10 +91,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } else {
             activeShortcutConfig = nil
         }
-    }
-
-    func shortcutConfigForRegistration() -> KeyboardShortcutConfig {
-        KeyboardShortcutConfig.load(from: defaults)
     }
 
     private func startRefreshLoop() {

--- a/Sources/Utilities/KeyboardShortcuts.swift
+++ b/Sources/Utilities/KeyboardShortcuts.swift
@@ -3,7 +3,13 @@ import AppKit
 import os
 
 @MainActor
-final class GlobalShortcut {
+protocol GlobalShortcutRegistering: AnyObject {
+  func register(config: KeyboardShortcutConfig, handler: @escaping @Sendable () -> Void) -> Bool
+  func unregister()
+}
+
+@MainActor
+final class GlobalShortcut: GlobalShortcutRegistering {
   private var eventTap: CFMachPort?
   private var tapThread: Thread?
 

--- a/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
@@ -181,24 +181,6 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
     #expect(events.allSatisfy { $0.reminderLeadMinutes == 15 })
 }
 
-@Test @MainActor func appDelegateLoadsShortcutConfigFromInjectedDefaults() {
-    let temporaryDefaults = makeTemporaryDefaults()
-    let defaults = temporaryDefaults.defaults
-    defer { temporaryDefaults.cleanup() }
-    let shortcut = KeyboardShortcutConfig.presets[1]
-    KeyboardShortcutConfig.save(shortcut, to: defaults)
-
-    let delegate = AppDelegate(
-        menuBarController: MenuBarController(),
-        timingEngine: TimingEngine(),
-        notificationService: NotificationService(center: RecordingNotificationCenter()),
-        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false),
-        defaults: defaults
-    )
-
-    #expect(delegate.shortcutConfigForRegistration() == shortcut)
-}
-
 private func makeTemporaryDefaults() -> TemporaryDefaults {
     let suiteName = "AppDelegateSchedulingTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/RedditReminderTests/AppDelegateShortcutRegistrationTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateShortcutRegistrationTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+import AppKit
+import UserNotifications
+@testable import RedditReminder
+
+private struct ShortcutTemporaryDefaults {
+    let defaults: UserDefaults
+    let suiteName: String
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+private final class ShortcutNotificationCenter: NotificationCenterProtocol, @unchecked Sendable {
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { true }
+    func add(_ request: UNNotificationRequest, withCompletionHandler handler: (@Sendable (Error?) -> Void)?) {}
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removeAllPendingNotificationRequests() {}
+    func getAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
+}
+
+@MainActor
+private final class RecordingGlobalShortcut: GlobalShortcutRegistering {
+    var registerResults = [true]
+    private(set) var registeredConfigs: [KeyboardShortcutConfig] = []
+    private(set) var unregisterCount = 0
+
+    func register(config: KeyboardShortcutConfig, handler: @escaping @Sendable () -> Void) -> Bool {
+        registeredConfigs.append(config)
+        return registerResults.isEmpty ? true : registerResults.removeFirst()
+    }
+
+    func unregister() {
+        unregisterCount += 1
+    }
+}
+
+@Test @MainActor func appDelegateRegistersShortcutFromInjectedDefaults() {
+    let temporaryDefaults = makeShortcutDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    let shortcut = KeyboardShortcutConfig.presets[1]
+    KeyboardShortcutConfig.save(shortcut, to: defaults)
+    let globalShortcut = RecordingGlobalShortcut()
+    let delegate = makeShortcutDelegate(defaults: defaults, globalShortcut: globalShortcut)
+
+    delegate.registerGlobalShortcut()
+
+    #expect(globalShortcut.registeredConfigs == [shortcut])
+}
+
+@Test @MainActor func appDelegateDoesNotRegisterUnchangedShortcutTwice() {
+    let temporaryDefaults = makeShortcutDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    let globalShortcut = RecordingGlobalShortcut()
+    let delegate = makeShortcutDelegate(defaults: defaults, globalShortcut: globalShortcut)
+
+    delegate.registerGlobalShortcut()
+    delegate.registerGlobalShortcut()
+
+    #expect(globalShortcut.registeredConfigs == [.defaultShortcut])
+}
+
+@Test @MainActor func appDelegateRetriesShortcutAfterFailedRegistration() {
+    let temporaryDefaults = makeShortcutDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    let globalShortcut = RecordingGlobalShortcut()
+    globalShortcut.registerResults = [false, true]
+    let delegate = makeShortcutDelegate(defaults: defaults, globalShortcut: globalShortcut)
+
+    delegate.registerGlobalShortcut()
+    delegate.registerGlobalShortcut()
+
+    #expect(globalShortcut.registeredConfigs == [.defaultShortcut, .defaultShortcut])
+}
+
+@Test @MainActor func appDelegateUnregistersShortcutOnTerminate() {
+    let temporaryDefaults = makeShortcutDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    let globalShortcut = RecordingGlobalShortcut()
+    let delegate = makeShortcutDelegate(defaults: defaults, globalShortcut: globalShortcut)
+
+    delegate.applicationWillTerminate(Notification(name: NSApplication.willTerminateNotification))
+
+    #expect(globalShortcut.unregisterCount == 1)
+}
+
+private func makeShortcutDefaults() -> ShortcutTemporaryDefaults {
+    let suiteName = "AppDelegateShortcutTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    return ShortcutTemporaryDefaults(defaults: defaults, suiteName: suiteName)
+}
+
+@MainActor
+private func makeShortcutDelegate(
+    defaults: UserDefaults,
+    globalShortcut: RecordingGlobalShortcut
+) -> AppDelegate {
+    AppDelegate(
+        menuBarController: MenuBarController(),
+        timingEngine: TimingEngine(),
+        notificationService: NotificationService(center: ShortcutNotificationCenter()),
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false),
+        defaults: defaults,
+        globalShortcut: globalShortcut
+    )
+}


### PR DESCRIPTION
Summary
- add a GlobalShortcutRegistering seam and inject it into AppDelegate
- keep production GlobalShortcut behavior unchanged
- cover injected-default registration, duplicate suppression, retry after failed registration, and terminate cleanup without installing an event tap

Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true