### PR TITLE
test: add media editor accessibility seams

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -20,11 +20,14 @@
 		130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
 		1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */; };
+		17C63DE6A4C14E2EA9AF2341 /* CaptureMediaAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C63DE5A4C14E2EA9AF2341 /* CaptureMediaAccessibility.swift */; };
 		180BA3D4D8C44E8BBF3F2C11 /* CaptureMediaEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180BA3D2D8C44E8BBF3F2C11 /* CaptureMediaEditing.swift */; };
+		18C63DE6A4C14E2EA9AF2341 /* CaptureMediaChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C63DE5A4C14E2EA9AF2341 /* CaptureMediaChips.swift */; };
 		19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */; };
 		1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */; };
 		1B491EC2EFC1BEC12FABB169 /* ProjectCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2462E2B8BF95342CCBB4FC70 /* ProjectCRUDTests.swift */; };
 		1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */; };
+		1DC63DE6A4C14E2EA9AF2341 /* CaptureMediaAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC63DE5A4C14E2EA9AF2341 /* CaptureMediaAccessibilityTests.swift */; };
 		1E0BA3D4D8C44E8BBF3F2C11 /* CaptureMediaEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0BA3D2D8C44E8BBF3F2C11 /* CaptureMediaEditingTests.swift */; };
 		1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */; };
 		2214090DA72A5B5AF58F6658 /* SubredditPeakTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */; };
@@ -142,8 +145,11 @@
 		1041614D1D7B295800149206 /* BackupTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupTestSupport.swift; sourceTree = "<group>"; };
 		128860C77D6625EB89D5DFFF /* RRuleEdgeCaseTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleEdgeCaseTestSupport.swift; sourceTree = "<group>"; };
 		18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureFormResult.swift; sourceTree = "<group>"; };
+		17C63DE5A4C14E2EA9AF2341 /* CaptureMediaAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaAccessibility.swift; sourceTree = "<group>"; };
 		180BA3D2D8C44E8BBF3F2C11 /* CaptureMediaEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaEditing.swift; sourceTree = "<group>"; };
+		18C63DE5A4C14E2EA9AF2341 /* CaptureMediaChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaChips.swift; sourceTree = "<group>"; };
 		1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostedListView.swift; sourceTree = "<group>"; };
+		1DC63DE5A4C14E2EA9AF2341 /* CaptureMediaAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaAccessibilityTests.swift; sourceTree = "<group>"; };
 		1E0BA3D2D8C44E8BBF3F2C11 /* CaptureMediaEditingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaEditingTests.swift; sourceTree = "<group>"; };
 		1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsTabView.swift; sourceTree = "<group>"; };
 		1F6975993534B39BF8DEB32E /* BackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupService.swift; sourceTree = "<group>"; };
@@ -274,6 +280,7 @@
 				E02E746452EDD7B17443C493 /* CaptureCRUDTests.swift */,
 				FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */,
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
+				1DC63DE5A4C14E2EA9AF2341 /* CaptureMediaAccessibilityTests.swift */,
 				1E0BA3D2D8C44E8BBF3F2C11 /* CaptureMediaEditingTests.swift */,
 				8B642ED62D86AC09680939A1 /* CaptureMediaSelectionTests.swift */,
 				06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */,
