### PR TITLE
fix: register menu actions once in AppDelegate

### DIFF
--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -50,7 +50,6 @@ struct RedditReminderApp: App {
           )
           .modelContainer(container)
           appDelegate.menuBarController.setup(popoverContent: popoverView)
-          appDelegate.wireMenuActions(container: container)
         }
     }
     .defaultSize(width: 1, height: 1)

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -52,8 +52,6 @@ struct PopoverContentView: View {
     .frame(width: 350).frame(maxHeight: (NSScreen.main?.visibleFrame.height ?? 800) * 0.85)
     .onAppear {
       refreshTiming()
-      menuBarController.onNewCapture = { [self] in openNewCapture() }
-      menuBarController.onOpenPreferences = { [self] in openPreferences() }
     }
     .onChange(of: captureTimingSignature) {
       refreshTiming()


### PR DESCRIPTION
## Summary

- Remove duplicate `menuBarController.onNewCapture` and `onOpenPreferences` registration from `PopoverContentView.onAppear` — these overwrote the AppDelegate registrations and caused Cmd+N and Cmd+, to not work until the popover was opened
- Remove redundant second `wireMenuActions` call in `RedditReminderApp.swift` — the first call at line 34 is sufficient

## Test plan

- [x] All unit tests pass
- [ ] Launch app fresh, press Cmd+N before opening popover — New Capture window should appear
- [ ] Launch app fresh, press Cmd+, before opening popover — Preferences window should appear