### PR TITLE
test: centralize notification identifiers

### DIFF
--- a/Sources/App/AppDelegateNotifications.swift
+++ b/Sources/App/AppDelegateNotifications.swift
@@ -8,7 +8,7 @@ extension AppDelegate {
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
-        let subredditName = userInfo["subredditName"] as? String
+        let subredditName = userInfo[AppNotificationIdentifiers.subredditNameUserInfoKey] as? String
         let actionId = response.actionIdentifier
 
         Task { @MainActor in
@@ -27,12 +27,12 @@ extension AppDelegate {
 
     func handleNotificationAction(_ actionId: String, subredditName: String?) {
         switch actionId {
-        case "MARK_POSTED_ACTION":
+        case AppNotificationIdentifiers.markPostedAction:
             if let subredditName {
                 markCapturesAsPosted(forSubreddit: subredditName)
             }
             menuBarController.openPopover()
-        case UNNotificationDefaultActionIdentifier, "OPEN_ACTION":
+        case UNNotificationDefaultActionIdentifier, AppNotificationIdentifiers.openAction:
             menuBarController.openPopover()
         default:
             break

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -16,6 +16,23 @@ extension UNUserNotificationCenter: NotificationCenterProtocol {
   }
 }
 
+enum AppNotificationIdentifiers {
+  static let openAction = "OPEN_ACTION"
+  static let markPostedAction = "MARK_POSTED_ACTION"
+  static let postingWindowCategory = "POSTING_WINDOW"
+  static let emptyQueueNudgeCategory = "EMPTY_QUEUE_NUDGE"
+  static let eventIdUserInfoKey = "eventId"
+  static let subredditNameUserInfoKey = "subredditName"
+
+  static func windowRequestId(eventId: String) -> String {
+    "window-\(eventId)"
+  }
+
+  static func nudgeRequestId(eventId: String) -> String {
+    "nudge-\(eventId)"
+  }
+}
+
 @MainActor
 final class NotificationService {
   private let center: any NotificationCenterProtocol
@@ -38,31 +55,36 @@ final class NotificationService {
   }
 
   func registerCategories() {
+    let categories = Self.categories()
+    if let realCenter = center as? UNUserNotificationCenter {
+      realCenter.setNotificationCategories(categories)
+    }
+  }
+
+  static func categories() -> Set<UNNotificationCategory> {
     let openAction = UNNotificationAction(
-      identifier: "OPEN_ACTION",
+      identifier: AppNotificationIdentifiers.openAction,
       title: "Open",
       options: [.foreground]
     )
     let markPostedAction = UNNotificationAction(
-      identifier: "MARK_POSTED_ACTION",
+      identifier: AppNotificationIdentifiers.markPostedAction,
       title: "Mark as Posted",
       options: []
     )
 
     let windowCategory = UNNotificationCategory(
-      identifier: "POSTING_WINDOW",
+      identifier: AppNotificationIdentifiers.postingWindowCategory,
       actions: [openAction, markPostedAction],
       intentIdentifiers: []
     )
     let nudgeCategory = UNNotificationCategory(
-      identifier: "EMPTY_QUEUE_NUDGE",
+      identifier: AppNotificationIdentifiers.emptyQueueNudgeCategory,
       actions: [openAction],
       intentIdentifiers: []
     )
 
-    if let realCenter = center as? UNUserNotificationCenter {
-      realCenter.setNotificationCategories([windowCategory, nudgeCategory])
-    }
+    return [windowCategory, nudgeCategory]
   }
 
   func scheduleWindowNotification(
@@ -76,8 +98,11 @@ final class NotificationService {
     content.title = title
     content.body = body
     content.sound = .default
-    content.categoryIdentifier = "POSTING_WINDOW"
-    content.userInfo = ["eventId": eventId, "subredditName": subredditName]
+    content.categoryIdentifier = AppNotificationIdentifiers.postingWindowCategory
+    content.userInfo = [
+      AppNotificationIdentifiers.eventIdUserInfoKey: eventId,
+      AppNotificationIdentifiers.subredditNameUserInfoKey: subredditName
+    ]
 
     let comps = Calendar.current.dateComponents(
       [.year, .month, .day, .hour, .minute],
@@ -86,7 +111,7 @@ final class NotificationService {
     let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
 
     let request = UNNotificationRequest(
-      identifier: "window-\(eventId)",
+      identifier: AppNotificationIdentifiers.windowRequestId(eventId: eventId),
       content: content,
       trigger: trigger
     )
@@ -108,8 +133,11 @@ final class NotificationService {
     content.title = "\(eventName) is approaching"
     content.body = "Nothing queued for \(subredditName) yet — capture something?"
     content.sound = .default
-    content.categoryIdentifier = "EMPTY_QUEUE_NUDGE"
-    content.userInfo = ["eventId": eventId, "subredditName": subredditName]
+    content.categoryIdentifier = AppNotificationIdentifiers.emptyQueueNudgeCategory
+    content.userInfo = [
+      AppNotificationIdentifiers.eventIdUserInfoKey: eventId,
+      AppNotificationIdentifiers.subredditNameUserInfoKey: subredditName
+    ]
 
     let comps = Calendar.current.dateComponents(
       [.year, .month, .day, .hour, .minute],
@@ -118,7 +146,7 @@ final class NotificationService {
     let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
 
     let request = UNNotificationRequest(
-      identifier: "nudge-\(eventId)",
+      identifier: AppNotificationIdentifiers.nudgeRequestId(eventId: eventId),
       content: content,
       trigger: trigger
     )
@@ -132,7 +160,10 @@ final class NotificationService {
 
   func cancelNotifications(eventId: String) {
     center.removePendingNotificationRequests(
-      withIdentifiers: ["window-\(eventId)", "nudge-\(eventId)"]
+      withIdentifiers: [
+        AppNotificationIdentifiers.windowRequestId(eventId: eventId),
+        AppNotificationIdentifiers.nudgeRequestId(eventId: eventId)
+      ]
     )
   }
 

--- a/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateSchedulingTests.swift
@@ -68,8 +68,14 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
 
     await delegate.scheduleNotifications(activeEvents: [event], windows: [window])
 
-    #expect(center.addedRequests.map(\.identifier).contains("window-\(event.id.uuidString)"))
-    #expect(center.addedRequests.map(\.identifier).contains("nudge-\(event.id.uuidString)"))
+    #expect(
+        center.addedRequests.map(\.identifier)
+            .contains(AppNotificationIdentifiers.windowRequestId(eventId: event.id.uuidString))
+    )
+    #expect(
+        center.addedRequests.map(\.identifier)
+            .contains(AppNotificationIdentifiers.nudgeRequestId(eventId: event.id.uuidString))
+    )
 }
 
 @Test @MainActor func appDelegateSkipsPastNotificationFireDatesAndCancelsExistingRequests() async {
@@ -100,8 +106,16 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
 
     #expect(center.addedRequests.isEmpty)
     #expect(center.removedIdentifiers.count == 1)
-    #expect(center.removedIdentifiers[0].contains("window-\(event.id.uuidString)"))
-    #expect(center.removedIdentifiers[0].contains("nudge-\(event.id.uuidString)"))
+    #expect(
+        center.removedIdentifiers[0].contains(
+            AppNotificationIdentifiers.windowRequestId(eventId: event.id.uuidString)
+        )
+    )
+    #expect(
+        center.removedIdentifiers[0].contains(
+            AppNotificationIdentifiers.nudgeRequestId(eventId: event.id.uuidString)
+        )
+    )
 }
 
 @Test @MainActor func appDelegateCancelsStaleActiveEvents() async {
@@ -124,8 +138,16 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
     await delegate.scheduleNotifications(activeEvents: [stale], windows: [])
 
     #expect(center.removedIdentifiers.count == 1)
-    #expect(center.removedIdentifiers[0].contains("window-\(stale.id.uuidString)"))
-    #expect(center.removedIdentifiers[0].contains("nudge-\(stale.id.uuidString)"))
+    #expect(
+        center.removedIdentifiers[0].contains(
+            AppNotificationIdentifiers.windowRequestId(eventId: stale.id.uuidString)
+        )
+    )
+    #expect(
+        center.removedIdentifiers[0].contains(
+            AppNotificationIdentifiers.nudgeRequestId(eventId: stale.id.uuidString)
+        )
+    )
 }
 
 @Test @MainActor func appDelegateCancelsAllWhenNotificationsDisabled() async {

--- a/Tests/RedditReminderTests/NotificationServiceTests.swift
+++ b/Tests/RedditReminderTests/NotificationServiceTests.swift
@@ -68,12 +68,15 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     )
 
     #expect(mock.addedRequests.count == 1)
-    #expect(mock.addedRequests[0].identifier == "window-\(eventId)")
-    #expect(mock.addedRequests[0].content.categoryIdentifier == "POSTING_WINDOW")
+    #expect(mock.addedRequests[0].identifier == AppNotificationIdentifiers.windowRequestId(eventId: eventId))
+    #expect(mock.addedRequests[0].content.categoryIdentifier == AppNotificationIdentifiers.postingWindowCategory)
     #expect(mock.addedRequests[0].content.title == "Post time")
     #expect(mock.addedRequests[0].content.body == "2 captures ready")
-    #expect(mock.addedRequests[0].content.userInfo["subredditName"] as? String == "r/Swift")
-    #expect(mock.addedRequests[0].content.userInfo["eventId"] as? String == eventId)
+    #expect(
+        mock.addedRequests[0].content.userInfo[AppNotificationIdentifiers.subredditNameUserInfoKey] as? String ==
+            "r/Swift"
+    )
+    #expect(mock.addedRequests[0].content.userInfo[AppNotificationIdentifiers.eventIdUserInfoKey] as? String == eventId)
 }
 
 @Test @MainActor func nudgeNotificationUsesCorrectIdentifier() {
@@ -89,12 +92,32 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     )
 
     #expect(mock.addedRequests.count == 1)
-    #expect(mock.addedRequests[0].identifier == "nudge-\(eventId)")
-    #expect(mock.addedRequests[0].content.categoryIdentifier == "EMPTY_QUEUE_NUDGE")
+    #expect(mock.addedRequests[0].identifier == AppNotificationIdentifiers.nudgeRequestId(eventId: eventId))
+    #expect(mock.addedRequests[0].content.categoryIdentifier == AppNotificationIdentifiers.emptyQueueNudgeCategory)
     #expect(mock.addedRequests[0].content.title == "Show-off Saturday is approaching")
     #expect(mock.addedRequests[0].content.body == "Nothing queued for r/SideProject yet — capture something?")
-    #expect(mock.addedRequests[0].content.userInfo["subredditName"] as? String == "r/SideProject")
-    #expect(mock.addedRequests[0].content.userInfo["eventId"] as? String == eventId)
+    #expect(
+        mock.addedRequests[0].content.userInfo[AppNotificationIdentifiers.subredditNameUserInfoKey] as? String ==
+            "r/SideProject"
+    )
+    #expect(mock.addedRequests[0].content.userInfo[AppNotificationIdentifiers.eventIdUserInfoKey] as? String == eventId)
+}
+
+@Test @MainActor func notificationCategoriesUseSharedActionIdentifiers() {
+    let categories = NotificationService.categories()
+    let windowCategory = categories.first {
+        $0.identifier == AppNotificationIdentifiers.postingWindowCategory
+    }
+    let nudgeCategory = categories.first {
+        $0.identifier == AppNotificationIdentifiers.emptyQueueNudgeCategory
+    }
+
+    #expect(categories.count == 2)
+    #expect(windowCategory?.actions.map(\.identifier) == [
+        AppNotificationIdentifiers.openAction,
+        AppNotificationIdentifiers.markPostedAction
+    ])
+    #expect(nudgeCategory?.actions.map(\.identifier) == [AppNotificationIdentifiers.openAction])
 }
 
 // MARK: - Cancellation
