### PR TITLE
feat: include media in backups

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		34A742D186F38DF2BCA6AB97 /* BackupImportValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */; };
 		34B04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
+		35B04E891C884EA6BCA6AB97 /* BackupMediaPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A04E891C884EA6BCA6AB97 /* BackupMediaPayloads.swift */; };
+		35C04E891C884EA6BCA6AB97 /* BackupMediaPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D04E891C884EA6BCA6AB97 /* BackupMediaPayloadTests.swift */; };
 		39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */; };
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
 		3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */; };
@@ -160,6 +162,8 @@
 		3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupImportValidationTests.swift; sourceTree = "<group>"; };
 		3CB04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupImportTransactionTests.swift; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
+		35A04E891C884EA6BCA6AB97 /* BackupMediaPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMediaPayloads.swift; sourceTree = "<group>"; };
+		35D04E891C884EA6BCA6AB97 /* BackupMediaPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMediaPayloadTests.swift; sourceTree = "<group>"; };
 		409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummaryTests.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4758BE68EE85AA3FA2EA4DC4 /* DefaultSubredditsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubredditsTests.swift; sourceTree = "<group>"; };
@@ -263,6 +267,7 @@
 				07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */,
 				3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */,
 				3CB04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift */,
+				35D04E891C884EA6BCA6AB97 /* BackupMediaPayloadTests.swift */,
 				EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */,
 				D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */,
 				1041614D1D7B295800149206 /* BackupTestSupport.swift */,
