### PR TITLE
test: cover shortcut recorder input validation

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -89,6 +89,8 @@
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
 		8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB005E503FDAD90271DB0AE /* EventBannerView.swift */; };
 		87AE17FDA4B3C169B340C8AA /* SubredditEventCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFAC40DD76013F2B88EEC64 /* SubredditEventCRUDTests.swift */; };
+		89A0C5B3E5F04C59A02DD001 /* ShortcutRecorderInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A0C5B1E5F04C59A02DD001 /* ShortcutRecorderInput.swift */; };
+		89A0C5B4E5F04C59A02DD001 /* ShortcutRecorderInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A0C5B2E5F04C59A02DD001 /* ShortcutRecorderInputTests.swift */; };
 		9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */; };
 		94CF7D2C65A9A2F6CCABCA92 /* CapturePersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */; };
 		9B6DE864F7F9D78BE7B6CA54 /* BackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6975993534B39BF8DEB32E /* BackupService.swift */; };
@@ -214,6 +216,8 @@
 		8C930E623DE20A82D94D4B3A /* PopoverCaptureFiltering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverCaptureFiltering.swift; sourceTree = "<group>"; };
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8FA9529C3BB40299A84C6FB8 /* RRuleInvalidInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleInvalidInputTests.swift; sourceTree = "<group>"; };
+		89A0C5B1E5F04C59A02DD001 /* ShortcutRecorderInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderInput.swift; sourceTree = "<group>"; };
+		89A0C5B2E5F04C59A02DD001 /* ShortcutRecorderInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderInputTests.swift; sourceTree = "<group>"; };
 		90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		975C23592B958F445105973E /* CaptureWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureWindowView.swift; sourceTree = "<group>"; };
 		9884E228CA7B8C32C3669A85 /* BackupMappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMappers.swift; sourceTree = "<group>"; };
@@ -310,6 +314,7 @@
 				8FA9529C3BB40299A84C6FB8 /* RRuleInvalidInputTests.swift */,
 				8A6C6B2B1A559FEFF67B391F /* RRuleOccurrenceEdgeCaseTests.swift */,
 				275F5DE20B1832CEA53FF535 /* SettingsOptionsTests.swift */,
+				89A0C5B2E5F04C59A02DD001 /* ShortcutRecorderInputTests.swift */,
 				EB4A20FE04DD7075E02C7092 /* SubredditCRUDTests.swift */,
 				BDFAC40DD76013F2B88EEC64 /* SubredditEventCRUDTests.swift */,
 				B3C81EDF4BBBB49EC3DEDA20 /* SubredditNameValidationTests.swift */,
@@ -440,6 +445,7 @@
 				1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */,
 				28906380DECDA56AD0DDE325 /* PreferencesView.swift */,
 				1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */,
+				89A0C5B1E5F04C59A02DD001 /* ShortcutRecorderInput.swift */,
 				90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */,
 				5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */,
 			);
@@ -591,6 +597,7 @@
 				57454FB537536D907117B756 /* RRuleOccurrenceEdgeCaseTests.swift in Sources */,
 				CCE3B3D5EE4B39D55222CA19 /* ResourcePackagingTests.swift in Sources */,
 				5417A38681E20BA30C06CD26 /* SettingsOptionsTests.swift in Sources */,
+				89A0C5B4E5F04C59A02DD001 /* ShortcutRecorderInputTests.swift in Sources */,
 				4907C5B4B92A0039716F0727 /* SubredditCRUDTests.swift in Sources */,
 				87AE17FDA4B3C169B340C8AA /* SubredditEventCRUDTests.swift in Sources */,
 				03D6222BEC9F6525C2727326 /* SubredditNameValidationTests.swift in Sources */,
@@ -664,6 +671,7 @@
 				17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */,
 				FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */,
 				1A56E70BA5F05C6021393E22 /* RedditReminderApp.swift in Sources */,
+				89A0C5B3E5F04C59A02DD001 /* ShortcutRecorderInput.swift in Sources */,
 				130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */,
 				35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */,
 				19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */,