@@ -107,8 +130,8 @@ private final class MockNotificationCenter: NotificationCenterProtocol, @uncheck
     service.cancelNotifications(eventId: eventId)
 
     #expect(mock.removedIdentifiers.count == 1)
-    #expect(mock.removedIdentifiers[0].contains("window-TEST-UUID"))
-    #expect(mock.removedIdentifiers[0].contains("nudge-TEST-UUID"))
+    #expect(mock.removedIdentifiers[0].contains(AppNotificationIdentifiers.windowRequestId(eventId: eventId)))
+    #expect(mock.removedIdentifiers[0].contains(AppNotificationIdentifiers.nudgeRequestId(eventId: eventId)))
 }
 
 @Test @MainActor func cancelAllRemovesEverything() {

--- a/Tests/RedditReminderTests/SubredditPersistenceActionsTests.swift
+++ b/Tests/RedditReminderTests/SubredditPersistenceActionsTests.swift
@@ -150,8 +150,8 @@ private func makeSubredditActionsContainer() throws -> ModelContainer {
 
     #expect(ok)
     #expect(center.removedIdentifiers.count == 1)
-    #expect(center.removedIdentifiers[0].contains("window-\(eventId)"))
-    #expect(center.removedIdentifiers[0].contains("nudge-\(eventId)"))
+    #expect(center.removedIdentifiers[0].contains(AppNotificationIdentifiers.windowRequestId(eventId: eventId)))
+    #expect(center.removedIdentifiers[0].contains(AppNotificationIdentifiers.nudgeRequestId(eventId: eventId)))
     #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 0)
     #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 0)
 }


### PR DESCRIPTION
## Summary
- add shared notification action, category, userInfo, and request ID identifiers
- route notification scheduling, cancellation, and action handling through the shared identifiers
- add category factory coverage so action IDs used by notifications stay aligned with the app delegate handler

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true
