### PR TITLE
feat: show subreddit input validation feedback

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		090F9D3B18C2B5C92FB9F5B7 /* EdgeCaseTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */; };
 		0A9365CFB7B1AB4C02CF61DB /* SubredditPeakSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */; };
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
+		0CE2B6354C93401B8D5B2001 /* SubredditInputValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE2B6344C93401B8D5B2001 /* SubredditInputValidation.swift */; };
 		0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E228CA7B8C32C3669A85 /* BackupMappers.swift */; };
 		1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */; };
 		12B7E4C8F9AB781325FFC21F /* ProjectPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */; };
@@ -216,6 +217,7 @@
 		8C930E623DE20A82D94D4B3A /* PopoverCaptureFiltering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverCaptureFiltering.swift; sourceTree = "<group>"; };
 		8F3630C63EE6A3A37D6E680B /* RedditReminder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RedditReminder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8FA9529C3BB40299A84C6FB8 /* RRuleInvalidInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleInvalidInputTests.swift; sourceTree = "<group>"; };
+		0CE2B6344C93401B8D5B2001 /* SubredditInputValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditInputValidation.swift; sourceTree = "<group>"; };
 		89A0C5B1E5F04C59A02DD001 /* ShortcutRecorderInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderInput.swift; sourceTree = "<group>"; };
 		89A0C5B2E5F04C59A02DD001 /* ShortcutRecorderInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderInputTests.swift; sourceTree = "<group>"; };
 		90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */,
 				B338E8D9C979B250564A392E /* QAFixtures.swift */,
 				46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */,
+				0CE2B6344C93401B8D5B2001 /* SubredditInputValidation.swift */,
 				70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */,
 				542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */,
 			);
@@ -675,6 +678,7 @@
 				130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */,
 				35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */,
 				19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */,
+				0CE2B6354C93401B8D5B2001 /* SubredditInputValidation.swift in Sources */,
 				0A9365CFB7B1AB4C02CF61DB /* SubredditPeakSelection.swift in Sources */,
 				2E04156554C7A2C39EF726A4 /* SubredditPersistenceActions.swift in Sources */,
 				4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */,

--- a/Sources/Utilities/SubredditInputValidation.swift
+++ b/Sources/Utilities/SubredditInputValidation.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct SubredditInputValidation: Equatable {
+    enum Feedback: Equatable {
+        case error(String)
+        case preview(String)
+    }
+
+    let canAdd: Bool
+    let feedback: Feedback?
+
+    @MainActor
+    static func evaluate(_ input: String, subreddits: [Subreddit]) -> SubredditInputValidation {
+        guard !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return SubredditInputValidation(canAdd: false, feedback: nil)
+        }
+
+        switch SubredditName.normalize(input) {
+        case .failure(let error):
+            return SubredditInputValidation(canAdd: false, feedback: .error(error.message))
+        case .success(let name):
+            guard SubredditPersistenceActions.isNameAvailable(name, subreddits: subreddits) else {
+                return SubredditInputValidation(canAdd: false, feedback: .error(SubredditName.ValidationError.duplicate.message))
+            }
+            return SubredditInputValidation(canAdd: true, feedback: .preview("Will add \(name)"))
+        }
+    }
+}

--- a/Sources/Utilities/SubredditPersistenceActions.swift
+++ b/Sources/Utilities/SubredditPersistenceActions.swift
@@ -10,8 +10,7 @@ enum SubredditPersistenceActions {
     }
 
     static func canAdd(_ input: String, subreddits: [Subreddit]) -> Bool {
-        guard let name = SubredditName.normalizedName(input) else { return false }
-        return isNameAvailable(name, subreddits: subreddits)
+        SubredditInputValidation.evaluate(input, subreddits: subreddits).canAdd
     }
 
     @discardableResult