--- a/Sources/Views/ShortcutRecorderInput.swift
+++ b/Sources/Views/ShortcutRecorderInput.swift
@@ -1,0 +1,60 @@
+@preconcurrency import CoreFoundation
+import Carbon.HIToolbox
+import Foundation
+
+struct ShortcutRecorderInput {
+  enum Result: Equatable {
+    case cancelled
+    case invalid(String)
+    case shortcut(KeyboardShortcutConfig)
+  }
+
+  static let validationMessage = "Use Command, Control, or Option with a key."
+
+  static func evaluate(keyCode: UInt16, modifiers: CGEventFlags, keyDisplay: String) -> Result {
+    guard keyCode != UInt16(kVK_Escape) else { return .cancelled }
+
+    let config = KeyboardShortcutConfig.custom(
+      keyCode: Int64(keyCode),
+      modifiers: modifiers,
+      keyDisplay: keyDisplay
+    )
+    return config.isValid ? .shortcut(config) : .invalid(validationMessage)
+  }
+
+  static func keyDisplay(keyCode: UInt16, charactersIgnoringModifiers: String?) -> String {
+    if let special = specialKeyDisplay[keyCode] {
+      return special
+    }
+
+    let characters = charactersIgnoringModifiers?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .uppercased()
+    return characters?.isEmpty == false ? characters! : "Key \(keyCode)"
+  }
+
+  private static let specialKeyDisplay: [UInt16: String] = [
+    UInt16(kVK_Space): "Space",
+    UInt16(kVK_Return): "Return",
+    UInt16(kVK_Tab): "Tab",
+    UInt16(kVK_Delete): "Delete",
+    UInt16(kVK_ForwardDelete): "Forward Delete",
+    UInt16(kVK_Escape): "Escape",
+    UInt16(kVK_LeftArrow): "←",
+    UInt16(kVK_RightArrow): "→",
+    UInt16(kVK_UpArrow): "↑",
+    UInt16(kVK_DownArrow): "↓",
+    UInt16(kVK_F1): "F1",
+    UInt16(kVK_F2): "F2",
+    UInt16(kVK_F3): "F3",
+    UInt16(kVK_F4): "F4",
+    UInt16(kVK_F5): "F5",
+    UInt16(kVK_F6): "F6",
+    UInt16(kVK_F7): "F7",
+    UInt16(kVK_F8): "F8",
+    UInt16(kVK_F9): "F9",
+    UInt16(kVK_F10): "F10",
+    UInt16(kVK_F11): "F11",
+    UInt16(kVK_F12): "F12",
+  ]
+}

