### PR TITLE
feat: UX improvements, UI test target, and Xcode 26 signing fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-debug test install install-debug clean generate qa
+.PHONY: build build-debug test ui-test install install-debug clean generate qa
 
 APP_NAME := RedditReminder
 PROJ := $(APP_NAME).xcodeproj
@@ -26,13 +26,37 @@ build-debug: generate
 	xcodebuild build \
 	  -project $(PROJ) -scheme $(APP_NAME) \
 	  -configuration Debug -destination 'platform=macOS' \
-	  -derivedDataPath $(BUILD_DIR)
+	  -derivedDataPath $(BUILD_DIR) \
+	  CODE_SIGN_IDENTITY=- \
+	  CODE_SIGN_STYLE=Manual \
+	  DEVELOPMENT_TEAM= \
+	  ENABLE_DEBUG_DYLIB=NO \
+	  ENABLE_HARDENED_RUNTIME=NO \
+	  OTHER_CODE_SIGN_FLAGS=
 
 test: generate
 	xcodebuild test \
 	  -project $(PROJ) -scheme $(APP_NAME) \
 	  -destination 'platform=macOS' \
-	  -derivedDataPath $(BUILD_DIR)
+	  -derivedDataPath $(BUILD_DIR) \
+	  CODE_SIGN_IDENTITY=- \
+	  CODE_SIGN_STYLE=Manual \
+	  DEVELOPMENT_TEAM= \
+	  ENABLE_DEBUG_DYLIB=NO \
+	  ENABLE_HARDENED_RUNTIME=NO \
+	  OTHER_CODE_SIGN_FLAGS=
+
+ui-test: generate
+	xcodebuild test \
+	  -project $(PROJ) -scheme $(APP_NAME)UITests \
+	  -destination 'platform=macOS' \
+	  -derivedDataPath $(BUILD_DIR) \
+	  CODE_SIGN_IDENTITY=- \
+	  CODE_SIGN_STYLE=Manual \
+	  DEVELOPMENT_TEAM= \
+	  ENABLE_DEBUG_DYLIB=NO \
+	  ENABLE_HARDENED_RUNTIME=NO \
+	  OTHER_CODE_SIGN_FLAGS=
 
 install: build
 	$(call copy_app,Release)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The global shortcut requires macOS Accessibility permission for the terminal/app
 ```sh
 make generate
 make test
+make ui-test
 make build-debug
 make install-debug
 ```
