### PR TITLE
fix: restore media attachments in original order

### DIFF
--- a/Sources/Utilities/CaptureMediaEditing.swift
+++ b/Sources/Utilities/CaptureMediaEditing.swift
@@ -15,11 +15,28 @@ enum CaptureMediaEditing {
     static func restoreExisting(
         ref: String,
         existingRefs: inout [String],
-        removedRefs: inout [String]
+        removedRefs: inout [String],
+        originalRefs: [String] = []
     ) {
         removedRefs.removeAll { $0 == ref }
         if !existingRefs.contains(ref) {
-            existingRefs.append(ref)
+            insertRestoredRef(ref, into: &existingRefs, originalRefs: originalRefs)
         }
+    }
+
+    private static func insertRestoredRef(
+        _ ref: String,
+        into existingRefs: inout [String],
+        originalRefs: [String]
+    ) {
+        guard let originalIndex = originalRefs.firstIndex(of: ref) else {
+            existingRefs.append(ref)
+            return
+        }
+        let insertionIndex = existingRefs.firstIndex { existingRef in
+            guard let existingIndex = originalRefs.firstIndex(of: existingRef) else { return false }
+            return existingIndex > originalIndex
+        } ?? existingRefs.endIndex
+        existingRefs.insert(ref, at: insertionIndex)
     }
 }

--- a/Sources/Views/CaptureMediaSection.swift
+++ b/Sources/Views/CaptureMediaSection.swift
@@ -6,6 +6,7 @@ struct CaptureMediaSection: View {
     var captureId: UUID?
     @Binding var existingRefs: [String]
     @Binding var removedRefs: [String]
+    var originalRefs: [String]
     var mediaStore: MediaStore = MediaStore()
 
     @State private var isDragOver: Bool = false
@@ -50,7 +51,8 @@ struct CaptureMediaSection: View {
                                 CaptureMediaEditing.restoreExisting(
                                     ref: ref,
                                     existingRefs: &existingRefs,
-                                    removedRefs: &removedRefs
+                                    removedRefs: &removedRefs,
+                                    originalRefs: originalRefs
                                 )
                             }
                         )
@@ -121,12 +123,14 @@ struct CaptureMediaSection: View {
         captureId: UUID? = nil,
         existingRefs: Binding<[String]> = .constant([]),
         removedRefs: Binding<[String]> = .constant([]),
+        originalRefs: [String] = [],
         mediaStore: MediaStore = MediaStore()
     ) {
         self._droppedFiles = droppedFiles
         self.captureId = captureId
         self._existingRefs = existingRefs
         self._removedRefs = removedRefs
+        self.originalRefs = originalRefs
         self.mediaStore = mediaStore
     }
 

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -23,6 +23,7 @@ struct CaptureWindowView: View {
     @State private var droppedFiles: [URL] = []
     @State private var existingMediaRefs: [String] = []
     @State private var removedMediaRefs: [String] = []
+    @State private var originalMediaRefs: [String] = []
     @State private var showPreview: Bool = false
     @State private var saveError: String?
     @AppStorage(SettingsKey.defaultProjectId) private var defaultProjectId: String = ""
@@ -46,7 +47,6 @@ struct CaptureWindowView: View {
                                             .clipShape(RoundedRectangle(cornerRadius: 3))
                                     }
                                     .buttonStyle(.plain)
-
                                     Button(action: { showPreview = true }) {
                                         Text("Preview")
                                             .font(.system(size: 9, weight: showPreview ? .semibold : .medium))
@@ -58,7 +58,6 @@ struct CaptureWindowView: View {
                                     .buttonStyle(.plain)
                                 }
                             }
-
                             if showPreview {
                                 MarkdownPreviewView(text: text)
                                     .frame(minHeight: 72)
@@ -72,7 +71,6 @@ struct CaptureWindowView: View {
                             }
                         }
                     }
-
                     fieldSection("SUBREDDIT") {
                         CaptureSubredditPicker(
                             subreddits: subreddits,
@@ -110,7 +108,8 @@ struct CaptureWindowView: View {
                             droppedFiles: $droppedFiles,
                             captureId: editCaptureId,
                             existingRefs: $existingMediaRefs,
-                            removedRefs: $removedMediaRefs
+                            removedRefs: $removedMediaRefs,
+                            originalRefs: originalMediaRefs
                         )
                     }
 
@@ -215,6 +214,7 @@ struct CaptureWindowView: View {
             selectedSubreddits = Set(capture.subreddits.map(\.id))
             links = capture.links
             existingMediaRefs = capture.mediaRefs
+            originalMediaRefs = capture.mediaRefs
         }
     }
 }

--- a/Tests/RedditReminderTests/CaptureMediaEditingTests.swift
+++ b/Tests/RedditReminderTests/CaptureMediaEditingTests.swift
@@ -29,7 +29,22 @@ import Testing
     #expect(removedRefs == ["first.png"])
 }
 
-@Test func captureMediaEditingRestoresRemovedRef() {
+@Test func captureMediaEditingRestoresRemovedRefToOriginalPosition() {
+    var existingRefs = ["second.png"]
+    var removedRefs = ["first.png"]
+
+    CaptureMediaEditing.restoreExisting(
+        ref: "first.png",
+        existingRefs: &existingRefs,
+        removedRefs: &removedRefs,
+        originalRefs: ["first.png", "second.png"]
+    )
+
+    #expect(existingRefs == ["first.png", "second.png"])
+    #expect(removedRefs.isEmpty)
+}
+
+@Test func captureMediaEditingAppendsRestoredRefWithoutOriginalPosition() {
     var existingRefs = ["second.png"]
     var removedRefs = ["first.png"]
 
@@ -50,7 +65,8 @@ import Testing
     CaptureMediaEditing.restoreExisting(
         ref: "first.png",
         existingRefs: &existingRefs,
-        removedRefs: &removedRefs
+        removedRefs: &removedRefs,
+        originalRefs: ["first.png", "second.png"]
     )
 
     #expect(existingRefs == ["first.png", "second.png"])


### PR DESCRIPTION
## Summary
- track original media ref order while editing a capture
- restore removed existing attachments back into their original relative position
- keep append fallback behavior when no original ordering is available

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true
