### PR TITLE
test: cover notification action routing

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     let heuristicsStore: HeuristicsStore
     let notificationScheduler: NotificationScheduler
     let defaults: UserDefaults
+    let openPopoverForNotificationAction: @MainActor () -> Void
 
     var modelContainer: ModelContainer?
 
@@ -33,7 +34,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         notificationService: NotificationService,
         heuristicsStore: HeuristicsStore,
         defaults: UserDefaults = .standard,
-        globalShortcut: any GlobalShortcutRegistering = GlobalShortcut()
+        globalShortcut: any GlobalShortcutRegistering = GlobalShortcut(),
+        notificationActionPopoverOpener: (@MainActor () -> Void)? = nil
     ) {
         self.menuBarController = menuBarController
         self.timingEngine = timingEngine
@@ -41,6 +43,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         self.heuristicsStore = heuristicsStore
         self.defaults = defaults
         self.globalShortcut = globalShortcut
+        self.openPopoverForNotificationAction = notificationActionPopoverOpener ?? {
+            menuBarController.openPopover()
+        }
         self.notificationScheduler = NotificationScheduler(notificationService: notificationService, defaults: defaults)
         super.init()
     }

--- a/Sources/App/AppDelegateNotifications.swift
+++ b/Sources/App/AppDelegateNotifications.swift
@@ -31,9 +31,9 @@ extension AppDelegate {
             if let subredditName {
                 markCapturesAsPosted(forSubreddit: subredditName)
             }
-            menuBarController.openPopover()
+            openPopoverForNotificationAction()
         case UNNotificationDefaultActionIdentifier, AppNotificationIdentifiers.openAction:
-            menuBarController.openPopover()
+            openPopoverForNotificationAction()
         default:
             break
         }

--- a/Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift
@@ -5,6 +5,61 @@ import UserNotifications
 @testable import RedditReminder
 
 @Test @MainActor func appDelegateMarksQueuedCapturesForNotificationSubredditAsPosted() throws {
+    let fixture = try makeCaptureFixture()
+    let delegate = makeNotificationActionDelegate()
+    delegate.modelContainer = fixture.container
+
+    delegate.markCapturesAsPosted(forSubreddit: "r/Test")
+
+    #expect(fixture.matching.status == .posted)
+    #expect(fixture.matching.postedAt != nil)
+    #expect(fixture.alreadyPosted.status == .posted)
+    #expect(fixture.unrelated.status == .queued)
+}
+
+@Test @MainActor func appDelegateMarkPostedActionIsNoopWithoutContainer() {
+    let delegate = makeNotificationActionDelegate()
+
+    delegate.markCapturesAsPosted(forSubreddit: "r/Test")
+}
+
+@Test @MainActor func appDelegateMarkPostedActionMarksCapturesAndOpensPopoverHeadlessly() throws {
+    let fixture = try makeCaptureFixture()
+    let recorder = PopoverActionRecorder()
+    let delegate = makeNotificationActionDelegate(popoverOpener: recorder.open)
+    delegate.modelContainer = fixture.container
+
+    delegate.handleNotificationAction(AppNotificationIdentifiers.markPostedAction, subredditName: "r/Test")
+
+    #expect(fixture.matching.status == .posted)
+    #expect(fixture.unrelated.status == .queued)
+    #expect(recorder.openCount == 1)
+}
+
+@Test @MainActor func appDelegateOpenActionOpensPopoverHeadlessly() {
+    let recorder = PopoverActionRecorder()
+    let delegate = makeNotificationActionDelegate(popoverOpener: recorder.open)
+
+    delegate.handleNotificationAction(AppNotificationIdentifiers.openAction, subredditName: nil)
+    delegate.handleNotificationAction(UNNotificationDefaultActionIdentifier, subredditName: nil)
+    delegate.handleNotificationAction("UNKNOWN_ACTION", subredditName: nil)
+
+    #expect(recorder.openCount == 2)
+}
+
+@MainActor
+private func makeNotificationActionDelegate(popoverOpener: (@MainActor () -> Void)? = nil) -> AppDelegate {
+    AppDelegate(
+        menuBarController: MenuBarController(),
+        timingEngine: TimingEngine(),
+        notificationService: NotificationService(center: NotificationActionCenter()),
+        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false),
+        notificationActionPopoverOpener: popoverOpener
+    )
+}
+
+@MainActor
+private func makeCaptureFixture() throws -> CaptureFixture {
     let container = try ModelContainer(
         for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
         configurations: ModelConfiguration(isStoredInMemoryOnly: true)
@@ -22,31 +77,28 @@ import UserNotifications
     context.insert(alreadyPosted)
     context.insert(unrelated)
     try context.save()
-    let delegate = makeNotificationActionDelegate()
-    delegate.modelContainer = container
-
-    delegate.markCapturesAsPosted(forSubreddit: "r/Test")
-
-    #expect(matching.status == .posted)
-    #expect(matching.postedAt != nil)
-    #expect(alreadyPosted.status == .posted)
-    #expect(unrelated.status == .queued)
+    return CaptureFixture(
+        container: container,
+        matching: matching,
+        alreadyPosted: alreadyPosted,
+        unrelated: unrelated
+    )
 }
 
-@Test @MainActor func appDelegateMarkPostedActionIsNoopWithoutContainer() {
-    let delegate = makeNotificationActionDelegate()
-
-    delegate.markCapturesAsPosted(forSubreddit: "r/Test")
+private struct CaptureFixture {
+    let container: ModelContainer
+    let matching: Capture
+    let alreadyPosted: Capture
+    let unrelated: Capture
 }
 
 @MainActor
-private func makeNotificationActionDelegate() -> AppDelegate {
-    AppDelegate(
-        menuBarController: MenuBarController(),
-        timingEngine: TimingEngine(),
-        notificationService: NotificationService(center: NotificationActionCenter()),
-        heuristicsStore: HeuristicsStore(bundle: Bundle(path: "/tmp") ?? .main, logsMissingResource: false)
-    )
+private final class PopoverActionRecorder {
+    private(set) var openCount = 0
+
+    func open() {
+        openCount += 1
+    }
 }
 
 private final class NotificationActionCenter: NotificationCenterProtocol, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- inject the notification-action popover opener so action routing can be tested without showing UI
- cover mark-posted routing, open/default routing, and unknown action no-op behavior
- keep production behavior opening the real menu bar popover

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true