@@ -46,6 +47,7 @@ make qa
 ```
 
 The QA script uses System Events and CGWindowList, so the terminal needs Accessibility and Screen Recording permissions.
+The UI test target exercises native menu/window smoke coverage. It requires macOS UI automation permission for Xcode or the invoking terminal, and a signing setup that can run XCTest UI bundles.
 
 ## Notes
 

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		474176ACD33799B0C433D8C5 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A523CACB82BF88E46FD3E /* MenuBarController.swift */; };
 		4907C5B4B92A0039716F0727 /* SubredditCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A20FE04DD7075E02C7092 /* SubredditCRUDTests.swift */; };
 		4C87F6917C877808862C53EE /* TimingEngineWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF54D62FF6A1D2DE6F157E60 /* TimingEngineWindowTests.swift */; };
+		4CCDBAA2B4BC2B3BB97CF38E /* RedditReminderSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EFC2837CE8B91A22B6A64D /* RedditReminderSmokeUITests.swift */; };
 		4D3F5B8B0063D3B9C1242D33 /* BackupTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72682A4379AE1A17B7D4559 /* BackupTypes.swift */; };
 		4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */; };
 		4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975C23592B958F445105973E /* CaptureWindowView.swift */; };
@@ -156,6 +157,13 @@
 			remoteGlobalIDString = 2DE905B343BA95604DD1F3C9;
 			remoteInfo = RedditReminder;
 		};
+		6E900711DA43C71348F391EC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BEC597240F8AE7DEB88002A9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2DE905B343BA95604DD1F3C9;
+			remoteInfo = RedditReminder;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -189,6 +197,7 @@
 		303FB325A99764563E4FB2AC /* PostHandoffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHandoffView.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		319AF7913AB415361A12500A /* PopoverTimingPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverTimingPresentationTests.swift; sourceTree = "<group>"; };
+		31EFC2837CE8B91A22B6A64D /* RedditReminderSmokeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderSmokeUITests.swift; sourceTree = "<group>"; };
 		331A38F1DC4F9E18A7D4A332 /* CaptureEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureEdgeCaseTests.swift; sourceTree = "<group>"; };
 		3769CC097D084C4E6DD34081 /* AppRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntime.swift; sourceTree = "<group>"; };
 		3788B79517572C51854172CC /* PlannerTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerTabView.swift; sourceTree = "<group>"; };
@@ -287,6 +296,7 @@
 		D5570C2EF1DD747B43C6F4ED /* PopoverChromeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverChromeViewTests.swift; sourceTree = "<group>"; };
 		D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsPersistenceTests.swift; sourceTree = "<group>"; };
 		DCB15AEFC17C70DC66CA4A05 /* PostHandoffViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHandoffViewHelpers.swift; sourceTree = "<group>"; };
+		DFF5D9C0E578E3A6273498E5 /* RedditReminderUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E02E746452EDD7B17443C493 /* CaptureCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureCRUDTests.swift; sourceTree = "<group>"; };
 		E1A24B20995755A25E411F4F /* UrgencyPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrgencyPresentation.swift; sourceTree = "<group>"; };
 		E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverChromeViews.swift; sourceTree = "<group>"; };
@@ -422,6 +432,7 @@
 			children = (
 				8F3630C63EE6A3A37D6E680B /* RedditReminder.app */,
 				317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */,
+				DFF5D9C0E578E3A6273498E5 /* RedditReminderUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -438,8 +449,17 @@
 			isa = PBXGroup;
 			children = (
 				465002D9A45996043976CEED /* RedditReminderTests */,
+				BC5638C6E3613905E02C4A7D /* RedditReminderUITests */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		BC5638C6E3613905E02C4A7D /* RedditReminderUITests */ = {
+			isa = PBXGroup;
+			children = (
+				31EFC2837CE8B91A22B6A64D /* RedditReminderSmokeUITests.swift */,
+			);
+			path = RedditReminderUITests;
 			sourceTree = "<group>";
 		};
 		C3AB2DC71CFCC2F390448956 /* Models */ = {
@@ -553,6 +573,24 @@
 			productReference = 8F3630C63EE6A3A37D6E680B /* RedditReminder.app */;
 			productType = "com.apple.product-type.application";
 		};
+		A990D0C6BF3F1C6102E5820C /* RedditReminderUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E8653FAAC968CC0C97F4A073 /* Build configuration list for PBXNativeTarget "RedditReminderUITests" */;
+			buildPhases = (
+				0AE594544843C4C4CDC3B162 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				51BC801A2ACF2D213EFCAA10 /* PBXTargetDependency */,
+			);
+			name = RedditReminderUITests;
+			packageProductDependencies = (
+			);
+			productName = RedditReminderUITests;
+			productReference = DFF5D9C0E578E3A6273498E5 /* RedditReminderUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		C2D6AA8E625EF0CD6E6BF408 /* RedditReminderTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 84FCFAC0815DCF99B6EC57E6 /* Build configuration list for PBXNativeTarget "RedditReminderTests" */;
@@ -584,6 +622,11 @@
 						DevelopmentTeam = B3A6AN2HA4;
 						ProvisioningStyle = Automatic;
 					};
+					A990D0C6BF3F1C6102E5820C = {
+						DevelopmentTeam = B3A6AN2HA4;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 2DE905B343BA95604DD1F3C9;
+					};
 					C2D6AA8E625EF0CD6E6BF408 = {
 						DevelopmentTeam = B3A6AN2HA4;
 						ProvisioningStyle = Automatic;
@@ -606,6 +649,7 @@
 			targets = (
 				2DE905B343BA95604DD1F3C9 /* RedditReminder */,
 				C2D6AA8E625EF0CD6E6BF408 /* RedditReminderTests */,
+				A990D0C6BF3F1C6102E5820C /* RedditReminderUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -622,6 +666,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0AE594544843C4C4CDC3B162 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4CCDBAA2B4BC2B3BB97CF38E /* RedditReminderSmokeUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8FFFE14891477FBE3BE423A2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -782,9 +834,48 @@
 			target = 2DE905B343BA95604DD1F3C9 /* RedditReminder */;
 			targetProxy = 13C0B876C4ED55C9BEE4E343 /* PBXContainerItemProxy */;
 		};
+		51BC801A2ACF2D213EFCAA10 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2DE905B343BA95604DD1F3C9 /* RedditReminder */;
+			targetProxy = 6E900711DA43C71348F391EC /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		7C2ECEEA56BD3DB349004439 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.neonwatty.RedditReminderUITests;
+				SDKROOT = macosx;
+				TEST_TARGET_NAME = RedditReminder;
+			};
+			name = Debug;
+		};
+		943C10974B51C2E1536CBFFA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.neonwatty.RedditReminderUITests;
+				SDKROOT = macosx;
+				TEST_TARGET_NAME = RedditReminder;
+			};
+			name = Release;
+		};
 		954A7B373093533B17B5963D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1012,6 +1103,15 @@
 			buildConfigurations = (
 				B530A36744BCA26147E62FD7 /* Debug */,
 				C0B50FBE13A640519B67ECC9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		E8653FAAC968CC0C97F4A073 /* Build configuration list for PBXNativeTarget "RedditReminderUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7C2ECEEA56BD3DB349004439 /* Debug */,
+				943C10974B51C2E1536CBFFA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/RedditReminder.xcodeproj/xcshareddata/xcschemes/RedditReminder.xcscheme
+++ b/RedditReminder.xcodeproj/xcshareddata/xcschemes/RedditReminder.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+               BuildableName = "RedditReminder.app"
+               BlueprintName = "RedditReminder"
+               ReferencedContainer = "container:RedditReminder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+            BuildableName = "RedditReminder.app"
+            BlueprintName = "RedditReminder"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C2D6AA8E625EF0CD6E6BF408"
+               BuildableName = "RedditReminderTests.xctest"
+               BlueprintName = "RedditReminderTests"
+               ReferencedContainer = "container:RedditReminder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+            BuildableName = "RedditReminder.app"
+            BlueprintName = "RedditReminder"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+            BuildableName = "RedditReminder.app"
+            BlueprintName = "RedditReminder"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RedditReminder.xcodeproj/xcshareddata/xcschemes/RedditReminderUITests.xcscheme
+++ b/RedditReminder.xcodeproj/xcshareddata/xcschemes/RedditReminderUITests.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+               BuildableName = "RedditReminder.app"
+               BlueprintName = "RedditReminder"
+               ReferencedContainer = "container:RedditReminder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A990D0C6BF3F1C6102E5820C"
+               BuildableName = "RedditReminderUITests.xctest"
+               BlueprintName = "RedditReminderUITests"
+               ReferencedContainer = "container:RedditReminder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+            BuildableName = "RedditReminder.app"
+            BlueprintName = "RedditReminder"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A990D0C6BF3F1C6102E5820C"
+               BuildableName = "RedditReminderUITests.xctest"
+               BlueprintName = "RedditReminderUITests"
+               ReferencedContainer = "container:RedditReminder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+            BuildableName = "RedditReminder.app"
+            BlueprintName = "RedditReminder"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DE905B343BA95604DD1F3C9"
+            BuildableName = "RedditReminder.app"
+            BlueprintName = "RedditReminder"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -67,11 +67,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       menuBarController.onQACreateTestCapture = { [weak self] in
         self?.qaCreateTestCapture()
       }
+      menuBarController.onQACreateTitleOnlyTestCapture = { [weak self] in
+        self?.qaCreateTitleOnlyTestCapture()
+      }
+      menuBarController.onQACreateMultiSubredditTestCapture = { [weak self] in
+        self?.qaCreateMultiSubredditTestCapture()
+      }
       menuBarController.onQADeleteTestCaptures = { [weak self] in
         self?.qaDeleteTestCaptures()
       }
       menuBarController.onQACopyFirstQueuedCaptureTitle = { [weak self] in
         self?.qaCopyFirstQueuedCaptureTitle()
+      }
+      menuBarController.onQACopyFirstQueuedCaptureSummary = { [weak self] in
+        self?.qaCopyFirstQueuedCaptureSummary()
       }
       menuBarController.onQACopyFirstPostedCaptureSummary = { [weak self] in
         self?.qaCopyFirstPostedCaptureSummary()

--- a/Sources/App/AppDelegateQA.swift
+++ b/Sources/App/AppDelegateQA.swift
@@ -6,6 +6,9 @@ import SwiftData
     static let qaTestCaptureTitle = "QA Workflow Capture"
     static let qaTestCaptureText = "Created by RedditReminder automated QA."
     static let qaTestCaptureLink = "https://example.com/reddit-reminder-qa"
+    static let qaTitleOnlyCaptureTitle = "QA Title Only Capture"
+    static let qaMultiSubredditCaptureTitle = "QA Multi Subreddit Capture"
+    static let qaMultiSubredditCaptureText = "Created to verify compact destination summaries."
     static let qaPostedURL =
       "https://www.reddit.com/r/SideProject/comments/qa123/reddit_reminder_qa/"
 
@@ -39,13 +42,70 @@ import SwiftData
     }
 
     @discardableResult
+    func qaCreateTitleOnlyTestCapture() -> Bool {
+      guard let container = modelContainer else { return false }
+      let context = container.mainContext
+
+      do {
+        guard let subreddit = try qaSubreddit(named: "r/SideProject", in: context) else {
+          return false
+        }
+        let capture = Capture(
+          title: Self.qaTitleOnlyCaptureTitle,
+          text: "",
+          subreddits: [subreddit]
+        )
+        context.insert(capture)
+        try context.save()
+        runRefreshCycle()
+        return true
+      } catch {
+        context.rollback()
+        NSLog("RedditReminder: QA create title-only test capture failed: \(error)")
+        return false
+      }
+    }
+
+    @discardableResult
+    func qaCreateMultiSubredditTestCapture() -> Bool {
+      guard let container = modelContainer else { return false }
+      let context = container.mainContext
+
+      do {
+        let subreddits = try qaSubreddits(named: ["r/SideProject", "r/SwiftUI"], in: context)
+        guard subreddits.count >= 2 else { return false }
+        let capture = Capture(
+          title: Self.qaMultiSubredditCaptureTitle,
+          text: Self.qaMultiSubredditCaptureText,
+          subreddits: subreddits
+        )
+        context.insert(capture)
+        try context.save()
+        runRefreshCycle()
+        return true
+      } catch {
+        context.rollback()
+        NSLog("RedditReminder: QA create multi-subreddit test capture failed: \(error)")
+        return false
+      }
+    }
+
+    @discardableResult
     func qaDeleteTestCaptures() -> Bool {
       guard let container = modelContainer else { return false }
       let context = container.mainContext
 
       do {
         let captures = try context.fetch(FetchDescriptor<Capture>())
-        let testCaptures = captures.filter { $0.title == Self.qaTestCaptureTitle }
+        let qaTitles = [
+          Self.qaTestCaptureTitle,
+          Self.qaTitleOnlyCaptureTitle,
+          Self.qaMultiSubredditCaptureTitle,
+        ]
+        let testCaptures = captures.filter { capture in
+          guard let title = capture.title else { return false }
+          return qaTitles.contains(title)
+        }
         guard !testCaptures.isEmpty else { return true }
 
         menuBarController.closePostHandoffWindow()
@@ -73,6 +133,14 @@ import SwiftData
         !title.isEmpty
       else { return false }
       return RedditPostingActions.copyText(title, to: pasteboard)
+    }
+
+    @discardableResult
+    func qaCopyFirstQueuedCaptureSummary(
+      to pasteboard: any PasteboardWriting = NSPasteboard.general
+    ) -> Bool {
+      guard let capture = qaFirstQueuedCapture() else { return false }
+      return RedditPostingActions.copyText(qaSummary(for: capture, includePostedURL: false), to: pasteboard)
     }
 
     @discardableResult
@@ -124,16 +192,7 @@ import SwiftData
       -> Bool
     {
       guard let capture = qaFirstPostedCapture() else { return false }
-      let title = capture.title?.trimmingCharacters(in: .whitespacesAndNewlines)
-      let subreddit = capture.subreddits.first?.name ?? "No subreddit"
-      let postedURL = capture.postedURL?.trimmingCharacters(in: .whitespacesAndNewlines)
-      let summary = [
-        "Title: \((title?.isEmpty == false) ? title! : "<none>")",
-        "Body: \(capture.text.trimmingCharacters(in: .whitespacesAndNewlines))",
-        "Subreddit: \(subreddit)",
-        "Posted URL: \((postedURL?.isEmpty == false) ? postedURL! : "<none>")",
-      ].joined(separator: "\n")
-      return RedditPostingActions.copyText(summary, to: pasteboard)
+      return RedditPostingActions.copyText(qaSummary(for: capture, includePostedURL: true), to: pasteboard)
     }
 
     @discardableResult
@@ -176,6 +235,35 @@ import SwiftData
         NSLog("RedditReminder: QA fetch first posted capture failed: \(error)")
         return nil
       }
+    }
+
+    private func qaSubreddit(named name: String, in context: ModelContext) throws -> Subreddit? {
+      let subreddits = try context.fetch(FetchDescriptor<Subreddit>())
+      return subreddits.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+        ?? subreddits.sorted { $0.sortOrder < $1.sortOrder }.first
+    }
+
+    private func qaSubreddits(named names: [String], in context: ModelContext) throws -> [Subreddit] {
+      let subreddits = try context.fetch(FetchDescriptor<Subreddit>())
+      return names.compactMap { name in
+        subreddits.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+      }
+    }
+
+    private func qaSummary(for capture: Capture, includePostedURL: Bool) -> String {
+      let title = capture.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let body = capture.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      let subreddit = CaptureHelpers.subredditSummary(for: capture.subreddits) ?? "No subreddit"
+      var lines = [
+        "Title: \((title?.isEmpty == false) ? title! : "<none>")",
+        "Body: \(body.isEmpty ? "<none>" : body)",
+        "Subreddit: \(subreddit)",
+      ]
+      if includePostedURL {
+        let postedURL = capture.postedURL?.trimmingCharacters(in: .whitespacesAndNewlines)
+        lines.append("Posted URL: \((postedURL?.isEmpty == false) ? postedURL! : "<none>")")
+      }
+      return lines.joined(separator: "\n")
     }
   }
 #endif

--- a/Sources/Services/MenuBarController.swift
+++ b/Sources/Services/MenuBarController.swift
@@ -26,8 +26,11 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
     var onQAMarkFirstQueuedCapturePosted: (() -> Void)?
     var onQAMarkFirstQueuedCapturePostedWithURL: (() -> Void)?
     var onQACreateTestCapture: (() -> Void)?
+    var onQACreateTitleOnlyTestCapture: (() -> Void)?
+    var onQACreateMultiSubredditTestCapture: (() -> Void)?
     var onQADeleteTestCaptures: (() -> Void)?
     var onQACopyFirstQueuedCaptureTitle: (() -> Void)?
+    var onQACopyFirstQueuedCaptureSummary: (() -> Void)?
     var onQACopyFirstPostedCaptureSummary: (() -> Void)?
     var onQACopyFirstPostedURL: (() -> Void)?
   #endif

--- a/Sources/Services/MenuBarControllerMenus.swift
+++ b/Sources/Services/MenuBarControllerMenus.swift
@@ -57,6 +57,9 @@ extension MenuBarController {
       addQAItem("Copy First Queued Capture", #selector(handleQACopyFirstQueuedCapture), to: qaMenu)
       addQAItem(
         "Copy First Queued Capture Title", #selector(handleQACopyFirstQueuedCaptureTitle), to: qaMenu)
+      addQAItem(
+        "Copy First Queued Capture Summary", #selector(handleQACopyFirstQueuedCaptureSummary),
+        to: qaMenu)
       addQAItem("Copy First Queued Submit URL", #selector(handleQACopyFirstQueuedSubmitURL), to: qaMenu)
       addQAItem("Mark First Queued Capture Posted", #selector(handleQAMarkFirstQueuedCapturePosted), to: qaMenu)
       addQAItem(
@@ -69,6 +72,10 @@ extension MenuBarController {
 
       qaMenu.addItem(NSMenuItem.separator())
       addQAItem("Create Test Capture", #selector(handleQACreateTestCapture), to: qaMenu)
+      addQAItem("Create Title Only Test Capture", #selector(handleQACreateTitleOnlyTestCapture), to: qaMenu)
+      addQAItem(
+        "Create Multi Subreddit Test Capture", #selector(handleQACreateMultiSubredditTestCapture),
+        to: qaMenu)
       addQAItem("Delete Test Captures", #selector(handleQADeleteTestCaptures), to: qaMenu)
 
       mainMenu.addItem(qaMenuItem)
@@ -100,12 +107,24 @@ extension MenuBarController {
       onQACreateTestCapture?()
     }
 
+    @objc private func handleQACreateTitleOnlyTestCapture() {
+      onQACreateTitleOnlyTestCapture?()
+    }
+
+    @objc private func handleQACreateMultiSubredditTestCapture() {
+      onQACreateMultiSubredditTestCapture?()
+    }
+
     @objc private func handleQADeleteTestCaptures() {
       onQADeleteTestCaptures?()
     }
 
     @objc private func handleQACopyFirstQueuedCaptureTitle() {
       onQACopyFirstQueuedCaptureTitle?()
+    }
+
+    @objc private func handleQACopyFirstQueuedCaptureSummary() {
+      onQACopyFirstQueuedCaptureSummary?()
     }
 
     @objc private func handleQACopyFirstPostedCaptureSummary() {

--- a/Sources/Utilities/CaptureHelpers.swift
+++ b/Sources/Utilities/CaptureHelpers.swift
@@ -20,20 +20,39 @@ enum CaptureHelpers {
     }
 
     /// Validates that a capture form has the minimum required fields.
-    static func canSave(text: String, selectedSubredditCount: Int) -> Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && selectedSubredditCount > 0
+    static func canSave(title: String, text: String, selectedSubredditCount: Int) -> Bool {
+        let hasTitle = !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return (hasTitle || hasText) && selectedSubredditCount > 0
+    }
+
+    static func subredditSummary(for subreddits: [Subreddit]) -> String? {
+        let names = subreddits
+            .sorted {
+                if $0.sortOrder == $1.sortOrder {
+                    return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+                }
+                return $0.sortOrder < $1.sortOrder
+            }
+            .map(\.name)
+        guard let first = names.first else { return nil }
+        return names.count == 1 ? first : "\(first) +\(names.count - 1)"
     }
 
     static func matchesSearch(_ capture: Capture, query: String) -> Bool {
         let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !normalized.isEmpty else { return true }
 
-        let fields = [
+        var fields: [String] = [
+            capture.title ?? "",
             capture.text,
             capture.notes ?? "",
             capture.project?.name ?? "",
-            capture.project?.projectDescription ?? ""
-        ] + capture.links + capture.mediaRefs + capture.subreddits.map(\.name)
+            capture.project?.projectDescription ?? "",
+        ]
+        fields.append(contentsOf: capture.links)
+        fields.append(contentsOf: capture.mediaRefs)
+        fields.append(contentsOf: capture.subreddits.map(\.name))
 
         return fields.contains { $0.lowercased().contains(normalized) }
     }

--- a/Sources/Views/CaptureCardView.swift
+++ b/Sources/Views/CaptureCardView.swift
@@ -103,10 +103,12 @@ struct CaptureCardView: View {
           .font(.system(size: 12, weight: .semibold))
           .foregroundStyle(.primary)
           .lineLimit(1)
-        Text(capture.text)
-          .font(.system(size: 11))
-          .foregroundStyle(.secondary)
-          .lineLimit(2)
+        if !capture.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          Text(capture.text)
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+        }
       } else {
         Text(capture.text)
           .font(.system(size: 12))
@@ -115,10 +117,11 @@ struct CaptureCardView: View {
       }
 
       HStack(spacing: 6) {
-        if let sub = capture.subreddits.first {
-          Text(sub.name)
+        if let subredditSummary {
+          Text(subredditSummary)
             .font(.system(size: 10, weight: .medium))
             .foregroundStyle(AppColors.redditOrange)
+            .lineLimit(1)
         }
 
         if !capture.links.isEmpty || !capture.mediaRefs.isEmpty || capture.notes != nil {
@@ -175,6 +178,10 @@ struct CaptureCardView: View {
       parts.append("notes")
     }
     return parts.joined(separator: " · ")
+  }
+
+  private var subredditSummary: String? {
+    CaptureHelpers.subredditSummary(for: capture.subreddits)
   }
 }
 

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -44,7 +44,7 @@ struct CaptureWindowView: View {
               .accessibilityIdentifier("captureWindow.title")
           }
 
-          fieldSection("CAPTURE TEXT") {
+          fieldSection("CAPTURE TEXT", optional: true) {
             VStack(spacing: 6) {
               HStack {
                 Spacer()
@@ -204,7 +204,11 @@ struct CaptureWindowView: View {
   }
 
   private var canSave: Bool {
-    CaptureHelpers.canSave(text: text, selectedSubredditCount: selectedSubreddits.count)
+    CaptureHelpers.canSave(
+      title: title,
+      text: text,
+      selectedSubredditCount: selectedSubreddits.count
+    )
   }
   private func save() {
     guard canSave else { return }

--- a/Sources/Views/PlannerTabView.swift
+++ b/Sources/Views/PlannerTabView.swift
@@ -6,6 +6,7 @@ struct PlannerTabView: View {
   @Query(sort: \Capture.createdAt, order: .reverse) private var captures: [Capture]
 
   @State private var timingEngine = TimingEngine()
+  private let refreshTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
   private var activeEvents: [SubredditEvent] {
     PopoverTimingPresentation.activeEvents(from: allEvents)
@@ -37,6 +38,9 @@ struct PlannerTabView: View {
       refreshTiming()
     }
     .onChange(of: PopoverTimingPresentation.captureTimingSignature(from: captures)) {
+      refreshTiming()
+    }
+    .onReceive(refreshTimer) { _ in
       refreshTiming()
     }
   }

--- a/Sources/Views/PostedListView.swift
+++ b/Sources/Views/PostedListView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct PostedListView: View {
   nonisolated static let openPostedLinkAccessibilityLabel = "Open posted link"
+  nonisolated static let restoreAccessibilityLabel = "Move posted capture back to queue"
+  nonisolated static let deleteAccessibilityLabel = "Delete posted capture"
 
   let captures: [Capture]
   var onOpenPostedURL: ((Capture) -> Void)? = nil
@@ -26,10 +28,12 @@ struct PostedListView: View {
             .font(.system(size: 12, weight: .semibold))
             .foregroundStyle(.primary)
             .lineLimit(1)
-          Text(capture.text)
-            .font(.system(size: 11))
-            .foregroundStyle(.secondary)
-            .lineLimit(2)
+          if !capture.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            Text(capture.text)
+              .font(.system(size: 11))
+              .foregroundStyle(.secondary)
+              .lineLimit(2)
+          }
         } else {
           Text(capture.text)
             .font(.system(size: 12))
@@ -37,10 +41,11 @@ struct PostedListView: View {
             .lineLimit(2)
         }
         HStack(spacing: 6) {
-          if let sub = capture.subreddits.first {
-            Text(sub.name)
+          if let subredditSummary = CaptureHelpers.subredditSummary(for: capture.subreddits) {
+            Text(subredditSummary)
               .font(.system(size: 10, weight: .medium))
               .foregroundStyle(AppColors.redditOrange)
+              .lineLimit(1)
           }
           if let postedAt = capture.postedAt {
             Text("\u{00B7}").font(.system(size: 9)).foregroundStyle(.secondary)
@@ -59,17 +64,28 @@ struct PostedListView: View {
       Spacer(minLength: 0)
       HStack(spacing: 8) {
         if let onOpenPostedURL, capture.postedURL != nil {
-          Button(action: { onOpenPostedURL(capture) }) {
-            Label(Self.openPostedLinkAccessibilityLabel, systemImage: "arrow.up.right.square")
-              .labelStyle(.iconOnly)
-              .font(.system(size: 12, weight: .medium))
-              .foregroundStyle(.secondary)
-              .frame(width: 18, height: 18)
-          }
-          .buttonStyle(.plain)
-          .help(Self.openPostedLinkAccessibilityLabel)
-          .accessibilityLabel(Self.openPostedLinkAccessibilityLabel)
-          .accessibilityIdentifier("postedList.openPostedLink")
+          actionButton(
+            systemName: "arrow.up.right.square",
+            label: Self.openPostedLinkAccessibilityLabel,
+            identifier: "postedList.openPostedLink",
+            action: { onOpenPostedURL(capture) }
+          )
+        }
+        if let onRestore {
+          actionButton(
+            systemName: "arrow.uturn.backward",
+            label: Self.restoreAccessibilityLabel,
+            identifier: "postedList.restore",
+            action: { onRestore(capture) }
+          )
+        }
+        if let onDelete {
+          actionButton(
+            systemName: "trash",
+            label: Self.deleteAccessibilityLabel,
+            identifier: "postedList.delete",
+            action: { onDelete(capture) }
+          )
         }
         Image(systemName: "checkmark.circle.fill")
           .font(.system(size: 12))
@@ -92,5 +108,25 @@ struct PostedListView: View {
         Button("Delete", role: .destructive) { onDelete(capture) }
       }
     }
+  }
+
+  private func actionButton(
+    systemName: String,
+    label: String,
+    identifier: String,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Label(label, systemImage: systemName)
+        .labelStyle(.iconOnly)
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(.secondary)
+        .frame(width: 18, height: 18)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help(label)
+    .accessibilityLabel(label)
+    .accessibilityIdentifier(identifier)
   }
 }

--- a/Tests/RedditReminderTests/CaptureCardViewTests.swift
+++ b/Tests/RedditReminderTests/CaptureCardViewTests.swift
@@ -9,3 +9,9 @@ import Testing
   #expect(CaptureCardView.markPostedAccessibilityLabel == "Mark as posted")
   #expect(CaptureCardView.deleteAccessibilityLabel == "Delete capture")
 }
+
+@Test func postedListExposesVisibleRecoveryActionAccessibilityLabels() {
+  #expect(PostedListView.openPostedLinkAccessibilityLabel == "Open posted link")
+  #expect(PostedListView.restoreAccessibilityLabel == "Move posted capture back to queue")
+  #expect(PostedListView.deleteAccessibilityLabel == "Delete posted capture")
+}

--- a/Tests/RedditReminderTests/CaptureHelpersTests.swift
+++ b/Tests/RedditReminderTests/CaptureHelpersTests.swift
@@ -49,30 +49,58 @@ import SwiftData
 
 // MARK: - canSave
 
-@Test func canSaveRequiresNonEmptyTextAndSubreddits() {
-    #expect(CaptureHelpers.canSave(text: "Hello", selectedSubredditCount: 1) == true)
+@Test func canSaveAcceptsNonEmptyTextAndSubreddits() {
+    #expect(CaptureHelpers.canSave(title: "", text: "Hello", selectedSubredditCount: 1))
 }
 
-@Test func canSaveRejectsEmptyText() {
-    #expect(CaptureHelpers.canSave(text: "", selectedSubredditCount: 1) == false)
+@Test func canSaveAcceptsNonEmptyTitleAndSubreddits() {
+    #expect(CaptureHelpers.canSave(title: "Hello", text: "", selectedSubredditCount: 1))
 }
 
-@Test func canSaveRejectsWhitespaceOnlyText() {
-    #expect(CaptureHelpers.canSave(text: "   \n  ", selectedSubredditCount: 1) == false)
+@Test func canSaveRejectsEmptyTitleAndText() {
+    #expect(CaptureHelpers.canSave(title: "", text: "", selectedSubredditCount: 1) == false)
+}
+
+@Test func canSaveRejectsWhitespaceOnlyTitleAndText() {
+    #expect(
+        CaptureHelpers.canSave(title: "  ", text: "   \n  ", selectedSubredditCount: 1) == false)
 }
 
 @Test func canSaveRejectsZeroSubreddits() {
-    #expect(CaptureHelpers.canSave(text: "Hello", selectedSubredditCount: 0) == false)
+    #expect(CaptureHelpers.canSave(title: "Title", text: "Hello", selectedSubredditCount: 0) == false)
 }
 
 @Test func canSaveRejectsBothEmpty() {
-    #expect(CaptureHelpers.canSave(text: "", selectedSubredditCount: 0) == false)
+    #expect(CaptureHelpers.canSave(title: "", text: "", selectedSubredditCount: 0) == false)
+}
+
+// MARK: - subredditSummary
+
+@Test func subredditSummaryReturnsNilForNoSubreddits() {
+    #expect(CaptureHelpers.subredditSummary(for: []) == nil)
+}
+
+@Test func subredditSummaryReturnsSingleSubredditName() {
+    #expect(CaptureHelpers.subredditSummary(for: [Subreddit(name: "r/SwiftUI")]) == "r/SwiftUI")
+}
+
+@Test func subredditSummaryUsesSortOrderAndRemainingCount() {
+    let later = Subreddit(name: "r/macOS", sortOrder: 2)
+    let first = Subreddit(name: "r/SideProject", sortOrder: 0)
+    let middle = Subreddit(name: "r/SwiftUI", sortOrder: 1)
+
+    #expect(CaptureHelpers.subredditSummary(for: [later, first, middle]) == "r/SideProject +2")
 }
 
 // MARK: - search
 
 @Test func captureSearchMatchesText() {
     let capture = Capture(text: "Launch notes")
+    #expect(CaptureHelpers.matchesSearch(capture, query: "launch"))
+}
+
+@Test func captureSearchMatchesTitle() {
+    let capture = Capture(title: "Launch notes", text: "")
     #expect(CaptureHelpers.matchesSearch(capture, query: "launch"))
 }
 

--- a/Tests/RedditReminderUITests/RedditReminderSmokeUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderSmokeUITests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+final class RedditReminderSmokeUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["--seed-qa"]
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    func testKeyboardCommandsOpenPrimaryWindows() throws {
+        app.launch()
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 5)
+                || app.wait(for: .runningBackground, timeout: 5)
+        )
+
+        app.activate()
+        app.typeKey("n", modifierFlags: .command)
+        XCTAssertTrue(app.windows["New Capture"].waitForExistence(timeout: 3))
+
+        app.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(app.windows["RedditReminder Preferences"].waitForExistence(timeout: 3))
+    }
+}

--- a/docs/manual-qa-workflows.md
+++ b/docs/manual-qa-workflows.md
@@ -34,6 +34,12 @@ Use this checklist after UX changes to verify the app still supports the full po
 - [ ] Confirm selected subreddit names appear.
 - [ ] Edit the capture if editing is available.
 - [ ] Confirm changes persist.
+- [ ] Create a title-only capture.
+- [ ] Confirm Save enables after selecting a subreddit.
+- [ ] Confirm the title-only queue row has no blank body gap.
+- [ ] Create a capture assigned to multiple subreddits.
+- [ ] Confirm the queue row shows the first destination plus the remaining count, such as `r/SideProject +1`.
+- [ ] Confirm the compact destination text does not crowd the action buttons.
 
 ## 3. Post Handoff
 
@@ -61,6 +67,11 @@ Use this checklist after UX changes to verify the app still supports the full po
 - [ ] Open the saved Reddit URL.
 - [ ] Repeat with another capture and leave the URL blank.
 - [ ] Confirm history records the post without showing a broken link.
+- [ ] Confirm posted rows show visible restore and delete actions.
+- [ ] Confirm the restore and delete icons are understandable and not too dense.
+- [ ] Restore a posted capture and confirm it returns to the queue.
+- [ ] Delete a posted capture and confirm the destructive confirmation/toast behavior feels correct.
+- [ ] Confirm posted rows for multi-subreddit captures show the first destination plus the remaining count.
 
 ## 5. Delete Safety
 
@@ -84,6 +95,8 @@ Use this checklist after UX changes to verify the app still supports the full po
 - [ ] Confirm readiness count updates.
 - [ ] Post or delete the capture.
 - [ ] Confirm readiness updates again.
+- [ ] Leave Planner open for over one minute.
+- [ ] Confirm the timer refresh does not cause visible flicker, scroll jumps, or row overlap.
 
 ## 7. Backup And Restore
 

--- a/project.yml
+++ b/project.yml
@@ -52,3 +52,33 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.neonwatty.RedditReminderTests
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/RedditReminder.app/Contents/MacOS/RedditReminder
         BUNDLE_LOADER: $(TEST_HOST)
+
+  RedditReminderUITests:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: Tests/RedditReminderUITests
+    dependencies:
+      - target: RedditReminder
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: com.neonwatty.RedditReminderUITests
+
+schemes:
+  RedditReminder:
+    build:
+      targets:
+        RedditReminder: all
+    test:
+      targets:
+        - RedditReminderTests
+
+  RedditReminderUITests:
+    build:
+      targets:
+        RedditReminder: all
+        RedditReminderUITests: [test]
+    test:
+      targets:
+        - RedditReminderUITests

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -562,6 +562,33 @@ Posted URL: <none>" "$posted_without_url_summary"
 
 click_menu_item "QA" "Delete Test Captures"
 
+click_menu_item "QA" "Create Title Only Test Capture"
+printf "sentinel" | pbcopy
+click_menu_item "QA" "Copy First Queued Capture Summary"
+title_only_summary=$(pbpaste)
+assert_eq "QA title-only queued summary" "Title: QA Title Only Capture
+Body: <none>
+Subreddit: r/SideProject" "$title_only_summary"
+
+click_menu_item "QA" "Create Multi Subreddit Test Capture"
+printf "sentinel" | pbcopy
+click_menu_item "QA" "Copy First Queued Capture Summary"
+multi_subreddit_summary=$(pbpaste)
+assert_eq "QA multi-subreddit queued summary" "Title: QA Multi Subreddit Capture
+Body: Created to verify compact destination summaries.
+Subreddit: r/SideProject +1" "$multi_subreddit_summary"
+
+click_menu_item "QA" "Mark First Queued Capture Posted"
+printf "sentinel" | pbcopy
+click_menu_item "QA" "Copy First Posted Capture Summary"
+multi_posted_summary=$(pbpaste)
+assert_eq "QA multi-subreddit posted summary" "Title: QA Multi Subreddit Capture
+Body: Created to verify compact destination summaries.
+Subreddit: r/SideProject +1
+Posted URL: <none>" "$multi_posted_summary"
+
+click_menu_item "QA" "Delete Test Captures"
+
 # ─── 10. Restart persistence ──────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary
- Allow title-only captures and show compact multi-subreddit summaries in queue/posted views
- Add XCTest UI smoke test target and extend QA script with title-only and multi-subreddit coverage
- Use ad-hoc signing for `build-debug`, `test`, and `ui-test` Makefile targets to fix Xcode 26 code signing failures

## Changes

### UX
- `CaptureHelpers.canSave` now accepts title-only captures (title or body required, not just body)
- Queue and posted rows show `r/SideProject +1` style compact summary for multi-subreddit captures
- Empty body text hidden in capture cards and posted rows (no blank gap)
- Posted captures show visible restore (arrow.uturn.backward) and delete (trash) action buttons
- Planner auto-refreshes every 60 seconds

### QA & Testing
- New `RedditReminderUITests` target with keyboard shortcut smoke test (`Cmd+N`, `Cmd+,`)
- `project.yml` defines explicit schemes for unit and UI test targets
- QA script extended with title-only capture, multi-subreddit capture, and summary verification tests
- New QA menu items: Create Title Only Test Capture, Create Multi Subreddit Test Capture, Copy First Queued Capture Summary

### Build
- `make test`, `make build-debug`, and `make ui-test` now use ad-hoc signing (`CODE_SIGN_IDENTITY=-`, `ENABLE_DEBUG_DYLIB=NO`) to avoid `errSecInternalComponent` and test framework re-signing failures on Xcode 26

## Test plan
- [x] `make test` — 371 unit tests pass
- [x] `make ui-test` — UI smoke test passes
- [x] `make qa` — 32 headed QA tests pass