--- a/Sources/Views/ChannelsView.swift
+++ b/Sources/Views/ChannelsView.swift
@@ -10,7 +10,7 @@ struct ChannelsTabView: View {
 
     @State private var expandedSubredditId: UUID?
     @State private var newSubredditName = ""
-    @State private var nameValidationMessage: String?
+    @State private var addFailureMessage: String?
     @State private var draggingSubreddit: Subreddit?
     @AppStorage(SettingsKey.defaultLeadTimeMinutes) private var defaultLeadTimeMinutes: Int = 60
 
@@ -24,7 +24,7 @@ struct ChannelsTabView: View {
                         .padding(7)
                         .inputFieldStyle(cornerRadius: 6)
                         .onChange(of: newSubredditName) {
-                            nameValidationMessage = nil
+                            addFailureMessage = nil
                         }
                         .onSubmit { addSubreddit() }
 
@@ -44,10 +44,10 @@ struct ChannelsTabView: View {
                     .disabled(!canAdd)
                 }
 
-                if let nameValidationMessage {
-                    Text(nameValidationMessage)
+                if let feedbackMessage {
+                    Text(feedbackMessage.text)
                         .font(.system(size: 10))
-                        .foregroundStyle(.red)
+                        .foregroundStyle(feedbackMessage.isError ? .red : .secondary)
                 }
             }
             .padding(12)
@@ -83,7 +83,26 @@ struct ChannelsTabView: View {
     }
 
     private var canAdd: Bool {
-        SubredditPersistenceActions.canAdd(newSubredditName, subreddits: subreddits)
+        inputValidation.canAdd
+    }
+
+    private var inputValidation: SubredditInputValidation {
+        SubredditInputValidation.evaluate(newSubredditName, subreddits: subreddits)
+    }
+
+    private var feedbackMessage: (text: String, isError: Bool)? {
+        if let addFailureMessage {
+            return (addFailureMessage, true)
+        }
+
+        switch inputValidation.feedback {
+        case .error(let message):
+            return (message, true)
+        case .preview(let message):
+            return (message, false)
+        case nil:
+            return nil
+        }
     }
 
     private func addSubreddit() {
@@ -96,9 +115,9 @@ struct ChannelsTabView: View {
         ) {
         case .success:
             newSubredditName = ""
-            nameValidationMessage = nil
+            addFailureMessage = nil
         case .failure(let error):
-            nameValidationMessage = error.message
+            addFailureMessage = error.message
         }
     }
 

--- a/Tests/RedditReminderTests/SubredditNameValidationTests.swift
+++ b/Tests/RedditReminderTests/SubredditNameValidationTests.swift
@@ -36,3 +36,40 @@ import Testing
 @Test func subredditNameRejectsTooLong() {
     #expect(SubredditName.normalize(String(repeating: "a", count: 22)) == .failure(.tooLong))
 }
+
+@Test @MainActor func subredditInputValidationHasNoFeedbackForEmptyInput() {
+    let validation = SubredditInputValidation.evaluate(" ", subreddits: [])
+
+    #expect(validation == SubredditInputValidation(canAdd: false, feedback: nil))
+}
+
+@Test @MainActor func subredditInputValidationShowsInvalidNameMessage() {
+    let validation = SubredditInputValidation.evaluate("bad name", subreddits: [])
+
+    #expect(validation == SubredditInputValidation(
+        canAdd: false,
+        feedback: .error(SubredditName.ValidationError.invalidCharacters.message)
+    ))
+}
+
+@Test @MainActor func subredditInputValidationShowsDuplicateMessage() {
+    let existing = Subreddit(name: "r/SwiftUI")
+    let validation = SubredditInputValidation.evaluate("swiftui", subreddits: [existing])
+
+    #expect(validation == SubredditInputValidation(
+        canAdd: false,
+        feedback: .error(SubredditName.ValidationError.duplicate.message)
+    ))
+}
+
+@Test @MainActor func subredditInputValidationPreviewsNormalizedName() {
+    let validation = SubredditInputValidation.evaluate(
+        "https://www.reddit.com/r/macOS/comments/abc",
+        subreddits: []
+    )
+
+    #expect(validation == SubredditInputValidation(
+        canAdd: true,
+        feedback: .preview("Will add r/macOS")
+    ))
+}


### PR DESCRIPTION
## Summary
- add a shared subreddit input validation state helper
- show inline invalid/duplicate feedback and normalized-name preview in Channels
- reuse the helper for add-button enablement
- cover empty, invalid, duplicate, and URL-normalized input states

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build\n- pkill -x RedditReminder || true\n- git diff --check\n- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \\; | sort\n- rg -n "UserDefaults\\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true