### PR TITLE
fix: surface shortcut registration failures

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		396D6C3C7B144AC6AD58F3E1 /* CaptureSubredditPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */; };
 		3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */; };
 		3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0972EE8B384E16C0A49F8555 /* AppDelegate.swift */; };
+		3DE8E37C7A3549B1865C0AC2 /* AppDelegateShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF8E37C7A3549B1865C0AC2 /* AppDelegateShortcuts.swift */; };
 		3E3AB083447626CC69DF693B /* SubredditPeakSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31CB6F345C1C2B72D954744 /* SubredditPeakSelectionTests.swift */; };
 		42EF49CDAB403FE9D2C36047 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BB3D18ECE13E70E7CED42 /* NotificationService.swift */; };
 		458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */; };
@@ -140,6 +141,7 @@
 		07A63D3714291E8917CA1694 /* PopoverContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentView.swift; sourceTree = "<group>"; };
 		07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeTests.swift; sourceTree = "<group>"; };
 		0972EE8B384E16C0A49F8555 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		3DF8E37C7A3549B1865C0AC2 /* AppDelegateShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcuts.swift; sourceTree = "<group>"; };
 		09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
 		0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelperTests.swift; sourceTree = "<group>"; };
 		1041614D1D7B295800149206 /* BackupTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupTestSupport.swift; sourceTree = "<group>"; };
@@ -448,6 +450,7 @@
 			isa = PBXGroup;
 			children = (
 				0972EE8B384E16C0A49F8555 /* AppDelegate.swift */,
+				3DF8E37C7A3549B1865C0AC2 /* AppDelegateShortcuts.swift */,
 				D4925806B8E7919B5E93D38D /* AppModelContainerFactory.swift */,
 				787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */,
 			);
@@ -606,6 +609,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */,
+				3DE8E37C7A3549B1865C0AC2 /* AppDelegateShortcuts.swift in Sources */,
 				F4DE010F9076D36DD9D98288 /* AppModelContainerFactory.swift in Sources */,
 				2D0134DEC22382048A22922F /* AppRuntime.swift in Sources */,
 				0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -13,10 +13,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     var modelContainer: ModelContainer?
 
-    private let globalShortcut: any GlobalShortcutRegistering
+    let globalShortcut: any GlobalShortcutRegistering
     private var refreshTask: Task<Void, Never>?
     private var shortcutObserver: NSObjectProtocol?
-    private var activeShortcutConfig: KeyboardShortcutConfig?
+    var activeShortcutConfig: KeyboardShortcutConfig?
 
     override convenience init() {
         self.init(
@@ -74,22 +74,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         refreshTask?.cancel()
         if let shortcutObserver {
             NotificationCenter.default.removeObserver(shortcutObserver)
-        }
-    }
-
-    func registerGlobalShortcut() {
-        let config = KeyboardShortcutConfig.load(from: defaults)
-        guard config != activeShortcutConfig else { return }
-        let registered = globalShortcut.register(config: config) { [weak self] in
-            MainActor.assumeIsolated {
-                self?.menuBarController.togglePopover()
-            }
-        }
-        if registered {
-            activeShortcutConfig = config
-            NSLog("RedditReminder: \(config.display) registered")
-        } else {
-            activeShortcutConfig = nil
         }
     }
 

--- a/Sources/App/AppDelegateShortcuts.swift
+++ b/Sources/App/AppDelegateShortcuts.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension AppDelegate {
+    func registerGlobalShortcut() {
+        let config = KeyboardShortcutConfig.load(from: defaults)
+        guard config != activeShortcutConfig else { return }
+        let registered = globalShortcut.register(config: config) { [weak self] in
+            MainActor.assumeIsolated {
+                self?.menuBarController.togglePopover()
+            }
+        }
+        if registered {
+            defaults.set(false, forKey: SettingsKey.globalShortcutRegistrationFailed)
+            activeShortcutConfig = config
+            NSLog("RedditReminder: \(config.display) registered")
+        } else {
+            defaults.set(true, forKey: SettingsKey.globalShortcutRegistrationFailed)
+            activeShortcutConfig = nil
+        }
+    }
+}

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -37,6 +37,7 @@ enum SettingsKey {
     static let globalShortcutKeyCode = "globalShortcutKeyCode"
     static let globalShortcutModifiers = "globalShortcutModifiers"
     static let globalShortcutDisplay = "globalShortcutDisplay"
+    static let globalShortcutRegistrationFailed = "globalShortcutRegistrationFailed"
 }
 
 enum SettingsOptions {

--- a/Sources/Views/GeneralTabView.swift
+++ b/Sources/Views/GeneralTabView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct GeneralTabView: View {
     @AppStorage(SettingsKey.defaultLeadTimeMinutes) private var defaultLeadTimeMinutes: Int = 60
     @AppStorage(SettingsKey.defaultProjectId) private var defaultProjectId: String = ""
+    @AppStorage(SettingsKey.globalShortcutRegistrationFailed) private var shortcutRegistrationFailed = false
     @State private var shortcutConfig = KeyboardShortcutConfig.load()
 
     @Query(sort: \Project.name) private var projects: [Project]
@@ -12,6 +13,11 @@ struct GeneralTabView: View {
         Form {
             Section("Keyboard Shortcut") {
                 ShortcutRecorderView(config: $shortcutConfig)
+                if shortcutRegistrationFailed {
+                    Text("Shortcut unavailable. Grant Accessibility permission or choose another shortcut.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Defaults") {

--- a/Tests/RedditReminderTests/AppDelegateShortcutRegistrationTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateShortcutRegistrationTests.swift
@@ -78,6 +78,32 @@ private final class RecordingGlobalShortcut: GlobalShortcutRegistering {
     #expect(globalShortcut.registeredConfigs == [.defaultShortcut, .defaultShortcut])
 }
 
+@Test @MainActor func appDelegateRecordsShortcutRegistrationFailure() {
+    let temporaryDefaults = makeShortcutDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    let globalShortcut = RecordingGlobalShortcut()
+    globalShortcut.registerResults = [false]
+    let delegate = makeShortcutDelegate(defaults: defaults, globalShortcut: globalShortcut)
+
+    delegate.registerGlobalShortcut()
+
+    #expect(defaults.bool(forKey: SettingsKey.globalShortcutRegistrationFailed))
+}
+
+@Test @MainActor func appDelegateClearsShortcutRegistrationFailureAfterSuccess() {
+    let temporaryDefaults = makeShortcutDefaults()
+    let defaults = temporaryDefaults.defaults
+    defer { temporaryDefaults.cleanup() }
+    defaults.set(true, forKey: SettingsKey.globalShortcutRegistrationFailed)
+    let globalShortcut = RecordingGlobalShortcut()
+    let delegate = makeShortcutDelegate(defaults: defaults, globalShortcut: globalShortcut)
+
+    delegate.registerGlobalShortcut()
+
+    #expect(defaults.bool(forKey: SettingsKey.globalShortcutRegistrationFailed) == false)
+}
+
 @Test @MainActor func appDelegateUnregistersShortcutOnTerminate() {
     let temporaryDefaults = makeShortcutDefaults()
     let defaults = temporaryDefaults.defaults


### PR DESCRIPTION
## Summary
- move shortcut registration logic into an AppDelegate extension
- persist shortcut registration failure state in defaults
- show Preferences guidance when registration fails
- cover failure and recovery paths in AppDelegate shortcut tests

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build\n- pkill -x RedditReminder || true\n- git diff --check\n- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \\; | sort\n- rg -n "UserDefaults\\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true