### PR TITLE
test: cover invalid media refs in imports

### DIFF
--- a/Tests/RedditReminderTests/BackupMediaPayloadTests.swift
+++ b/Tests/RedditReminderTests/BackupMediaPayloadTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftData
 import Testing
@@ -52,4 +53,67 @@ import Testing
     #expect(captures[0].mediaRefs == [ref])
     #expect(destinationMediaStore.loadImage(captureId: sourceCapture.id, ref: ref) != nil)
     #expect(destinationMediaStore.loadThumbnail(captureId: sourceCapture.id, ref: ref) != nil)
+}
+
+@Test @MainActor func backupImportRejectsEmbeddedMediaWithInvalidRefsBeforeClearingData() throws {
+    let container = try makeBackupContainer()
+    let context = ModelContext(container)
+    let existing = Capture(text: "Existing")
+    context.insert(existing)
+    try context.save()
+
+    let mediaRoot = temporaryBackupMediaRoot()
+    let mediaStore = MediaStore(rootDir: mediaRoot)
+    let outsideURL = mediaRoot.deletingLastPathComponent().appendingPathComponent("outside.png")
+    try? FileManager.default.removeItem(at: outsideURL)
+    let importedCaptureId = UUID()
+    let backup = AppBackup(
+        settings: BackupSettings(),
+        projects: [],
+        subreddits: [],
+        events: [],
+        captures: [
+            BackupCapture(
+                id: importedCaptureId,
+                text: "Imported",
+                notes: nil,
+                links: [],
+                mediaRefs: ["../outside.png"],
+                status: .queued,
+                createdAt: Date(),
+                postedAt: nil,
+                projectId: nil,
+                subredditIds: []
+            )
+        ],
+        mediaFiles: [
+            BackupMediaFile(
+                captureId: importedCaptureId,
+                ref: "../outside.png",
+                data: try backupPNGFixtureData()
+            )
+        ]
+    )
+    let data = try JSONEncoder().encode(backup)
+
+    do {
+        try BackupService().importBackup(from: data, into: context, mediaStore: mediaStore)
+        Issue.record("Expected invalid media reference error")
+    } catch MediaError.invalidReference {
+        let captures = try context.fetch(FetchDescriptor<Capture>())
+        #expect(captures.map(\.text) == ["Existing"])
+        #expect(!FileManager.default.fileExists(atPath: outsideURL.path))
+    } catch {
+        throw error
+    }
+}
+
+private func backupPNGFixtureData() throws -> Data {
+    let image = backupTestImage()
+    guard let tiff = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiff),
+          let png = bitmap.representation(using: .png, properties: [:]) else {
+        throw MediaError.encodingFailed
+    }
+    return png
 }

--- a/Tests/RedditReminderTests/MediaStoreTests.swift
+++ b/Tests/RedditReminderTests/MediaStoreTests.swift
@@ -153,6 +153,23 @@ import AppKit
   #expect(store.loadThumbnail(captureId: otherCaptureId, ref: otherRef) != nil)
 }
 
+@Test func saveDataRejectsInvalidMediaRefsBeforeWriting() throws {
+  let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let store = MediaStore(rootDir: rootDir)
+  let outsideURL = rootDir.deletingLastPathComponent().appendingPathComponent("outside.png")
+  try? FileManager.default.removeItem(at: outsideURL)
+  let data = try pngFixtureData()
+
+  do {
+    try store.saveData(data, captureId: UUID(), ref: "../outside.png")
+    Issue.record("Expected invalid reference error")
+  } catch MediaError.invalidReference {
+    #expect(!FileManager.default.fileExists(atPath: outsideURL.path))
+  } catch {
+    throw error
+  }
+}
+
 private func createTestImage(width: Int, height: Int) -> NSImage {
   let image = NSImage(size: NSSize(width: width, height: height))
   image.lockFocus()
@@ -160,4 +177,14 @@ private func createTestImage(width: Int, height: Int) -> NSImage {
   NSRect(x: 0, y: 0, width: width, height: height).fill()
   image.unlockFocus()
   return image
+}
+
+private func pngFixtureData() throws -> Data {
+  let image = createTestImage(width: 32, height: 32)
+  guard let tiff = image.tiffRepresentation,
+        let bitmap = NSBitmapImageRep(data: tiff),
+        let png = bitmap.representation(using: .png, properties: [:]) else {
+    throw MediaError.encodingFailed
+  }
+  return png
 }


### PR DESCRIPTION
## Summary
- cover MediaStore.saveData rejecting invalid refs before writes
- cover backup import rejecting embedded media refs before clearing existing data
- verify invalid refs cannot write outside the media root

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build\n- pkill -x RedditReminder || true\n- git diff --check\n- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \\; | sort\n- rg -n "UserDefaults\\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true