@@ -320,6 +327,7 @@
 			children = (
 				3769CC097D084C4E6DD34081 /* AppRuntime.swift */,
 				8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */,
+				17C63DE5A4C14E2EA9AF2341 /* CaptureMediaAccessibility.swift */,
 				180BA3D2D8C44E8BBF3F2C11 /* CaptureMediaEditing.swift */,
 				288C13F7511FB37215593E12 /* CaptureMediaSelection.swift */,
 				E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */,
@@ -411,6 +419,7 @@
 				BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */,
 				A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */,
 				4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */,
+				18C63DE5A4C14E2EA9AF2341 /* CaptureMediaChips.swift */,
 				6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */,
 				04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */,
 				975C23592B958F445105973E /* CaptureWindowView.swift */,
@@ -552,6 +561,7 @@
 				61A0CF870F46A9CA5D4D825B /* CaptureCRUDTests.swift in Sources */,
 				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
 				1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */,
+				1DC63DE6A4C14E2EA9AF2341 /* CaptureMediaAccessibilityTests.swift in Sources */,
 				1E0BA3D4D8C44E8BBF3F2C11 /* CaptureMediaEditingTests.swift in Sources */,
 				CE614FCDDCCDE1DA0C484E58 /* CaptureMediaSelectionTests.swift in Sources */,
 				94CF7D2C65A9A2F6CCABCA92 /* CapturePersistenceActionsTests.swift in Sources */,
@@ -609,7 +619,9 @@
 				6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */,
 				E3F5BC123C653EDC86231434 /* CaptureHelpers.swift in Sources */,
 				632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */,
+				17C63DE6A4C14E2EA9AF2341 /* CaptureMediaAccessibility.swift in Sources */,
 				180BA3D4D8C44E8BBF3F2C11 /* CaptureMediaEditing.swift in Sources */,
+				18C63DE6A4C14E2EA9AF2341 /* CaptureMediaChips.swift in Sources */,
 				458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */,
 				B78555115700D912FE912EAE /* CaptureMediaSelection.swift in Sources */,
 				FF7560E040B2D7B3297B2AAB /* CapturePersistenceActions.swift in Sources */,

--- a/Sources/Utilities/CaptureMediaAccessibility.swift
+++ b/Sources/Utilities/CaptureMediaAccessibility.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum CaptureMediaAccessibility {
+    static let dropZone = "capture-media-drop-zone"
+
+    static func previewExisting(ref: String) -> String {
+        "capture-media-preview-existing-\(token(ref))"
+    }
+
+    static func removeExisting(ref: String) -> String {
+        "capture-media-remove-existing-\(token(ref))"
+    }
+
+    static func restoreExisting(ref: String) -> String {
+        "capture-media-restore-existing-\(token(ref))"
+    }
+
+    static func previewNew(fileName: String) -> String {
+        "capture-media-preview-new-\(token(fileName))"
+    }
+
+    static func removeNew(index: Int) -> String {
+        "capture-media-remove-new-\(index)"
+    }
+
+    private static func token(_ value: String) -> String {
+        value
+            .lowercased()
+            .map { $0.isLetter || $0.isNumber ? $0 : "-" }
+            .reduce(into: "") { partial, character in
+                if character != "-" || partial.last != "-" {
+                    partial.append(character)
+                }
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}

--- a/Sources/Views/CaptureMediaChips.swift
+++ b/Sources/Views/CaptureMediaChips.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct CaptureMediaChip: View {
+    let title: String
+    let image: NSImage?
+    let previewIdentifier: String
+    let removeIdentifier: String
+    let onPreview: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 5) {
+            mediaIcon
+            Button(action: onPreview) {
+                Text(title)
+                    .font(.system(size: 10))
+                    .lineLimit(1)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(previewIdentifier)
+            Button(action: onRemove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(removeIdentifier)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.quaternary.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private var mediaIcon: some View {
+        if let image {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 18, height: 18)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+        } else {
+            Image(systemName: "photo")
+                .font(.system(size: 9))
+        }
+    }
+}
+
+struct RemovedCaptureMediaChip: View {
+    let title: String
+    let image: NSImage?
+    let restoreIdentifier: String
+    let onRestore: () -> Void
+
+    var body: some View {
+        HStack(spacing: 5) {
+            mediaIcon
+            Text(title)
+                .font(.system(size: 10))
+                .lineLimit(1)
+                .strikethrough()
+                .foregroundStyle(.secondary)
+            Button(action: onRestore) {
+                Image(systemName: "arrow.uturn.backward")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(restoreIdentifier)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.quaternary.opacity(0.18))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private var mediaIcon: some View {
+        if let image {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 18, height: 18)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+        } else {
+            Image(systemName: "photo")
+                .font(.system(size: 9))
+        }
+    }
+}

--- a/Sources/Views/CaptureMediaSection.swift
+++ b/Sources/Views/CaptureMediaSection.swift
@@ -17,9 +17,11 @@ struct CaptureMediaSection: View {
             if let captureId, !existingRefs.isEmpty {
                 FlowLayout(spacing: 6) {
                     ForEach(existingRefs, id: \.self) { ref in
-                        mediaChip(
+                        CaptureMediaChip(
                             title: ref,
                             image: mediaStore.loadThumbnail(captureId: captureId, ref: ref),
+                            previewIdentifier: CaptureMediaAccessibility.previewExisting(ref: ref),
+                            removeIdentifier: CaptureMediaAccessibility.removeExisting(ref: ref),
                             onPreview: {
                                 if let image = mediaStore.loadImage(captureId: captureId, ref: ref) {
                                     previewImage = PreviewImage(value: image)
@@ -40,9 +42,10 @@ struct CaptureMediaSection: View {
             if let captureId, !removedRefs.isEmpty {
                 FlowLayout(spacing: 6) {
                     ForEach(removedRefs, id: \.self) { ref in
-                        removedMediaChip(
+                        RemovedCaptureMediaChip(
                             title: ref,
                             image: mediaStore.loadThumbnail(captureId: captureId, ref: ref),
+                            restoreIdentifier: CaptureMediaAccessibility.restoreExisting(ref: ref),
                             onRestore: {
                                 CaptureMediaEditing.restoreExisting(
                                     ref: ref,
@@ -58,9 +61,11 @@ struct CaptureMediaSection: View {
             if !droppedFiles.isEmpty {
                 FlowLayout(spacing: 6) {
                     ForEach(Array(droppedFiles.enumerated()), id: \.offset) { index, url in
-                        mediaChip(
+                        CaptureMediaChip(
                             title: url.lastPathComponent,
                             image: NSImage(contentsOf: url),
+                            previewIdentifier: CaptureMediaAccessibility.previewNew(fileName: url.lastPathComponent),
+                            removeIdentifier: CaptureMediaAccessibility.removeNew(index: index),
                             onPreview: {
                                 if let image = NSImage(contentsOf: url) {
                                     previewImage = PreviewImage(value: image)
@@ -82,6 +87,7 @@ struct CaptureMediaSection: View {
                 .background(isDragOver ? Color.blue.opacity(0.05) : Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .onTapGesture { isShowingImporter = true }
+                .accessibilityIdentifier(CaptureMediaAccessibility.dropZone)
                 .onDrop(of: [.fileURL], isTargeted: $isDragOver) { providers in
                     handleFileDrop(providers)
                 }
@@ -124,79 +130,9 @@ struct CaptureMediaSection: View {
         self.mediaStore = mediaStore
     }
 
-    private func mediaChip(
-        title: String,
-        image: NSImage?,
-        onPreview: @escaping () -> Void,
-        onRemove: @escaping () -> Void
-    ) -> some View {
-        HStack(spacing: 5) {
-            if let image {
-                Image(nsImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 18, height: 18)
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
-            } else {
-                Image(systemName: "photo")
-                    .font(.system(size: 9))
-            }
-            Button(action: onPreview) {
-                Text(title)
-                    .font(.system(size: 10))
-                    .lineLimit(1)
-            }
-            .buttonStyle(.plain)
-            Button(action: onRemove) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 7, weight: .bold))
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
-    }
-
     private struct PreviewImage: Identifiable {
         let id = UUID()
         let value: NSImage
-    }
-
-    private func removedMediaChip(
-        title: String,
-        image: NSImage?,
-        onRestore: @escaping () -> Void
-    ) -> some View {
-        HStack(spacing: 5) {
-            if let image {
-                Image(nsImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 18, height: 18)
-                    .clipShape(RoundedRectangle(cornerRadius: 3))
-            } else {
-                Image(systemName: "photo")
-                    .font(.system(size: 9))
-            }
-            Text(title)
-                .font(.system(size: 10))
-                .lineLimit(1)
-                .strikethrough()
-                .foregroundStyle(.secondary)
-            Button(action: onRestore) {
-                Image(systemName: "arrow.uturn.backward")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(.quaternary.opacity(0.18))
-        .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
     private func appendImageFiles(_ urls: [URL]) {

--- a/Tests/RedditReminderTests/CaptureMediaAccessibilityTests.swift
+++ b/Tests/RedditReminderTests/CaptureMediaAccessibilityTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import RedditReminder
+
+@Test func captureMediaAccessibilityDefinesStableDropZoneIdentifier() {
+    #expect(CaptureMediaAccessibility.dropZone == "capture-media-drop-zone")
+}
+
+@Test func captureMediaAccessibilityNormalizesExistingRefIdentifiers() {
+    #expect(
+        CaptureMediaAccessibility.previewExisting(ref: "Hero Image.PNG")
+            == "capture-media-preview-existing-hero-image-png"
+    )
+    #expect(
+        CaptureMediaAccessibility.removeExisting(ref: "Hero Image.PNG")
+            == "capture-media-remove-existing-hero-image-png"
+    )
+    #expect(
+        CaptureMediaAccessibility.restoreExisting(ref: "Hero Image.PNG")
+            == "capture-media-restore-existing-hero-image-png"
+    )
+}
+
+@Test func captureMediaAccessibilityDefinesNewMediaIdentifiers() {
+    #expect(
+        CaptureMediaAccessibility.previewNew(fileName: "Draft 1.PNG")
+            == "capture-media-preview-new-draft-1-png"
+    )
+    #expect(CaptureMediaAccessibility.removeNew(index: 2) == "capture-media-remove-new-2")
+}


### PR DESCRIPTION
Summary
- add stable accessibility identifiers for media drop, preview, remove, and restore controls
- cover identifier generation for existing and newly added media
- split media chip views out of CaptureMediaSection to keep files within the project size limit

Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true