### PR TITLE
fix: make backup import transactional

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		326E8AD5FB53C2321638FA11 /* RRuleInvalidInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA9529C3BB40299A84C6FB8 /* RRuleInvalidInputTests.swift */; };
 		347F4FD54749869424F5CD6C /* SubredditPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */; };
 		34A742D186F38DF2BCA6AB97 /* BackupImportValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */; };
+		34B04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */; };
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
@@ -157,6 +158,7 @@
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
 		3BDDF7799BF55CF7FFC730BA /* peak-times.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "peak-times.json"; sourceTree = "<group>"; };
 		3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupImportValidationTests.swift; sourceTree = "<group>"; };
+		3CB04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupImportTransactionTests.swift; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummaryTests.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				618187DB22F5025BA72A0166 /* AppModelContainerFactoryTests.swift */,
 				07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */,
 				3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */,
+				3CB04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift */,
 				EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */,
 				D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */,
 				1041614D1D7B295800149206 /* BackupTestSupport.swift */,
@@ -534,6 +537,7 @@
 				A049BB3E8B0B7E4BF8A24C90 /* AppModelContainerFactoryTests.swift in Sources */,
 				E9EDB8A89099DE463C304AA7 /* AppRuntimeTests.swift in Sources */,
 				34A742D186F38DF2BCA6AB97 /* BackupImportValidationTests.swift in Sources */,
+				34B04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift in Sources */,
 				6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */,
 				2C6F6A5981CBCEC7CE258964 /* BackupSettingsPersistenceTests.swift in Sources */,
 				2957BBD6DAAF914CD3A0E08A /* BackupTestSupport.swift in Sources */,

--- a/Sources/Services/BackupService.swift
+++ b/Sources/Services/BackupService.swift
@@ -33,8 +33,25 @@ struct BackupService {
         guard backup.version == 1 else { throw BackupError.unsupportedVersion(backup.version) }
         try validate(backup)
 
-        try clearData(in: context)
+        do {
+            try clearData(in: context)
+            try insert(backup, into: context, mediaStore: mediaStore)
+            try context.save()
+        } catch {
+            context.rollback()
+            throw error
+        }
+        BackupSettingsPersistence.apply(backup.settings, to: defaults)
+    }
 
+    private func clearData(in context: ModelContext) throws {
+        for capture in try context.fetch(FetchDescriptor<Capture>()) { context.delete(capture) }
+        for event in try context.fetch(FetchDescriptor<SubredditEvent>()) { context.delete(event) }
+        for project in try context.fetch(FetchDescriptor<Project>()) { context.delete(project) }
+        for subreddit in try context.fetch(FetchDescriptor<Subreddit>()) { context.delete(subreddit) }
+    }
+
+    private func insert(_ backup: AppBackup, into context: ModelContext, mediaStore: MediaStore?) throws {
         var projectsById: [UUID: Project] = [:]
         var subredditsById: [UUID: Subreddit] = [:]
 
@@ -101,17 +118,6 @@ struct BackupService {
             capture.postedAt = item.postedAt
             context.insert(capture)
         }
-
-        BackupSettingsPersistence.apply(backup.settings, to: defaults)
-        try context.save()
-    }
-
-    private func clearData(in context: ModelContext) throws {
-        for capture in try context.fetch(FetchDescriptor<Capture>()) { context.delete(capture) }
-        for event in try context.fetch(FetchDescriptor<SubredditEvent>()) { context.delete(event) }
-        for project in try context.fetch(FetchDescriptor<Project>()) { context.delete(project) }
-        for subreddit in try context.fetch(FetchDescriptor<Subreddit>()) { context.delete(subreddit) }
-        try context.save()
     }
 
     private func validate(_ backup: AppBackup) throws {

--- a/Tests/RedditReminderTests/BackupImportTransactionTests.swift
+++ b/Tests/RedditReminderTests/BackupImportTransactionTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import RedditReminder
+
+@Test @MainActor func backupImportFailurePreservesExistingSettings() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let suiteName = "BackupImportTransactionTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set("existing-project", forKey: SettingsKey.defaultProjectId)
+    defaults.set(30, forKey: SettingsKey.defaultLeadTimeMinutes)
+    defaults.set(false, forKey: SettingsKey.notificationsEnabled)
+
+    let backup = AppBackup(
+        settings: BackupSettings(
+            defaultProjectId: "incoming-project",
+            defaultLeadTimeMinutes: 120,
+            notificationsEnabled: true
+        ),
+        projects: [],
+        subreddits: [],
+        events: [
+            BackupSubredditEvent(
+                id: UUID(),
+                name: "Broken",
+                subredditId: UUID(),
+                rrule: nil,
+                oneOffDate: nil,
+                recurrenceHour: nil,
+                recurrenceMinute: nil,
+                recurrenceTimeZoneIdentifier: nil,
+                reminderLeadMinutes: 60,
+                isActive: true,
+                isGeneratedFromHeuristics: false,
+                generationKey: nil
+            )
+        ],
+        captures: []
+    )
+
+    #expect(throws: BackupError.self) {
+        try BackupService().importBackup(
+            from: JSONEncoder().encode(backup),
+            into: context,
+            defaults: defaults
+        )
+    }
+    #expect(defaults.string(forKey: SettingsKey.defaultProjectId) == "existing-project")
+    #expect(defaults.integer(forKey: SettingsKey.defaultLeadTimeMinutes) == 30)
+    #expect(defaults.bool(forKey: SettingsKey.notificationsEnabled) == false)
+}
+
+@Test @MainActor func backupImportFailurePreservesExistingData() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let existing = Subreddit(name: "r/Existing")
+    context.insert(existing)
+    try context.save()
+
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [],
+        subreddits: [],
+        events: [],
+        captures: [
+            BackupCapture(
+                id: UUID(),
+                text: "Broken capture",
+                notes: nil,
+                links: [],
+                mediaRefs: [],
+                status: .queued,
+                createdAt: Date(),
+                postedAt: nil,
+                projectId: nil,
+                subredditIds: [UUID()]
+            )
+        ]
+    )
+
+    #expect(throws: BackupError.self) {
+        try BackupService().importBackup(from: JSONEncoder().encode(backup), into: context)
+    }
+    let subreddits = try context.fetch(FetchDescriptor<Subreddit>())
+    #expect(subreddits.map(\.name) == ["r/Existing"])
+}


### PR DESCRIPTION
Summary
- save backup import data replacement as one unit instead of saving the clear phase separately
- rollback SwiftData changes if replacement fails
- apply imported settings only after the data save succeeds
- add failure-path tests for preserving existing data and settings

Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true