--- a/Sources/Views/ShortcutRecorderView.swift
+++ b/Sources/Views/ShortcutRecorderView.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Carbon.HIToolbox
 import SwiftUI
 
 struct ShortcutRecorderView: View {
@@ -47,64 +46,26 @@ struct ShortcutRecorderView: View {
   }
 
   private func record(_ event: NSEvent) {
-    guard event.keyCode != UInt16(kVK_Escape) else {
-      isRecording = false
-      validationMessage = nil
-      return
-    }
-
-    let keyDisplay = Self.keyDisplay(for: event)
-    let next = KeyboardShortcutConfig.custom(
-      keyCode: Int64(event.keyCode),
+    let keyDisplay = ShortcutRecorderInput.keyDisplay(
+      keyCode: event.keyCode,
+      charactersIgnoringModifiers: event.charactersIgnoringModifiers
+    )
+    switch ShortcutRecorderInput.evaluate(
+      keyCode: event.keyCode,
       modifiers: event.modifierFlags.cgEventFlags,
       keyDisplay: keyDisplay
-    )
-
-    guard next.isValid else {
-      validationMessage = "Use Command, Control, or Option with a key."
-      return
+    ) {
+    case .cancelled:
+      isRecording = false
+      validationMessage = nil
+    case let .invalid(message):
+      validationMessage = message
+    case let .shortcut(next):
+      config = next
+      validationMessage = nil
+      isRecording = false
     }
-
-    config = next
-    validationMessage = nil
-    isRecording = false
   }
-
-  private static func keyDisplay(for event: NSEvent) -> String {
-    if let special = specialKeyDisplay[event.keyCode] {
-      return special
-    }
-
-    let characters = event.charactersIgnoringModifiers?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-      .uppercased()
-    return characters?.isEmpty == false ? characters! : "Key \(event.keyCode)"
-  }
-
-  private static let specialKeyDisplay: [UInt16: String] = [
-    UInt16(kVK_Space): "Space",
-    UInt16(kVK_Return): "Return",
-    UInt16(kVK_Tab): "Tab",
-    UInt16(kVK_Delete): "Delete",
-    UInt16(kVK_ForwardDelete): "Forward Delete",
-    UInt16(kVK_Escape): "Escape",
-    UInt16(kVK_LeftArrow): "←",
-    UInt16(kVK_RightArrow): "→",
-    UInt16(kVK_UpArrow): "↑",
-    UInt16(kVK_DownArrow): "↓",
-    UInt16(kVK_F1): "F1",
-    UInt16(kVK_F2): "F2",
-    UInt16(kVK_F3): "F3",
-    UInt16(kVK_F4): "F4",
-    UInt16(kVK_F5): "F5",
-    UInt16(kVK_F6): "F6",
-    UInt16(kVK_F7): "F7",
-    UInt16(kVK_F8): "F8",
-    UInt16(kVK_F9): "F9",
-    UInt16(kVK_F10): "F10",
-    UInt16(kVK_F11): "F11",
-    UInt16(kVK_F12): "F12",
-  ]
 }
 
 private struct ShortcutKeyCaptureView: NSViewRepresentable {

--- a/Tests/RedditReminderTests/ShortcutRecorderInputTests.swift
+++ b/Tests/RedditReminderTests/ShortcutRecorderInputTests.swift
@@ -1,0 +1,49 @@
+import Carbon.HIToolbox
+import Testing
+@testable import RedditReminder
+
+@Test func shortcutRecorderCancelsOnEscape() {
+    let result = ShortcutRecorderInput.evaluate(
+        keyCode: UInt16(kVK_Escape),
+        modifiers: [.maskCommand],
+        keyDisplay: "Escape"
+    )
+
+    #expect(result == .cancelled)
+}
+
+@Test func shortcutRecorderRejectsModifierOnlyInput() {
+    let result = ShortcutRecorderInput.evaluate(
+        keyCode: 35,
+        modifiers: [.maskShift],
+        keyDisplay: "P"
+    )
+
+    #expect(result == .invalid(ShortcutRecorderInput.validationMessage))
+}
+
+@Test func shortcutRecorderBuildsValidCustomShortcut() {
+    let result = ShortcutRecorderInput.evaluate(
+        keyCode: 35,
+        modifiers: [.maskCommand, .maskAlternate],
+        keyDisplay: "P"
+    )
+
+    #expect(result == .shortcut(KeyboardShortcutConfig.custom(
+        keyCode: 35,
+        modifiers: [.maskCommand, .maskAlternate],
+        keyDisplay: "P"
+    )))
+}
+
+@Test func shortcutRecorderNormalizesCharacterDisplay() {
+    #expect(ShortcutRecorderInput.keyDisplay(keyCode: 35, charactersIgnoringModifiers: " p ") == "P")
+}
+
+@Test func shortcutRecorderUsesFallbackDisplayForBlankCharacters() {
+    #expect(ShortcutRecorderInput.keyDisplay(keyCode: 1234, charactersIgnoringModifiers: " ") == "Key 1234")
+}
+
+@Test func shortcutRecorderNamesSpecialKeysWithoutEventConstruction() {
+    #expect(ShortcutRecorderInput.keyDisplay(keyCode: UInt16(kVK_Space), charactersIgnoringModifiers: nil) == "Space")
+}


### PR DESCRIPTION
## Summary
- extract shortcut recorder event interpretation into a testable helper
- keep the SwiftUI recorder focused on local state transitions
- add coverage for Escape cancel, invalid modifier-only input, valid custom shortcuts, and key display normalization

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build\n- pkill -x RedditReminder || true\n- git diff --check\n- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \\; | sort\n- rg -n "UserDefaults\\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true