### PR TITLE
feat: show unsupported media selection feedback

### DIFF
--- a/Sources/Utilities/CaptureMediaAccessibility.swift
+++ b/Sources/Utilities/CaptureMediaAccessibility.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum CaptureMediaAccessibility {
     static let dropZone = "capture-media-drop-zone"
+    static let selectionError = "capture-media-selection-error"
 
     static func previewExisting(ref: String) -> String {
         "capture-media-preview-existing-\(token(ref))"

--- a/Sources/Utilities/CaptureMediaSelection.swift
+++ b/Sources/Utilities/CaptureMediaSelection.swift
@@ -2,8 +2,18 @@ import Foundation
 import UniformTypeIdentifiers
 
 enum CaptureMediaSelection {
+    struct Result: Equatable {
+        let imageURLs: [URL]
+        let rejectedCount: Int
+    }
+
     static func imageURLs(from urls: [URL]) -> [URL] {
-        urls.filter(isImageURL)
+        result(from: urls).imageURLs
+    }
+
+    static func result(from urls: [URL]) -> Result {
+        let imageURLs = urls.filter(isImageURL)
+        return Result(imageURLs: imageURLs, rejectedCount: urls.count - imageURLs.count)
     }
 
     static func isImageURL(_ url: URL) -> Bool {

--- a/Sources/Views/CaptureMediaSection.swift
+++ b/Sources/Views/CaptureMediaSection.swift
@@ -12,6 +12,7 @@ struct CaptureMediaSection: View {
     @State private var isDragOver: Bool = false
     @State private var isShowingImporter: Bool = false
     @State private var previewImage: PreviewImage?
+    @State private var mediaSelectionError: String?
 
     var body: some View {
         VStack(spacing: 8) {
@@ -105,6 +106,11 @@ struct CaptureMediaSection: View {
                         NSLog("RedditReminder: media import failed: \(error)")
                     }
                 }
+            if let mediaSelectionError {
+                Text(mediaSelectionError)
+                    .font(.system(size: 11)).foregroundStyle(.red)
+                    .accessibilityIdentifier(CaptureMediaAccessibility.selectionError)
+            }
         }
         .sheet(item: $previewImage) { image in
             VStack(spacing: 0) {
@@ -140,8 +146,9 @@ struct CaptureMediaSection: View {
     }
 
     private func appendImageFiles(_ urls: [URL]) {
-        let imageURLs = CaptureMediaSelection.imageURLs(from: urls)
-        droppedFiles.append(contentsOf: imageURLs)
+        let result = CaptureMediaSelection.result(from: urls)
+        droppedFiles.append(contentsOf: result.imageURLs)
+        mediaSelectionError = result.rejectedCount > 0 ? "Only image files can be attached." : nil
     }
 
     private func handleFileDrop(_ providers: [NSItemProvider]) -> Bool {

--- a/Tests/RedditReminderTests/CaptureMediaAccessibilityTests.swift
+++ b/Tests/RedditReminderTests/CaptureMediaAccessibilityTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @Test func captureMediaAccessibilityDefinesStableDropZoneIdentifier() {
     #expect(CaptureMediaAccessibility.dropZone == "capture-media-drop-zone")
+    #expect(CaptureMediaAccessibility.selectionError == "capture-media-selection-error")
 }
 
 @Test func captureMediaAccessibilityNormalizesExistingRefIdentifiers() {

--- a/Tests/RedditReminderTests/CaptureMediaSelectionTests.swift
+++ b/Tests/RedditReminderTests/CaptureMediaSelectionTests.swift
@@ -14,6 +14,9 @@ import Testing
         try? FileManager.default.removeItem(at: textURL)
     }
 
+    let result = CaptureMediaSelection.result(from: [imageURL, textURL])
+    #expect(result.imageURLs == [imageURL])
+    #expect(result.rejectedCount == 1)
     #expect(CaptureMediaSelection.imageURLs(from: [imageURL, textURL]) == [imageURL])
 }
 


### PR DESCRIPTION
## Summary
- make media selection report rejected files instead of silently dropping them
- show inline feedback when dropped/imported files are not attachable images
- add stable accessibility coverage for the new feedback state

## Verification
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build
- pkill -x RedditReminder || true
- git diff --check
- find Sources Tests/RedditReminderTests -name '*.swift' -exec awk 'END { if (NR > 220) print FILENAME ": " NR " lines" }' {} \; | sort
- rg -n "UserDefaults\.standard|fatalError|try!|as!|TODO|FIXME" Sources Tests -g '*.swift' || true