@@ -376,6 +381,7 @@
 			isa = PBXGroup;
 			children = (
 				9884E228CA7B8C32C3669A85 /* BackupMappers.swift */,
+				35A04E891C884EA6BCA6AB97 /* BackupMediaPayloads.swift */,
 				1F6975993534B39BF8DEB32E /* BackupService.swift */,
 				61052DF5F8EFC70EA9076106 /* BackupSettingsPersistence.swift */,
 				F72682A4379AE1A17B7D4559 /* BackupTypes.swift */,
@@ -538,6 +544,7 @@
 				E9EDB8A89099DE463C304AA7 /* AppRuntimeTests.swift in Sources */,
 				34A742D186F38DF2BCA6AB97 /* BackupImportValidationTests.swift in Sources */,
 				34B04E891C884EA6BCA6AB97 /* BackupImportTransactionTests.swift in Sources */,
+				35C04E891C884EA6BCA6AB97 /* BackupMediaPayloadTests.swift in Sources */,
 				6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */,
 				2C6F6A5981CBCEC7CE258964 /* BackupSettingsPersistenceTests.swift in Sources */,
 				2957BBD6DAAF914CD3A0E08A /* BackupTestSupport.swift in Sources */,
@@ -592,6 +599,7 @@
 				F4DE010F9076D36DD9D98288 /* AppModelContainerFactory.swift in Sources */,
 				2D0134DEC22382048A22922F /* AppRuntime.swift in Sources */,
 				0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */,
+				35B04E891C884EA6BCA6AB97 /* BackupMediaPayloads.swift in Sources */,
 				26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */,
 				9B6DE864F7F9D78BE7B6CA54 /* BackupService.swift in Sources */,
 				BEE74F03864389AD3A108EFE /* BackupSettingsPersistence.swift in Sources */,

--- a/Sources/Services/BackupMediaPayloads.swift
+++ b/Sources/Services/BackupMediaPayloads.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+extension BackupService {
+    func mediaFiles(from captures: [Capture], mediaStore: MediaStore?) throws -> [BackupMediaFile]? {
+        guard let mediaStore else { return nil }
+        var files: [BackupMediaFile] = []
+        for capture in captures {
+            for ref in capture.mediaRefs {
+                guard let data = try mediaStore.loadData(captureId: capture.id, ref: ref) else { continue }
+                files.append(BackupMediaFile(captureId: capture.id, ref: ref, data: data))
+            }
+        }
+        return files
+    }
+
+    func restoreEmbeddedMedia(from backup: AppBackup, mediaStore: MediaStore?) throws -> Set<MediaIdentity> {
+        guard let mediaStore, let mediaFiles = backup.mediaFiles else { return [] }
+        var restored: Set<MediaIdentity> = []
+        do {
+            for file in mediaFiles {
+                try mediaStore.saveData(file.data, captureId: file.captureId, ref: file.ref)
+                restored.insert(MediaIdentity(captureId: file.captureId, ref: file.ref))
+            }
+            return restored
+        } catch {
+            deleteMedia(restored, mediaStore: mediaStore)
+            throw error
+        }
+    }
+
+    func deleteMedia(_ files: Set<MediaIdentity>, mediaStore: MediaStore?) {
+        guard let mediaStore else { return }
+        for file in files {
+            mediaStore.delete(captureId: file.captureId, ref: file.ref)
+        }
+    }
+
+    func restoredMediaRefs(
+        from capture: BackupCapture,
+        mediaStore: MediaStore?,
+        restoredMedia: Set<MediaIdentity>
+    ) -> [String] {
+        guard let mediaStore else { return capture.mediaRefs }
+        return capture.mediaRefs.filter { ref in
+            restoredMedia.contains(MediaIdentity(captureId: capture.id, ref: ref)) ||
+                mediaStore.exists(captureId: capture.id, ref: ref)
+        }
+    }
+}
+
+struct MediaIdentity: Hashable {
+    let captureId: UUID
+    let ref: String
+}

--- a/Sources/Services/BackupService.swift
+++ b/Sources/Services/BackupService.swift
@@ -12,13 +12,19 @@ struct BackupService {
         decoder = JSONDecoder()
     }
 
-    func exportBackup(from context: ModelContext, defaults: UserDefaults = .standard) throws -> Data {
+    func exportBackup(
+        from context: ModelContext,
+        defaults: UserDefaults = .standard,
+        mediaStore: MediaStore? = nil
+    ) throws -> Data {
+        let captures = try context.fetch(FetchDescriptor<Capture>())
         let backup = AppBackup(
             settings: BackupSettingsPersistence.snapshot(from: defaults),
             projects: try context.fetch(FetchDescriptor<Project>()).map { BackupProject(project: $0) },
             subreddits: try context.fetch(FetchDescriptor<Subreddit>()).map { BackupSubreddit(subreddit: $0) },
             events: try context.fetch(FetchDescriptor<SubredditEvent>()).map { BackupSubredditEvent(event: $0) },
-            captures: try context.fetch(FetchDescriptor<Capture>()).map { BackupCapture(capture: $0) }
+            captures: captures.map { BackupCapture(capture: $0) },
+            mediaFiles: try mediaFiles(from: captures, mediaStore: mediaStore)
         )
         return try encoder.encode(backup)
     }
@@ -33,12 +39,15 @@ struct BackupService {
         guard backup.version == 1 else { throw BackupError.unsupportedVersion(backup.version) }
         try validate(backup)
 
+        var restoredMedia: Set<MediaIdentity> = []
         do {
+            restoredMedia = try restoreEmbeddedMedia(from: backup, mediaStore: mediaStore)
             try clearData(in: context)
-            try insert(backup, into: context, mediaStore: mediaStore)
+            try insert(backup, into: context, mediaStore: mediaStore, restoredMedia: restoredMedia)
             try context.save()
         } catch {
             context.rollback()
+            deleteMedia(restoredMedia, mediaStore: mediaStore)
             throw error
         }
         BackupSettingsPersistence.apply(backup.settings, to: defaults)
@@ -51,7 +60,12 @@ struct BackupService {
         for subreddit in try context.fetch(FetchDescriptor<Subreddit>()) { context.delete(subreddit) }
     }
 
-    private func insert(_ backup: AppBackup, into context: ModelContext, mediaStore: MediaStore?) throws {
+    private func insert(
+        _ backup: AppBackup,
+        into context: ModelContext,
+        mediaStore: MediaStore?,
+        restoredMedia: Set<MediaIdentity>
+    ) throws {
         var projectsById: [UUID: Project] = [:]
         var subredditsById: [UUID: Subreddit] = [:]
 
@@ -108,7 +122,7 @@ struct BackupService {
                 text: item.text,
                 notes: item.notes,
                 links: item.links,
-                mediaRefs: restoredMediaRefs(from: item, mediaStore: mediaStore),
+                mediaRefs: restoredMediaRefs(from: item, mediaStore: mediaStore, restoredMedia: restoredMedia),
                 project: item.projectId.flatMap { projectsById[$0] },
                 subreddits: subreddits
             )
@@ -150,11 +164,6 @@ struct BackupService {
                 throw BackupError.duplicateId(id.uuidString)
             }
         }
-    }
-
-    private func restoredMediaRefs(from capture: BackupCapture, mediaStore: MediaStore?) -> [String] {
-        guard let mediaStore else { return capture.mediaRefs }
-        return capture.mediaRefs.filter { mediaStore.exists(captureId: capture.id, ref: $0) }
     }
 
 }

--- a/Sources/Services/BackupTypes.swift
+++ b/Sources/Services/BackupTypes.swift
@@ -25,6 +25,7 @@ struct AppBackup: Codable, Equatable {
     var subreddits: [BackupSubreddit]
     var events: [BackupSubredditEvent]
     var captures: [BackupCapture]
+    var mediaFiles: [BackupMediaFile]? = nil
 }
 
 struct BackupSettings: Codable, Equatable {
@@ -101,4 +102,10 @@ struct BackupCapture: Codable, Equatable {
     var postedAt: Date?
     var projectId: UUID?
     var subredditIds: [UUID]
+}
+
+struct BackupMediaFile: Codable, Equatable {
+    var captureId: UUID
+    var ref: String
+    var data: Data
 }

--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -70,6 +70,28 @@ final class MediaStore {
     return NSImage(contentsOf: url)
   }
 
+  func loadData(captureId: UUID, ref: String) throws -> Data? {
+    guard isValidMediaRef(ref) else { return nil }
+    let url = mediaURL(captureId: captureId, ref: ref)
+    guard fm.fileExists(atPath: url.path) else { return nil }
+    return try Data(contentsOf: url)
+  }
+
+  func saveData(_ data: Data, captureId: UUID, ref: String) throws {
+    guard isValidMediaRef(ref) else { throw MediaError.invalidReference }
+    guard let image = NSImage(data: data) else { throw MediaError.decodingFailed }
+    let captureDir = rootDir.appendingPathComponent(captureId.uuidString)
+    let thumbDir = captureDir.appendingPathComponent("thumbnails")
+    try fm.createDirectory(at: captureDir, withIntermediateDirectories: true)
+    try fm.createDirectory(at: thumbDir, withIntermediateDirectories: true)
+    try data.write(to: mediaURL(captureId: captureId, ref: ref))
+
+    let thumbnail = generateThumbnail(from: image, maxSize: MediaConstants.thumbnailMaxSize)
+    if let thumbData = pngData(from: thumbnail) {
+      try thumbData.write(to: thumbnailURL(captureId: captureId, ref: ref))
+    }
+  }
+
   private func mediaURL(captureId: UUID, ref: String) -> URL {
     rootDir
       .appendingPathComponent(captureId.uuidString)
@@ -171,5 +193,6 @@ final class MediaStore {
 enum MediaError: Error {
   case decodingFailed
   case encodingFailed
+  case invalidReference
   case unsupportedType
 }

--- a/Sources/Views/BackupSectionView.swift
+++ b/Sources/Views/BackupSectionView.swift
@@ -60,7 +60,7 @@ struct BackupSectionView: View {
 
     private func exportBackup() {
         do {
-            let data = try backupService.exportBackup(from: modelContext)
+            let data = try backupService.exportBackup(from: modelContext, mediaStore: mediaStore)
             exportDocument = BackupDocument(data: data)
             isExporting = true
             statusMessage = nil

--- a/Tests/RedditReminderTests/BackupMediaPayloadTests.swift
+++ b/Tests/RedditReminderTests/BackupMediaPayloadTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import RedditReminder
+
+@Test @MainActor func backupExportEmbedsExistingMediaFiles() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let mediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+    let capture = Capture(text: "With media")
+    context.insert(capture)
+    let ref = try mediaStore.save(image: backupTestImage(), captureId: capture.id, fileName: "image.png")
+    capture.mediaRefs = [ref]
+    try context.save()
+
+    let data = try BackupService().exportBackup(from: context, mediaStore: mediaStore)
+    let backup = try JSONDecoder().decode(AppBackup.self, from: data)
+
+    #expect(backup.mediaFiles?.count == 1)
+    #expect(backup.mediaFiles?[0].captureId == capture.id)
+    #expect(backup.mediaFiles?[0].ref == ref)
+    #expect(backup.mediaFiles?[0].data.isEmpty == false)
+}
+
+@Test @MainActor func backupImportRestoresEmbeddedMediaFiles() throws {
+    let sourceContainer = try makeBackupContainer()
+    let sourceContext = ModelContext(sourceContainer)
+    let sourceMediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+    let sourceCapture = Capture(text: "With media")
+    sourceContext.insert(sourceCapture)
+    let ref = try sourceMediaStore.save(
+        image: backupTestImage(),
+        captureId: sourceCapture.id,
+        fileName: "image.png"
+    )
+    sourceCapture.mediaRefs = [ref]
+    try sourceContext.save()
+    let data = try BackupService().exportBackup(from: sourceContext, mediaStore: sourceMediaStore)
+
+    let destinationContainer = try makeBackupContainer()
+    let destinationContext = ModelContext(destinationContainer)
+    let destinationMediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+
+    try BackupService().importBackup(
+        from: data,
+        into: destinationContext,
+        mediaStore: destinationMediaStore
+    )
+
+    let captures = try destinationContext.fetch(FetchDescriptor<Capture>())
+    #expect(captures.count == 1)
+    #expect(captures[0].mediaRefs == [ref])
+    #expect(destinationMediaStore.loadImage(captureId: sourceCapture.id, ref: ref) != nil)
+    #expect(destinationMediaStore.loadThumbnail(captureId: sourceCapture.id, ref: ref) != nil)
+}


### PR DESCRIPTION
Summary
- embed media payloads in JSON backups when media files exist
- restore embedded media files and thumbnails during import
- keep old backups compatible by treating media payloads as optional
- wire Preferences export through the app MediaStore

Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true