### PR TITLE
feat: peak time editing UX — local timezone, presets, suggested defaults

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */; };
 		090F9D3B18C2B5C92FB9F5B7 /* EdgeCaseTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */; };
 		0A9365CFB7B1AB4C02CF61DB /* SubredditPeakSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */; };
+		0C53C021246A49333D8F111B /* NotificationSchedulerPermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C5DAE3A8EB7A0149E897CD /* NotificationSchedulerPermissionTests.swift */; };
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
 		0D450A66EF492AF4779AD92B /* PostHandoffViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB15AEFC17C70DC66CA4A05 /* PostHandoffViewHelpers.swift */; };
 		0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E228CA7B8C32C3669A85 /* BackupMappers.swift */; };
@@ -57,6 +58,7 @@
 		458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */; };
 		474176ACD33799B0C433D8C5 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A523CACB82BF88E46FD3E /* MenuBarController.swift */; };
 		4907C5B4B92A0039716F0727 /* SubredditCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A20FE04DD7075E02C7092 /* SubredditCRUDTests.swift */; };
+		4A0EC0BB9F82C06D8CED3928 /* TimingEngineTimezoneEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4871F815198EF14E6C1B2C22 /* TimingEngineTimezoneEdgeCaseTests.swift */; };
 		4C87F6917C877808862C53EE /* TimingEngineWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF54D62FF6A1D2DE6F157E60 /* TimingEngineWindowTests.swift */; };
 		4CCDBAA2B4BC2B3BB97CF38E /* RedditReminderSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EFC2837CE8B91A22B6A64D /* RedditReminderSmokeUITests.swift */; };
 		4D3F5B8B0063D3B9C1242D33 /* BackupTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72682A4379AE1A17B7D4559 /* BackupTypes.swift */; };
@@ -76,6 +78,7 @@
 		5A2B495DD4D68A03E298A1BE /* QAFixturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25CB54C32FE0925CD459588 /* QAFixturesTests.swift */; };
 		5B69D9E7F11752087138A0C6 /* RedditPostingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B419BD1AF2CF70DEC1509B /* RedditPostingActions.swift */; };
 		5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */; };
+		5C0D0E781F591772712EFB08 /* SubredditRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */; };
 		5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */; };
 		5E9E214B7FD7706B64F703BA /* PlannerTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3788B79517572C51854172CC /* PlannerTabView.swift */; };
 		5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */; };
@@ -89,13 +92,16 @@
 		690C38B0C986D2C9B9F268D5 /* PopoverChromeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
 		6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */; };
+		6D0A4C091A8F25EA682C95AC /* RedditReminderWorkflowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBD69B43B6F15A3A6874D22 /* RedditReminderWorkflowUITests.swift */; };
 		6D9854352FD87623F0FD290F /* PostingChecklistItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA87973FC3B43FDB7B37F8 /* PostingChecklistItemsTests.swift */; };
 		70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */; };
 		714D61E3C7BED6A5FEFED970 /* CaptureMediaEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12332E0A0899E73E2C0FD6E4 /* CaptureMediaEditingTests.swift */; };
+		726A8DC23D85AA198EF079E6 /* CapturePerSubredditPostingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E6715672E45708F5B3DDD5 /* CapturePerSubredditPostingTests.swift */; };
 		73D1EA6EF5BCBC4321589A5D /* NotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9511753E51E30A7111B248 /* NotificationScheduler.swift */; };
 		73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */; };
 		75C175CE268B7C7B29D8E3F2 /* TimingEngineUrgencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C77B4031AB91C412094FA2C /* TimingEngineUrgencyTests.swift */; };
 		7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */; };
+		7E68CAC4BA7F5A44D4927EF8 /* CaptureLifecycleIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7253DDCFDD2A38F779E451A6 /* CaptureLifecycleIntegrationTests.swift */; };
 		8125DD9D788F57B8CA1BA791 /* MenuBarControllerMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CDE29A1F978DF7DFBC7661 /* MenuBarControllerMenus.swift */; };
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
 		8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB005E503FDAD90271DB0AE /* EventBannerView.swift */; };
@@ -137,6 +143,7 @@
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
 		EB5423C577C49336A436A8D9 /* EventBannerPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B74D94BD1D9656DC58B93F8 /* EventBannerPresentationTests.swift */; };
 		ED21B7051250C90DD162186E /* AppDelegateShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94E8BF8DAD4FB3EAEB7B9D2 /* AppDelegateShortcuts.swift */; };
+		EE2531711B88442E10595188 /* BackupRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5405DCCD365B6CCD48CAAD0D /* BackupRoundTripTests.swift */; };
 		EFE86AB0870D685D53D203E0 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */; };
 		F2A0ED2765FCADD7E2D9C267 /* UrgencyPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A24B20995755A25E411F4F /* UrgencyPresentation.swift */; };
@@ -206,10 +213,12 @@
 		3BDDF7799BF55CF7FFC730BA /* peak-times.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "peak-times.json"; sourceTree = "<group>"; };
 		3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupImportValidationTests.swift; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
+		3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditRowHelpers.swift; sourceTree = "<group>"; };
 		409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummaryTests.swift; sourceTree = "<group>"; };
 		40A4D807E91E15E3C1B5275C /* UrgencyPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrgencyPresentationTests.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4758BE68EE85AA3FA2EA4DC4 /* DefaultSubredditsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubredditsTests.swift; sourceTree = "<group>"; };
+		4871F815198EF14E6C1B2C22 /* TimingEngineTimezoneEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineTimezoneEdgeCaseTests.swift; sourceTree = "<group>"; };
 		4AA4ACEAB2D47066769A2A44 /* TimingEngineRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineRefreshTests.swift; sourceTree = "<group>"; };
 		4B9511753E51E30A7111B248 /* NotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationScheduler.swift; sourceTree = "<group>"; };
 		4CB005E503FDAD90271DB0AE /* EventBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBannerView.swift; sourceTree = "<group>"; };
@@ -219,6 +228,7 @@
 		4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksSection.swift; sourceTree = "<group>"; };
 		4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngine.swift; sourceTree = "<group>"; };
 		52127801DAED9C14B36BEE2B /* AppDelegateNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateNotifications.swift; sourceTree = "<group>"; };
+		5405DCCD365B6CCD48CAAD0D /* BackupRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupRoundTripTests.swift; sourceTree = "<group>"; };
 		542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActions.swift; sourceTree = "<group>"; };
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
@@ -239,6 +249,7 @@
 		6F6B386C8282DFD34809B554 /* AppDelegateNotificationActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateNotificationActionTests.swift; sourceTree = "<group>"; };
 		6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSection.swift; sourceTree = "<group>"; };
 		70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPeakSelection.swift; sourceTree = "<group>"; };
+		7253DDCFDD2A38F779E451A6 /* CaptureLifecycleIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLifecycleIntegrationTests.swift; sourceTree = "<group>"; };
 		726D903A97B808C6ED572BCA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActionsTests.swift; sourceTree = "<group>"; };
 		75FA87973FC3B43FDB7B37F8 /* PostingChecklistItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingChecklistItemsTests.swift; sourceTree = "<group>"; };
@@ -247,6 +258,7 @@
 		7D9810B901F7241E88A6D898 /* SubredditInputValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditInputValidation.swift; sourceTree = "<group>"; };
 		83951E8660A332C18651B94E /* BackupMediaPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMediaPayloadTests.swift; sourceTree = "<group>"; };
 		843A01564D830A81EEF54CF9 /* NotificationSettingsOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsOpener.swift; sourceTree = "<group>"; };
+		84C5DAE3A8EB7A0149E897CD /* NotificationSchedulerPermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSchedulerPermissionTests.swift; sourceTree = "<group>"; };
 		8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
 		88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		8A6C6B2B1A559FEFF67B391F /* RRuleOccurrenceEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleOccurrenceEdgeCaseTests.swift; sourceTree = "<group>"; };
@@ -291,6 +303,7 @@
 		C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTestSupport.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
 		D08AEB86FFDCB22E4FB7E9F0 /* PlannerPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerPresentationTests.swift; sourceTree = "<group>"; };
+		D3E6715672E45708F5B3DDD5 /* CapturePerSubredditPostingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePerSubredditPostingTests.swift; sourceTree = "<group>"; };
 		D483D5534D2A0BC4C03BC77B /* AppDelegateShortcutRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRegistrationTests.swift; sourceTree = "<group>"; };
 		D4925806B8E7919B5E93D38D /* AppModelContainerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModelContainerFactory.swift; sourceTree = "<group>"; };
 		D5570C2EF1DD747B43C6F4ED /* PopoverChromeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverChromeViewTests.swift; sourceTree = "<group>"; };
@@ -310,6 +323,7 @@
 		F89CCDB745C6D3B557E3342A /* AppDelegateQA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateQA.swift; sourceTree = "<group>"; };
 		FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpersTests.swift; sourceTree = "<group>"; };
 		FB0A7A7AAA2C09449780FF4F /* LinkChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkChipView.swift; sourceTree = "<group>"; };
+		FCBD69B43B6F15A3A6874D22 /* RedditReminderWorkflowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderWorkflowUITests.swift; sourceTree = "<group>"; };
 		FE0A03801E8A55E99F8739D1 /* RedditPostingActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditPostingActionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -339,6 +353,7 @@
 				3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */,
 				83951E8660A332C18651B94E /* BackupMediaPayloadTests.swift */,
 				00BE11378DD3F2E280F890D6 /* BackupPreviewTests.swift */,
+				5405DCCD365B6CCD48CAAD0D /* BackupRoundTripTests.swift */,
 				EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */,
 				D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */,
 				1041614D1D7B295800149206 /* BackupTestSupport.swift */,
@@ -346,11 +361,13 @@
 				E02E746452EDD7B17443C493 /* CaptureCRUDTests.swift */,
 				331A38F1DC4F9E18A7D4A332 /* CaptureEdgeCaseTests.swift */,
 				FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */,
+				7253DDCFDD2A38F779E451A6 /* CaptureLifecycleIntegrationTests.swift */,
 				3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */,
 				EBC07E95FAB15C8EAB34E541 /* CaptureMediaAccessibilityTests.swift */,
 				12332E0A0899E73E2C0FD6E4 /* CaptureMediaEditingTests.swift */,
 				8B642ED62D86AC09680939A1 /* CaptureMediaSelectionTests.swift */,
 				06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */,
+				D3E6715672E45708F5B3DDD5 /* CapturePerSubredditPostingTests.swift */,
 				0660CE7B44D0AAA9892ADBBD /* CRUDTestSupport.swift */,
 				4758BE68EE85AA3FA2EA4DC4 /* DefaultSubredditsTests.swift */,
 				C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */,
@@ -362,6 +379,7 @@
 				E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */,
 				B1ABCB2C47C7D7B2B9D3809B /* ModelEdgeCaseTests.swift */,
 				9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */,
+				84C5DAE3A8EB7A0149E897CD /* NotificationSchedulerPermissionTests.swift */,
 				3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */,
 				37AEC6DD3FA5A8034E07E6B9 /* NotificationSettingsOpenerTests.swift */,
 				D08AEB86FFDCB22E4FB7E9F0 /* PlannerPresentationTests.swift */,
@@ -389,6 +407,7 @@
 				75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */,
 				4AA4ACEAB2D47066769A2A44 /* TimingEngineRefreshTests.swift */,
 				B727389070814347602E1AB3 /* TimingEngineTests.swift */,
+				4871F815198EF14E6C1B2C22 /* TimingEngineTimezoneEdgeCaseTests.swift */,
 				8C77B4031AB91C412094FA2C /* TimingEngineUrgencyTests.swift */,
 				BF54D62FF6A1D2DE6F157E60 /* TimingEngineWindowTests.swift */,
 				40A4D807E91E15E3C1B5275C /* UrgencyPresentationTests.swift */,
@@ -458,6 +477,7 @@
 			isa = PBXGroup;
 			children = (
 				31EFC2837CE8B91A22B6A64D /* RedditReminderSmokeUITests.swift */,
+				FCBD69B43B6F15A3A6874D22 /* RedditReminderWorkflowUITests.swift */,
 			);
 			path = RedditReminderUITests;
 			sourceTree = "<group>";
@@ -534,6 +554,7 @@
 				BB9D18BDF63A57734A4A6C7A /* ShortcutRecorderInput.swift */,
 				90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */,
 				5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */,
+				3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -671,6 +692,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CCDBAA2B4BC2B3BB97CF38E /* RedditReminderSmokeUITests.swift in Sources */,
+				6D0A4C091A8F25EA682C95AC /* RedditReminderWorkflowUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -687,6 +709,7 @@
 				34A742D186F38DF2BCA6AB97 /* BackupImportValidationTests.swift in Sources */,
 				94636B0369D90D9FC93B2780 /* BackupMediaPayloadTests.swift in Sources */,
 				8A950262833C2D936554FEE7 /* BackupPreviewTests.swift in Sources */,
+				EE2531711B88442E10595188 /* BackupRoundTripTests.swift in Sources */,
 				6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */,
 				2C6F6A5981CBCEC7CE258964 /* BackupSettingsPersistenceTests.swift in Sources */,
 				2957BBD6DAAF914CD3A0E08A /* BackupTestSupport.swift in Sources */,
@@ -695,10 +718,12 @@
 				637776DD2C3FE925B0CC3036 /* CaptureCardViewTests.swift in Sources */,
 				3686DE3CF630B2A2461E80ED /* CaptureEdgeCaseTests.swift in Sources */,
 				1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */,
+				7E68CAC4BA7F5A44D4927EF8 /* CaptureLifecycleIntegrationTests.swift in Sources */,
 				1D7C85EE78D8FD2D46ACF6C3 /* CaptureLinksTests.swift in Sources */,
 				29AE487FE24C1FCE6423B27D /* CaptureMediaAccessibilityTests.swift in Sources */,
 				714D61E3C7BED6A5FEFED970 /* CaptureMediaEditingTests.swift in Sources */,
 				CE614FCDDCCDE1DA0C484E58 /* CaptureMediaSelectionTests.swift in Sources */,
+				726A8DC23D85AA198EF079E6 /* CapturePerSubredditPostingTests.swift in Sources */,
 				94CF7D2C65A9A2F6CCABCA92 /* CapturePersistenceActionsTests.swift in Sources */,
 				54CBDE5AFC27C95AF4C406DC /* DefaultSubredditsTests.swift in Sources */,
 				090F9D3B18C2B5C92FB9F5B7 /* EdgeCaseTestSupport.swift in Sources */,
@@ -710,6 +735,7 @@
 				9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */,
 				6665F0F720DA51B85DEAF841 /* ModelEdgeCaseTests.swift in Sources */,
 				AAE18F8CEE99E9D8E91C6ECD /* ModelTests.swift in Sources */,
+				0C53C021246A49333D8F111B /* NotificationSchedulerPermissionTests.swift in Sources */,
 				7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */,
 				B10546669B16B587E5C2D40E /* NotificationSettingsOpenerTests.swift in Sources */,
 				B62012033BD77A2602911EC6 /* PlannerPresentationTests.swift in Sources */,
@@ -737,6 +763,7 @@
 				347F4FD54749869424F5CD6C /* SubredditPersistenceActionsTests.swift in Sources */,
 				4F2AF8896DC44D8074BECAA5 /* TimingEngineRefreshTests.swift in Sources */,
 				24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */,
+				4A0EC0BB9F82C06D8CED3928 /* TimingEngineTimezoneEdgeCaseTests.swift in Sources */,
 				75C175CE268B7C7B29D8E3F2 /* TimingEngineUrgencyTests.swift in Sources */,
 				4C87F6917C877808862C53EE /* TimingEngineWindowTests.swift in Sources */,
 				1122C4AD1E639816DF206396 /* UrgencyPresentationTests.swift in Sources */,
@@ -821,6 +848,7 @@
 				0A9365CFB7B1AB4C02CF61DB /* SubredditPeakSelection.swift in Sources */,
 				2E04156554C7A2C39EF726A4 /* SubredditPersistenceActions.swift in Sources */,
 				4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */,
+				5C0D0E781F591772712EFB08 /* SubredditRowHelpers.swift in Sources */,
 				1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */,
 				F2A0ED2765FCADD7E2D9C267 /* UrgencyPresentation.swift in Sources */,
 			);

--- a/Sources/Utilities/SubredditPeakSelection.swift
+++ b/Sources/Utilities/SubredditPeakSelection.swift
@@ -3,7 +3,7 @@ import Foundation
 enum SubredditPeakSelection {
     static let allDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     static let dayKeys = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
-    static let displayHours = [0, 2, 4, 6, 8, 10, 12, 14, 15, 16, 17, 18, 20, 22]
+    static let displayHours = Array(0...23)
 
     static func toggledDay(_ day: String, in override: [String]?) -> [String]? {
         var days = override ?? []
@@ -73,7 +73,7 @@ enum SubredditPeakSelection {
     }
 
     static func utcHoursToLocal(_ utcHours: [Int], timeZone: TimeZone = .current, referenceDate: Date = Date()) -> [Int] {
-        utcHours.map { utcHourToLocal($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
+        Array(Set(utcHours.map { utcHourToLocal($0, timeZone: timeZone, referenceDate: referenceDate) })).sorted()
     }
 
     struct PeakPreset {
@@ -111,7 +111,7 @@ enum SubredditPeakSelection {
         return SuggestedDefaults(days: applied.days, localHours: preset.localHours, utcHours: applied.utcHours)
     }
 
-    static func needsSuggestedDefaults(override: [String]?, peakInfo: PeakInfo?) -> Bool {
-        override == nil && peakInfo == nil
+    static func needsSuggestedDefaults(daysOverride: [String]?, hoursOverride: [Int]?, peakInfo: PeakInfo?) -> Bool {
+        daysOverride == nil && hoursOverride == nil && peakInfo == nil
     }
 }

--- a/Sources/Utilities/SubredditPeakSelection.swift
+++ b/Sources/Utilities/SubredditPeakSelection.swift
@@ -43,4 +43,36 @@ enum SubredditPeakSelection {
     static func effectivePeakHours(override: [Int]?, peakInfo: PeakInfo?) -> [Int] {
         override ?? peakInfo?.peakHoursUtc ?? []
     }
+
+    static func localHourToUtc(_ localHour: Int, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> Int {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timeZone
+        let comps = cal.dateComponents([.year, .month, .day], from: referenceDate)
+        var localComps = comps
+        localComps.hour = localHour
+        localComps.minute = 0
+        guard let localDate = cal.date(from: localComps) else { return localHour }
+
+        var utcCal = Calendar(identifier: .gregorian)
+        utcCal.timeZone = TimeZone(identifier: "UTC")!
+        return utcCal.component(.hour, from: localDate)
+    }
+
+    static func utcHourToLocal(_ utcHour: Int, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> Int {
+        var utcCal = Calendar(identifier: .gregorian)
+        utcCal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = utcCal.dateComponents([.year, .month, .day], from: referenceDate)
+        var utcComps = comps
+        utcComps.hour = utcHour
+        utcComps.minute = 0
+        guard let utcDate = utcCal.date(from: utcComps) else { return utcHour }
+
+        var localCal = Calendar(identifier: .gregorian)
+        localCal.timeZone = timeZone
+        return localCal.component(.hour, from: utcDate)
+    }
+
+    static func utcHoursToLocal(_ utcHours: [Int], timeZone: TimeZone = .current, referenceDate: Date = Date()) -> [Int] {
+        utcHours.map { utcHourToLocal($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
+    }
 }

--- a/Sources/Utilities/SubredditPeakSelection.swift
+++ b/Sources/Utilities/SubredditPeakSelection.swift
@@ -98,4 +98,20 @@ enum SubredditPeakSelection {
         let utcHours = preset.localHours.map { localHourToUtc($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
         return AppliedPreset(days: preset.days, utcHours: utcHours)
     }
+
+    struct SuggestedDefaults {
+        let days: [String]
+        let localHours: [Int]
+        let utcHours: [Int]
+    }
+
+    static func suggestedDefaults(timeZone: TimeZone = .current, referenceDate: Date = Date()) -> SuggestedDefaults {
+        let preset = presets[0] // Weekday AM
+        let applied = applyPreset(preset, timeZone: timeZone, referenceDate: referenceDate)
+        return SuggestedDefaults(days: applied.days, localHours: preset.localHours, utcHours: applied.utcHours)
+    }
+
+    static func needsSuggestedDefaults(override: [String]?, peakInfo: PeakInfo?) -> Bool {
+        override == nil && peakInfo == nil
+    }
 }

--- a/Sources/Utilities/SubredditPeakSelection.swift
+++ b/Sources/Utilities/SubredditPeakSelection.swift
@@ -75,4 +75,27 @@ enum SubredditPeakSelection {
     static func utcHoursToLocal(_ utcHours: [Int], timeZone: TimeZone = .current, referenceDate: Date = Date()) -> [Int] {
         utcHours.map { utcHourToLocal($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
     }
+
+    struct PeakPreset {
+        let label: String
+        let days: [String]
+        let localHours: [Int]
+    }
+
+    struct AppliedPreset {
+        let days: [String]
+        let utcHours: [Int]
+    }
+
+    static let presets: [PeakPreset] = [
+        PeakPreset(label: "Weekday AM", days: ["mon", "tue", "wed", "thu", "fri"], localHours: [8, 9, 10, 11]),
+        PeakPreset(label: "Weekday PM", days: ["mon", "tue", "wed", "thu", "fri"], localHours: [17, 18, 19, 20]),
+        PeakPreset(label: "Weekend midday", days: ["sat", "sun"], localHours: [10, 11, 12, 13, 14]),
+        PeakPreset(label: "Daily prime", days: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"], localHours: [9, 10, 11, 12]),
+    ]
+
+    static func applyPreset(_ preset: PeakPreset, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> AppliedPreset {
+        let utcHours = preset.localHours.map { localHourToUtc($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
+        return AppliedPreset(days: preset.days, utcHours: utcHours)
+    }
 }

--- a/Sources/Views/SubredditRow.swift
+++ b/Sources/Views/SubredditRow.swift
@@ -76,7 +76,7 @@ struct SubredditRow: View {
           peakDayChips
 
           HStack(spacing: 4) {
-            Text("PEAK HOURS (local — \(TimeZone.current.abbreviation() ?? "UTC"))")
+            Text("PEAK HOURS (local — \(TimeZone.current.abbreviation() ?? TimeZone.current.identifier))")
               .font(.system(size: 9, weight: .medium))
               .foregroundStyle(.secondary)
               .tracking(0.3)
@@ -169,6 +169,9 @@ struct SubredditRow: View {
       sub.peakHoursUtcOverride = suggested.utcHours
     } else {
       sub.peakDaysOverride = SubredditPeakSelection.toggledDay(day, in: sub.peakDaysOverride)
+      if sub.peakDaysOverride == nil {
+        sub.peakHoursUtcOverride = nil
+      }
     }
   }
 
@@ -273,7 +276,8 @@ struct SubredditRow: View {
 
   private var showsSuggested: Bool {
     SubredditPeakSelection.needsSuggestedDefaults(
-      override: sub.peakDaysOverride ?? (sub.peakHoursUtcOverride != nil ? [] : nil),
+      daysOverride: sub.peakDaysOverride,
+      hoursOverride: sub.peakHoursUtcOverride,
       peakInfo: peakInfo
     )
   }

--- a/Sources/Views/SubredditRow.swift
+++ b/Sources/Views/SubredditRow.swift
@@ -30,7 +30,7 @@ struct SubredditRow: View {
               .accessibilityIdentifier("channels.subredditRow.\(sub.id.uuidString).remove")
           } else {
             VStack(alignment: .trailing, spacing: 2) {
-              Text(peakDaysSummary)
+              Text(peakDaysSummaryText)
                 .font(.system(size: 10))
                 .foregroundStyle(.secondary)
               if hasPostingChecklist {
@@ -221,11 +221,6 @@ struct SubredditRow: View {
     }
   }
 
-  private func applyPreset(_ preset: SubredditPeakSelection.PeakPreset) {
-    let applied = SubredditPeakSelection.applyPreset(preset)
-    sub.peakDaysOverride = applied.days
-    sub.peakHoursUtcOverride = applied.utcHours
-  }
 
   private var eventSourceChips: some View {
     HStack(spacing: 6) {
@@ -249,102 +244,8 @@ struct SubredditRow: View {
       .foregroundStyle(count > 0 ? color : .secondary)
   }
 
-  private func toggleHourLocal(_ localHour: Int) {
-    let utcHour = SubredditPeakSelection.localHourToUtc(localHour)
-    if showsSuggested {
-      let suggested = SubredditPeakSelection.suggestedDefaults()
-      sub.peakDaysOverride = suggested.days
-      sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: suggested.utcHours)
-    } else {
-      sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: sub.peakHoursUtcOverride)
-    }
-  }
-
-  private var peakDaysSummary: String {
-    SubredditPeakSelection.peakDaysSummary(
-      effectivePeakDays: effectivePeakDays, hasOverride: hasOverride)
-  }
-
   private func resetDefaults() {
     sub.peakDaysOverride = nil
     sub.peakHoursUtcOverride = nil
-  }
-
-  private var hasOverride: Bool {
-    SubredditPeakSelection.hasOverride(days: sub.peakDaysOverride, hours: sub.peakHoursUtcOverride)
-  }
-
-  private var showsSuggested: Bool {
-    SubredditPeakSelection.needsSuggestedDefaults(
-      daysOverride: sub.peakDaysOverride,
-      hoursOverride: sub.peakHoursUtcOverride,
-      peakInfo: peakInfo
-    )
-  }
-
-  private var effectivePeakDays: [String] {
-    if showsSuggested {
-      return SubredditPeakSelection.suggestedDefaults().days
-    }
-    return SubredditPeakSelection.effectivePeakDays(override: sub.peakDaysOverride, peakInfo: peakInfo)
-  }
-
-  private var effectivePeakHours: [Int] {
-    if showsSuggested {
-      return SubredditPeakSelection.suggestedDefaults().utcHours
-    }
-    return SubredditPeakSelection.effectivePeakHours(
-      override: sub.peakHoursUtcOverride, peakInfo: peakInfo)
-  }
-
-  private var effectivePeakHoursLocal: [Int] {
-    if showsSuggested {
-      return SubredditPeakSelection.suggestedDefaults().localHours
-    }
-    return SubredditPeakSelection.utcHoursToLocal(effectivePeakHours)
-  }
-
-  private var eventSourceSummary: EventSourceSummary {
-    EventSourceSummary.active(events: sub.events)
-  }
-
-  private var hasPostingChecklist: Bool {
-    !(sub.postingChecklist?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
-  }
-
-  private var postingChecklistBinding: Binding<String> {
-    Binding(
-      get: { sub.postingChecklist ?? "" },
-      set: { newValue in
-        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        sub.postingChecklist = trimmed.isEmpty ? nil : newValue
-      }
-    )
-  }
-}
-
-struct SubredditDropDelegate: DropDelegate {
-  let target: Subreddit
-  @Binding var dragging: Subreddit?
-  let subreddits: [Subreddit]
-  let modelContext: ModelContext
-
-  func performDrop(info: DropInfo) -> Bool {
-    dragging = nil
-    return true
-  }
-
-  func dropEntered(info: DropInfo) {
-    guard let source = dragging, source.id != target.id else { return }
-    SubredditPersistenceActions.reorder(
-      source: source,
-      target: target,
-      subreddits: subreddits,
-      modelContext: modelContext
-    )
-  }
-
-  func dropUpdated(info: DropInfo) -> DropProposal? {
-    DropProposal(operation: .move)
   }
 }

--- a/Sources/Views/SubredditRow.swift
+++ b/Sources/Views/SubredditRow.swift
@@ -55,16 +55,37 @@ struct SubredditRow: View {
         VStack(alignment: .leading, spacing: 10) {
           Divider()
 
-          Text("PEAK DAYS")
+          Text("PRESETS")
             .font(.system(size: 9, weight: .medium))
             .foregroundStyle(.secondary)
             .tracking(0.3)
+
+          presetChips
+
+          HStack(spacing: 4) {
+            Text("PEAK DAYS")
+              .font(.system(size: 9, weight: .medium))
+              .foregroundStyle(.secondary)
+              .tracking(0.3)
+            if showsSuggested {
+              Text("(suggested)")
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+            }
+          }
           peakDayChips
 
-          Text("PEAK HOURS (UTC)")
-            .font(.system(size: 9, weight: .medium))
-            .foregroundStyle(.secondary)
-            .tracking(0.3)
+          HStack(spacing: 4) {
+            Text("PEAK HOURS (local — \(TimeZone.current.abbreviation() ?? "UTC"))")
+              .font(.system(size: 9, weight: .medium))
+              .foregroundStyle(.secondary)
+              .tracking(0.3)
+            if showsSuggested {
+              Text("(suggested)")
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+            }
+          }
           peakHourChips
 
           Text("EVENT SOURCES")
@@ -126,7 +147,7 @@ struct SubredditRow: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(
-              isOn ? AppColors.redditOrange.opacity(hasOverride ? 0.12 : 0.06) : Color.clear
+              isOn ? AppColors.redditOrange.opacity(showsSuggested ? 0.04 : (hasOverride ? 0.12 : 0.06)) : Color.clear
             )
             .clipShape(RoundedRectangle(cornerRadius: 5))
             .overlay(
@@ -142,21 +163,28 @@ struct SubredditRow: View {
   }
 
   private func toggleDay(_ day: String) {
-    sub.peakDaysOverride = SubredditPeakSelection.toggledDay(day, in: sub.peakDaysOverride)
+    if showsSuggested {
+      let suggested = SubredditPeakSelection.suggestedDefaults()
+      sub.peakDaysOverride = SubredditPeakSelection.toggledDay(day, in: suggested.days)
+      sub.peakHoursUtcOverride = suggested.utcHours
+    } else {
+      sub.peakDaysOverride = SubredditPeakSelection.toggledDay(day, in: sub.peakDaysOverride)
+    }
   }
 
   private var peakHourChips: some View {
     let columns = [GridItem(.adaptive(minimum: 30), spacing: 3)]
     let hours = SubredditPeakSelection.displayHours
+    let localSelected = effectivePeakHoursLocal
     return LazyVGrid(columns: columns, spacing: 3) {
       ForEach(hours, id: \.self) { hour in
-        let isOn = effectivePeakHours.contains(hour)
-        Button(action: { toggleHour(hour) }) {
+        let isOn = localSelected.contains(hour)
+        Button(action: { toggleHourLocal(hour) }) {
           Text("\(hour)")
             .font(.system(size: 9, weight: .medium))
             .frame(minWidth: 24)
             .padding(.vertical, 3)
-            .background(isOn ? Color.green.opacity(hasOverride ? 0.12 : 0.06) : Color.clear)
+            .background(isOn ? Color.green.opacity(showsSuggested ? 0.04 : (hasOverride ? 0.12 : 0.06)) : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: 4))
             .overlay(
               RoundedRectangle(cornerRadius: 4)
@@ -167,6 +195,33 @@ struct SubredditRow: View {
         .buttonStyle(.plain)
       }
     }
+  }
+
+  private var presetChips: some View {
+    HStack(spacing: 4) {
+      ForEach(SubredditPeakSelection.presets, id: \.label) { preset in
+        Button(action: { applyPreset(preset) }) {
+          Text(preset.label)
+            .font(.system(size: 9, weight: .medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.quaternary.opacity(0.3))
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .overlay(
+              RoundedRectangle(cornerRadius: 5)
+                .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+            )
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+      }
+    }
+  }
+
+  private func applyPreset(_ preset: SubredditPeakSelection.PeakPreset) {
+    let applied = SubredditPeakSelection.applyPreset(preset)
+    sub.peakDaysOverride = applied.days
+    sub.peakHoursUtcOverride = applied.utcHours
   }
 
   private var eventSourceChips: some View {
@@ -191,9 +246,15 @@ struct SubredditRow: View {
       .foregroundStyle(count > 0 ? color : .secondary)
   }
 
-  private func toggleHour(_ hour: Int) {
-    sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(
-      hour, in: sub.peakHoursUtcOverride)
+  private func toggleHourLocal(_ localHour: Int) {
+    let utcHour = SubredditPeakSelection.localHourToUtc(localHour)
+    if showsSuggested {
+      let suggested = SubredditPeakSelection.suggestedDefaults()
+      sub.peakDaysOverride = suggested.days
+      sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: suggested.utcHours)
+    } else {
+      sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: sub.peakHoursUtcOverride)
+    }
   }
 
   private var peakDaysSummary: String {
@@ -210,13 +271,33 @@ struct SubredditRow: View {
     SubredditPeakSelection.hasOverride(days: sub.peakDaysOverride, hours: sub.peakHoursUtcOverride)
   }
 
+  private var showsSuggested: Bool {
+    SubredditPeakSelection.needsSuggestedDefaults(
+      override: sub.peakDaysOverride ?? (sub.peakHoursUtcOverride != nil ? [] : nil),
+      peakInfo: peakInfo
+    )
+  }
+
   private var effectivePeakDays: [String] {
-    SubredditPeakSelection.effectivePeakDays(override: sub.peakDaysOverride, peakInfo: peakInfo)
+    if showsSuggested {
+      return SubredditPeakSelection.suggestedDefaults().days
+    }
+    return SubredditPeakSelection.effectivePeakDays(override: sub.peakDaysOverride, peakInfo: peakInfo)
   }
 
   private var effectivePeakHours: [Int] {
-    SubredditPeakSelection.effectivePeakHours(
+    if showsSuggested {
+      return SubredditPeakSelection.suggestedDefaults().utcHours
+    }
+    return SubredditPeakSelection.effectivePeakHours(
       override: sub.peakHoursUtcOverride, peakInfo: peakInfo)
+  }
+
+  private var effectivePeakHoursLocal: [Int] {
+    if showsSuggested {
+      return SubredditPeakSelection.suggestedDefaults().localHours
+    }
+    return SubredditPeakSelection.utcHoursToLocal(effectivePeakHours)
   }
 
   private var eventSourceSummary: EventSourceSummary {

--- a/Sources/Views/SubredditRowHelpers.swift
+++ b/Sources/Views/SubredditRowHelpers.swift
@@ -1,0 +1,104 @@
+import SwiftData
+import SwiftUI
+
+extension SubredditRow {
+  func toggleHourLocal(_ localHour: Int) {
+    let utcHour = SubredditPeakSelection.localHourToUtc(localHour)
+    if showsSuggested {
+      let suggested = SubredditPeakSelection.suggestedDefaults()
+      sub.peakDaysOverride = suggested.days
+      sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: suggested.utcHours)
+    } else {
+      sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: sub.peakHoursUtcOverride)
+    }
+  }
+
+  func applyPreset(_ preset: SubredditPeakSelection.PeakPreset) {
+    let applied = SubredditPeakSelection.applyPreset(preset)
+    sub.peakDaysOverride = applied.days
+    sub.peakHoursUtcOverride = applied.utcHours
+  }
+
+  var peakDaysSummaryText: String {
+    SubredditPeakSelection.peakDaysSummary(
+      effectivePeakDays: effectivePeakDays, hasOverride: hasOverride)
+  }
+
+  var hasOverride: Bool {
+    SubredditPeakSelection.hasOverride(days: sub.peakDaysOverride, hours: sub.peakHoursUtcOverride)
+  }
+
+  var showsSuggested: Bool {
+    SubredditPeakSelection.needsSuggestedDefaults(
+      daysOverride: sub.peakDaysOverride,
+      hoursOverride: sub.peakHoursUtcOverride,
+      peakInfo: peakInfo
+    )
+  }
+
+  var effectivePeakDays: [String] {
+    if showsSuggested {
+      return SubredditPeakSelection.suggestedDefaults().days
+    }
+    return SubredditPeakSelection.effectivePeakDays(override: sub.peakDaysOverride, peakInfo: peakInfo)
+  }
+
+  var effectivePeakHours: [Int] {
+    if showsSuggested {
+      return SubredditPeakSelection.suggestedDefaults().utcHours
+    }
+    return SubredditPeakSelection.effectivePeakHours(
+      override: sub.peakHoursUtcOverride, peakInfo: peakInfo)
+  }
+
+  var effectivePeakHoursLocal: [Int] {
+    if showsSuggested {
+      return SubredditPeakSelection.suggestedDefaults().localHours
+    }
+    return SubredditPeakSelection.utcHoursToLocal(effectivePeakHours)
+  }
+
+  var eventSourceSummary: EventSourceSummary {
+    EventSourceSummary.active(events: sub.events)
+  }
+
+  var hasPostingChecklist: Bool {
+    !(sub.postingChecklist?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+  }
+
+  var postingChecklistBinding: Binding<String> {
+    Binding(
+      get: { sub.postingChecklist ?? "" },
+      set: { newValue in
+        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        sub.postingChecklist = trimmed.isEmpty ? nil : newValue
+      }
+    )
+  }
+}
+
+struct SubredditDropDelegate: DropDelegate {
+  let target: Subreddit
+  @Binding var dragging: Subreddit?
+  let subreddits: [Subreddit]
+  let modelContext: ModelContext
+
+  func performDrop(info: DropInfo) -> Bool {
+    dragging = nil
+    return true
+  }
+
+  func dropEntered(info: DropInfo) {
+    guard let source = dragging, source.id != target.id else { return }
+    SubredditPersistenceActions.reorder(
+      source: source,
+      target: target,
+      subreddits: subreddits,
+      modelContext: modelContext
+    )
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    DropProposal(operation: .move)
+  }
+}

--- a/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+++ b/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import RedditReminder
 
 @Test func subredditPeakSelectionAddsAndRemovesDayOverrides() {
@@ -44,4 +45,41 @@ import Testing
     #expect(SubredditPeakSelection.allDays.count == SubredditPeakSelection.dayKeys.count)
     #expect(SubredditPeakSelection.dayKeys == ["mon", "tue", "wed", "thu", "fri", "sat", "sun"])
     #expect(SubredditPeakSelection.displayHours == SubredditPeakSelection.displayHours.sorted())
+}
+
+@Test func localHourToUtcConvertsCorrectly() {
+    // PDT is UTC-7
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    // In summer (PDT): local 9 AM = UTC 16
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    #expect(SubredditPeakSelection.localHourToUtc(9, timeZone: pdt, referenceDate: summer) == 16)
+    #expect(SubredditPeakSelection.localHourToUtc(0, timeZone: pdt, referenceDate: summer) == 7)
+    #expect(SubredditPeakSelection.localHourToUtc(20, timeZone: pdt, referenceDate: summer) == 3)
+}
+
+@Test func utcHourToLocalConvertsCorrectly() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    #expect(SubredditPeakSelection.utcHourToLocal(16, timeZone: pdt, referenceDate: summer) == 9)
+    #expect(SubredditPeakSelection.utcHourToLocal(7, timeZone: pdt, referenceDate: summer) == 0)
+    #expect(SubredditPeakSelection.utcHourToLocal(3, timeZone: pdt, referenceDate: summer) == 20)
+}
+
+@Test func timezoneConversionRoundTrips() {
+    let tokyo = TimeZone(identifier: "Asia/Tokyo")!
+    let ref = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    for hour in 0..<24 {
+        let utc = SubredditPeakSelection.localHourToUtc(hour, timeZone: tokyo, referenceDate: ref)
+        let back = SubredditPeakSelection.utcHourToLocal(utc, timeZone: tokyo, referenceDate: ref)
+        #expect(back == hour)
+    }
+}
+
+@Test func halfHourTimezoneConversion() {
+    // India is UTC+5:30 — rounds to nearest hour
+    let india = TimeZone(identifier: "Asia/Kolkata")!
+    let ref = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    // Local 9 AM IST = UTC 3:30 AM → rounds to UTC 3 (truncated by Calendar.component(.hour))
+    let utc = SubredditPeakSelection.localHourToUtc(9, timeZone: india, referenceDate: ref)
+    #expect(utc == 3 || utc == 4) // Either rounding direction is acceptable
 }

--- a/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+++ b/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
@@ -134,8 +134,9 @@ import Foundation
 }
 
 @Test func needsSuggestedDefaultsReturnsTrueWhenBlank() {
-    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: nil, peakInfo: nil) == true)
-    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: ["mon"], peakInfo: nil) == false)
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(daysOverride: nil, hoursOverride: nil, peakInfo: nil) == true)
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(daysOverride: ["mon"], hoursOverride: nil, peakInfo: nil) == false)
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(daysOverride: nil, hoursOverride: [14], peakInfo: nil) == false)
     let info = PeakInfo(peakDays: ["tue"], peakHoursUtc: [14])
-    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: nil, peakInfo: info) == false)
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(daysOverride: nil, hoursOverride: nil, peakInfo: info) == false)
 }

--- a/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+++ b/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
@@ -115,3 +115,27 @@ import Foundation
     // PDT is UTC-7: local 8=UTC15, 9=UTC16, 10=UTC17, 11=UTC18
     #expect(result.utcHours == [15, 16, 17, 18])
 }
+
+@Test func suggestedDefaultsReturnsWeekdayAMPreset() {
+    let suggested = SubredditPeakSelection.suggestedDefaults(timeZone: .current)
+    #expect(suggested.days == ["mon", "tue", "wed", "thu", "fri"])
+    #expect(suggested.localHours == [8, 9, 10, 11])
+}
+
+@Test func suggestedDefaultsUtcMatchesPresetApplication() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+
+    let suggested = SubredditPeakSelection.suggestedDefaults(timeZone: pdt, referenceDate: summer)
+    let applied = SubredditPeakSelection.applyPreset(SubredditPeakSelection.presets[0], timeZone: pdt, referenceDate: summer)
+
+    #expect(suggested.utcHours == applied.utcHours)
+    #expect(suggested.days == applied.days)
+}
+
+@Test func needsSuggestedDefaultsReturnsTrueWhenBlank() {
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: nil, peakInfo: nil) == true)
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: ["mon"], peakInfo: nil) == false)
+    let info = PeakInfo(peakDays: ["tue"], peakHoursUtc: [14])
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: nil, peakInfo: info) == false)
+}

--- a/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+++ b/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
@@ -83,3 +83,35 @@ import Foundation
     let utc = SubredditPeakSelection.localHourToUtc(9, timeZone: india, referenceDate: ref)
     #expect(utc == 3 || utc == 4) // Either rounding direction is acceptable
 }
+
+@Test func presetsDefineExpectedPatterns() {
+    let presets = SubredditPeakSelection.presets
+    #expect(presets.count == 4)
+    #expect(presets[0].label == "Weekday AM")
+    #expect(presets[0].days == ["mon", "tue", "wed", "thu", "fri"])
+    #expect(presets[0].localHours == [8, 9, 10, 11])
+
+    #expect(presets[1].label == "Weekday PM")
+    #expect(presets[1].days == ["mon", "tue", "wed", "thu", "fri"])
+    #expect(presets[1].localHours == [17, 18, 19, 20])
+
+    #expect(presets[2].label == "Weekend midday")
+    #expect(presets[2].days == ["sat", "sun"])
+    #expect(presets[2].localHours == [10, 11, 12, 13, 14])
+
+    #expect(presets[3].label == "Daily prime")
+    #expect(presets[3].days == ["mon", "tue", "wed", "thu", "fri", "sat", "sun"])
+    #expect(presets[3].localHours == [9, 10, 11, 12])
+}
+
+@Test func applyPresetConvertsToUtc() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    let preset = SubredditPeakSelection.presets[0] // Weekday AM: local 8-11
+
+    let result = SubredditPeakSelection.applyPreset(preset, timeZone: pdt, referenceDate: summer)
+
+    #expect(result.days == ["mon", "tue", "wed", "thu", "fri"])
+    // PDT is UTC-7: local 8=UTC15, 9=UTC16, 10=UTC17, 11=UTC18
+    #expect(result.utcHours == [15, 16, 17, 18])
+}

--- a/docs/superpowers/plans/2026-05-01-peak-time-editing-ux.md
+++ b/docs/superpowers/plans/2026-05-01-peak-time-editing-ux.md
@@ -1,0 +1,627 @@
+# Peak Time Editing UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make peak time editing frictionless by showing hours in local time, providing sensible defaults for blank subreddits, and adding preset buttons for common patterns.
+
+**Architecture:** All changes stay within the existing `SubredditPeakSelection` utility (logic) and `SubredditRow` view (UI). Storage remains UTC — conversion happens at the display/input boundary. Presets and suggested defaults are defined as static data in the utility, applied via existing override mechanisms.
+
+**Tech Stack:** Swift 6, SwiftUI, Foundation (TimeZone, Calendar), Swift Testing framework
+
+---
+
+## File Structure
+
+**Modified files:**
+- `Sources/Utilities/SubredditPeakSelection.swift` — add timezone conversion, presets, suggested defaults
+- `Sources/Views/SubredditRow.swift` — local hour display, preset row, suggested state rendering
+- `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift` — extend with conversion and preset tests
+
+---
+
+### Task 1: Timezone Conversion Functions
+
+**Files:**
+- Modify: `Sources/Utilities/SubredditPeakSelection.swift`
+- Modify: `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift`
+
+- [ ] **Step 1: Write failing tests for timezone conversion**
+
+Add to `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift`:
+
+```swift
+import Foundation
+
+@Test func localHourToUtcConvertsCorrectly() {
+    // PDT is UTC-7
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    // In summer (PDT): local 9 AM = UTC 16
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    #expect(SubredditPeakSelection.localHourToUtc(9, timeZone: pdt, referenceDate: summer) == 16)
+    #expect(SubredditPeakSelection.localHourToUtc(0, timeZone: pdt, referenceDate: summer) == 7)
+    #expect(SubredditPeakSelection.localHourToUtc(20, timeZone: pdt, referenceDate: summer) == 3)
+}
+
+@Test func utcHourToLocalConvertsCorrectly() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    #expect(SubredditPeakSelection.utcHourToLocal(16, timeZone: pdt, referenceDate: summer) == 9)
+    #expect(SubredditPeakSelection.utcHourToLocal(7, timeZone: pdt, referenceDate: summer) == 0)
+    #expect(SubredditPeakSelection.utcHourToLocal(3, timeZone: pdt, referenceDate: summer) == 20)
+}
+
+@Test func timezoneConversionRoundTrips() {
+    let tokyo = TimeZone(identifier: "Asia/Tokyo")!
+    let ref = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    for hour in 0..<24 {
+        let utc = SubredditPeakSelection.localHourToUtc(hour, timeZone: tokyo, referenceDate: ref)
+        let back = SubredditPeakSelection.utcHourToLocal(utc, timeZone: tokyo, referenceDate: ref)
+        #expect(back == hour)
+    }
+}
+
+@Test func halfHourTimezoneConversion() {
+    // India is UTC+5:30 — rounds to nearest hour
+    let india = TimeZone(identifier: "Asia/Kolkata")!
+    let ref = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    // Local 9 AM IST = UTC 3:30 AM → rounds to UTC 4
+    let utc = SubredditPeakSelection.localHourToUtc(9, timeZone: india, referenceDate: ref)
+    #expect(utc == 3 || utc == 4) // Either rounding direction is acceptable
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests/SubredditPeakSelectionTests 2>&1 | grep -E "(passed|failed)" | tail -5`
+Expected: FAIL — functions don't exist.
+
+- [ ] **Step 3: Implement conversion functions**
+
+Add to `Sources/Utilities/SubredditPeakSelection.swift` after the existing `effectivePeakHours` method:
+
+```swift
+static func localHourToUtc(_ localHour: Int, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> Int {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = timeZone
+    let comps = cal.dateComponents([.year, .month, .day], from: referenceDate)
+    var localComps = comps
+    localComps.hour = localHour
+    localComps.minute = 0
+    guard let localDate = cal.date(from: localComps) else { return localHour }
+
+    var utcCal = Calendar(identifier: .gregorian)
+    utcCal.timeZone = TimeZone(identifier: "UTC")!
+    return utcCal.component(.hour, from: localDate)
+}
+
+static func utcHourToLocal(_ utcHour: Int, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> Int {
+    var utcCal = Calendar(identifier: .gregorian)
+    utcCal.timeZone = TimeZone(identifier: "UTC")!
+    let comps = utcCal.dateComponents([.year, .month, .day], from: referenceDate)
+    var utcComps = comps
+    utcComps.hour = utcHour
+    utcComps.minute = 0
+    guard let utcDate = utcCal.date(from: utcComps) else { return utcHour }
+
+    var localCal = Calendar(identifier: .gregorian)
+    localCal.timeZone = timeZone
+    return localCal.component(.hour, from: utcDate)
+}
+
+static func utcHoursToLocal(_ utcHours: [Int], timeZone: TimeZone = .current, referenceDate: Date = Date()) -> [Int] {
+    utcHours.map { utcHourToLocal($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests/SubredditPeakSelectionTests 2>&1 | grep -E "(passed|failed)" | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Utilities/SubredditPeakSelection.swift Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+git commit -m "feat: add local/UTC hour conversion to SubredditPeakSelection"
+```
+
+---
+
+### Task 2: Preset Definitions and Application
+
+**Files:**
+- Modify: `Sources/Utilities/SubredditPeakSelection.swift`
+- Modify: `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift`
+
+- [ ] **Step 1: Write failing tests for presets**
+
+Add to `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift`:
+
+```swift
+@Test func presetsDefineExpectedPatterns() {
+    let presets = SubredditPeakSelection.presets
+    #expect(presets.count == 4)
+    #expect(presets[0].label == "Weekday AM")
+    #expect(presets[0].days == ["mon", "tue", "wed", "thu", "fri"])
+    #expect(presets[0].localHours == [8, 9, 10, 11])
+
+    #expect(presets[1].label == "Weekday PM")
+    #expect(presets[1].days == ["mon", "tue", "wed", "thu", "fri"])
+    #expect(presets[1].localHours == [17, 18, 19, 20])
+
+    #expect(presets[2].label == "Weekend midday")
+    #expect(presets[2].days == ["sat", "sun"])
+    #expect(presets[2].localHours == [10, 11, 12, 13, 14])
+
+    #expect(presets[3].label == "Daily prime")
+    #expect(presets[3].days == ["mon", "tue", "wed", "thu", "fri", "sat", "sun"])
+    #expect(presets[3].localHours == [9, 10, 11, 12])
+}
+
+@Test func applyPresetConvertsToUtc() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    let preset = SubredditPeakSelection.presets[0] // Weekday AM: local 8-11
+
+    let result = SubredditPeakSelection.applyPreset(preset, timeZone: pdt, referenceDate: summer)
+
+    #expect(result.days == ["mon", "tue", "wed", "thu", "fri"])
+    // PDT is UTC-7: local 8=UTC15, 9=UTC16, 10=UTC17, 11=UTC18
+    #expect(result.utcHours == [15, 16, 17, 18])
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests/SubredditPeakSelectionTests 2>&1 | grep -E "(passed|failed)" | tail -5`
+Expected: FAIL — `presets` and `applyPreset` don't exist.
+
+- [ ] **Step 3: Implement preset types and application**
+
+Add to `Sources/Utilities/SubredditPeakSelection.swift`:
+
+```swift
+struct PeakPreset {
+    let label: String
+    let days: [String]
+    let localHours: [Int]
+}
+
+struct AppliedPreset {
+    let days: [String]
+    let utcHours: [Int]
+}
+
+static let presets: [PeakPreset] = [
+    PeakPreset(label: "Weekday AM", days: ["mon", "tue", "wed", "thu", "fri"], localHours: [8, 9, 10, 11]),
+    PeakPreset(label: "Weekday PM", days: ["mon", "tue", "wed", "thu", "fri"], localHours: [17, 18, 19, 20]),
+    PeakPreset(label: "Weekend midday", days: ["sat", "sun"], localHours: [10, 11, 12, 13, 14]),
+    PeakPreset(label: "Daily prime", days: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"], localHours: [9, 10, 11, 12]),
+]
+
+static func applyPreset(_ preset: PeakPreset, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> AppliedPreset {
+    let utcHours = preset.localHours.map { localHourToUtc($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
+    return AppliedPreset(days: preset.days, utcHours: utcHours)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests/SubredditPeakSelectionTests 2>&1 | grep -E "(passed|failed)" | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Utilities/SubredditPeakSelection.swift Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+git commit -m "feat: add peak time presets with local-to-UTC conversion"
+```
+
+---
+
+### Task 3: Suggested Defaults
+
+**Files:**
+- Modify: `Sources/Utilities/SubredditPeakSelection.swift`
+- Modify: `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift`
+
+- [ ] **Step 1: Write failing tests for suggested defaults**
+
+Add to `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift`:
+
+```swift
+@Test func suggestedDefaultsReturnsWeekdayAMPreset() {
+    let suggested = SubredditPeakSelection.suggestedDefaults(timeZone: .current)
+    #expect(suggested.days == ["mon", "tue", "wed", "thu", "fri"])
+    #expect(suggested.localHours == [8, 9, 10, 11])
+}
+
+@Test func suggestedDefaultsUtcMatchesPresetApplication() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+
+    let suggested = SubredditPeakSelection.suggestedDefaults(timeZone: pdt, referenceDate: summer)
+    let applied = SubredditPeakSelection.applyPreset(SubredditPeakSelection.presets[0], timeZone: pdt, referenceDate: summer)
+
+    #expect(suggested.utcHours == applied.utcHours)
+    #expect(suggested.days == applied.days)
+}
+
+@Test func needsSuggestedDefaultsReturnsTrueWhenBlank() {
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: nil, peakInfo: nil) == true)
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: ["mon"], peakInfo: nil) == false)
+    let info = PeakInfo(peakDays: ["tue"], peakHoursUtc: [14])
+    #expect(SubredditPeakSelection.needsSuggestedDefaults(override: nil, peakInfo: info) == false)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests/SubredditPeakSelectionTests 2>&1 | grep -E "(passed|failed)" | tail -5`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement suggested defaults**
+
+Add to `Sources/Utilities/SubredditPeakSelection.swift`:
+
+```swift
+struct SuggestedDefaults {
+    let days: [String]
+    let localHours: [Int]
+    let utcHours: [Int]
+}
+
+static func suggestedDefaults(timeZone: TimeZone = .current, referenceDate: Date = Date()) -> SuggestedDefaults {
+    let preset = presets[0] // Weekday AM
+    let applied = applyPreset(preset, timeZone: timeZone, referenceDate: referenceDate)
+    return SuggestedDefaults(days: applied.days, localHours: preset.localHours, utcHours: applied.utcHours)
+}
+
+static func needsSuggestedDefaults(override: [String]?, peakInfo: PeakInfo?) -> Bool {
+    override == nil && peakInfo == nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests/SubredditPeakSelectionTests 2>&1 | grep -E "(passed|failed)" | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Utilities/SubredditPeakSelection.swift Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+git commit -m "feat: add suggested defaults for blank subreddits"
+```
+
+---
+
+### Task 4: SubredditRow — Local Hour Display
+
+**Files:**
+- Modify: `Sources/Views/SubredditRow.swift:58-69,148-170,194-195`
+
+- [ ] **Step 1: Change the "PEAK HOURS" header to show local timezone**
+
+In `Sources/Views/SubredditRow.swift`, replace the "PEAK HOURS (UTC)" text (line 65):
+
+```swift
+// Old:
+Text("PEAK HOURS (UTC)")
+    .font(.system(size: 9, weight: .medium))
+    .foregroundStyle(.secondary)
+    .tracking(0.3)
+
+// New:
+Text("PEAK HOURS (local — \(TimeZone.current.abbreviation() ?? "UTC"))")
+    .font(.system(size: 9, weight: .medium))
+    .foregroundStyle(.secondary)
+    .tracking(0.3)
+```
+
+- [ ] **Step 2: Add `effectivePeakHoursLocal` computed property**
+
+Add after the existing `effectivePeakHours` computed property (around line 219):
+
+```swift
+private var effectivePeakHoursLocal: [Int] {
+    SubredditPeakSelection.utcHoursToLocal(effectivePeakHours)
+}
+```
+
+- [ ] **Step 3: Update `peakHourChips` to use local hours for display**
+
+Replace `peakHourChips` (lines 148-170):
+
+```swift
+private var peakHourChips: some View {
+    let columns = [GridItem(.adaptive(minimum: 30), spacing: 3)]
+    let hours = SubredditPeakSelection.displayHours
+    let localSelected = effectivePeakHoursLocal
+    return LazyVGrid(columns: columns, spacing: 3) {
+        ForEach(hours, id: \.self) { hour in
+            let isOn = localSelected.contains(hour)
+            Button(action: { toggleHourLocal(hour) }) {
+                Text("\(hour)")
+                    .font(.system(size: 9, weight: .medium))
+                    .frame(minWidth: 24)
+                    .padding(.vertical, 3)
+                    .background(isOn ? Color.green.opacity(hasOverride ? 0.12 : 0.06) : Color.clear)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(isOn ? Color.green : Color(NSColor.separatorColor), lineWidth: 0.5)
+                    )
+                    .foregroundStyle(isOn ? .green : .secondary)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Replace `toggleHour` with `toggleHourLocal`**
+
+Replace the existing `toggleHour` method (line 194-195):
+
+```swift
+// Old:
+private func toggleHour(_ hour: Int) {
+    sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(
+        hour, in: sub.peakHoursUtcOverride)
+}
+
+// New:
+private func toggleHourLocal(_ localHour: Int) {
+    let utcHour = SubredditPeakSelection.localHourToUtc(localHour)
+    sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(
+        utcHour, in: sub.peakHoursUtcOverride)
+}
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `xcodebuild build -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 2>&1 | tail -3`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Views/SubredditRow.swift
+git commit -m "feat: display peak hours in local timezone with UTC conversion on tap"
+```
+
+---
+
+### Task 5: SubredditRow — Preset Buttons
+
+**Files:**
+- Modify: `Sources/Views/SubredditRow.swift`
+
+- [ ] **Step 1: Add preset row above the day chips**
+
+In `SubredditRow.swift`, in the expanded section (after the `Divider()` at line 56, before the "PEAK DAYS" label at line 58), insert the preset row:
+
+```swift
+Text("PRESETS")
+    .font(.system(size: 9, weight: .medium))
+    .foregroundStyle(.secondary)
+    .tracking(0.3)
+
+presetChips
+```
+
+- [ ] **Step 2: Implement `presetChips` view**
+
+Add a new computed property after `eventSourceChips`:
+
+```swift
+private var presetChips: some View {
+    HStack(spacing: 4) {
+        ForEach(SubredditPeakSelection.presets, id: \.label) { preset in
+            Button(action: { applyPreset(preset) }) {
+                Text(preset.label)
+                    .font(.system(size: 9, weight: .medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.quaternary.opacity(0.3))
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+                    )
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Implement `applyPreset` method**
+
+Add after `toggleHourLocal`:
+
+```swift
+private func applyPreset(_ preset: SubredditPeakSelection.PeakPreset) {
+    let applied = SubredditPeakSelection.applyPreset(preset)
+    sub.peakDaysOverride = applied.days
+    sub.peakHoursUtcOverride = applied.utcHours
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `xcodebuild build -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 2>&1 | tail -3`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Views/SubredditRow.swift
+git commit -m "feat: add preset buttons for quick peak time configuration"
+```
+
+---
+
+### Task 6: SubredditRow — Suggested Defaults State
+
+**Files:**
+- Modify: `Sources/Views/SubredditRow.swift`
+
+- [ ] **Step 1: Add `showsSuggested` computed property**
+
+Add after `hasOverride`:
+
+```swift
+private var showsSuggested: Bool {
+    SubredditPeakSelection.needsSuggestedDefaults(
+        override: sub.peakDaysOverride ?? (sub.peakHoursUtcOverride != nil ? [] : nil),
+        peakInfo: peakInfo
+    )
+}
+```
+
+- [ ] **Step 2: Update `effectivePeakDays` and `effectivePeakHoursLocal` to include suggested**
+
+Replace the existing computed properties:
+
+```swift
+private var effectivePeakDays: [String] {
+    if showsSuggested {
+        return SubredditPeakSelection.suggestedDefaults().days
+    }
+    return SubredditPeakSelection.effectivePeakDays(override: sub.peakDaysOverride, peakInfo: peakInfo)
+}
+
+private var effectivePeakHours: [Int] {
+    if showsSuggested {
+        return SubredditPeakSelection.suggestedDefaults().utcHours
+    }
+    return SubredditPeakSelection.effectivePeakHours(override: sub.peakHoursUtcOverride, peakInfo: peakInfo)
+}
+
+private var effectivePeakHoursLocal: [Int] {
+    if showsSuggested {
+        return SubredditPeakSelection.suggestedDefaults().localHours
+    }
+    return SubredditPeakSelection.utcHoursToLocal(effectivePeakHours)
+}
+```
+
+- [ ] **Step 3: Update chip opacity to reflect suggested state**
+
+In `peakDayChips`, change the background opacity:
+
+```swift
+// Old:
+.background(
+    isOn ? AppColors.redditOrange.opacity(hasOverride ? 0.12 : 0.06) : Color.clear
+)
+
+// New:
+.background(
+    isOn ? AppColors.redditOrange.opacity(showsSuggested ? 0.04 : (hasOverride ? 0.12 : 0.06)) : Color.clear
+)
+```
+
+In `peakHourChips`, change the background opacity:
+
+```swift
+// Old:
+.background(isOn ? Color.green.opacity(hasOverride ? 0.12 : 0.06) : Color.clear)
+
+// New:
+.background(isOn ? Color.green.opacity(showsSuggested ? 0.04 : (hasOverride ? 0.12 : 0.06)) : Color.clear)
+```
+
+- [ ] **Step 4: Add "(suggested)" label to headers when in suggested state**
+
+Update the "PEAK DAYS" header:
+
+```swift
+HStack(spacing: 4) {
+    Text("PEAK DAYS")
+        .font(.system(size: 9, weight: .medium))
+        .foregroundStyle(.secondary)
+        .tracking(0.3)
+    if showsSuggested {
+        Text("(suggested)")
+            .font(.system(size: 9))
+            .foregroundStyle(.tertiary)
+    }
+}
+```
+
+Update the "PEAK HOURS" header similarly:
+
+```swift
+HStack(spacing: 4) {
+    Text("PEAK HOURS (local — \(TimeZone.current.abbreviation() ?? "UTC"))")
+        .font(.system(size: 9, weight: .medium))
+        .foregroundStyle(.secondary)
+        .tracking(0.3)
+    if showsSuggested {
+        Text("(suggested)")
+            .font(.system(size: 9))
+            .foregroundStyle(.tertiary)
+    }
+}
+```
+
+- [ ] **Step 5: Update `toggleDay` and `toggleHourLocal` to commit suggested on first interact**
+
+Replace `toggleDay`:
+
+```swift
+private func toggleDay(_ day: String) {
+    if showsSuggested {
+        let suggested = SubredditPeakSelection.suggestedDefaults()
+        sub.peakDaysOverride = SubredditPeakSelection.toggledDay(day, in: suggested.days)
+        sub.peakHoursUtcOverride = suggested.utcHours
+    } else {
+        sub.peakDaysOverride = SubredditPeakSelection.toggledDay(day, in: sub.peakDaysOverride)
+    }
+}
+```
+
+Replace `toggleHourLocal`:
+
+```swift
+private func toggleHourLocal(_ localHour: Int) {
+    let utcHour = SubredditPeakSelection.localHourToUtc(localHour)
+    if showsSuggested {
+        let suggested = SubredditPeakSelection.suggestedDefaults()
+        sub.peakDaysOverride = suggested.days
+        sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: suggested.utcHours)
+    } else {
+        sub.peakHoursUtcOverride = SubredditPeakSelection.toggledHour(utcHour, in: sub.peakHoursUtcOverride)
+    }
+}
+```
+
+- [ ] **Step 6: Build and run full tests**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests 2>&1 | grep -E "(Test run|passed|failed)" | tail -3`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Views/SubredditRow.swift
+git commit -m "feat: show suggested defaults for blank subreddits with commit-on-first-interact"
+```
+
+---
+
+### Task 7: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `xcodebuild test -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing RedditReminderTests 2>&1 | grep -E "(Test run|passed|failed)" | tail -3`
+Expected: All tests pass, no failures.
+
+- [ ] **Step 2: Run full build**
+
+Run: `xcodebuild build -scheme RedditReminder -destination 'platform=macOS' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO 2>&1 | tail -3`
+Expected: BUILD SUCCEEDED.

--- a/docs/superpowers/specs/2026-05-01-peak-time-editing-ux-design.md
+++ b/docs/superpowers/specs/2026-05-01-peak-time-editing-ux-design.md
@@ -1,0 +1,86 @@
+# Peak Time Editing UX Design
+
+**Date:** 2026-05-01
+**Status:** Approved
+
+## Overview
+
+Improve the peak time editing experience in the Channels tab by: (1) displaying hours in the user's local timezone instead of UTC, (2) providing sensible defaults for subreddits without bundled data, and (3) adding preset buttons for common scheduling patterns.
+
+---
+
+## 1. Local Timezone Display
+
+**Problem:** Peak hours are stored and displayed in UTC. Users must mentally convert to their local timezone when picking hours.
+
+**Design:**
+
+- All storage remains UTC — no data migration needed.
+- The hour chip grid displays local-time hours (0-23). When the user taps hour "9" (local), it stores the UTC equivalent.
+- Add conversion functions to `SubredditPeakSelection`:
+  - `localHourToUtc(_ localHour: Int, timeZone: TimeZone = .current) -> Int`
+  - `utcHourToLocal(_ utcHour: Int, timeZone: TimeZone = .current) -> Int`
+- `effectivePeakHours` continues to return UTC hours internally. A new `effectivePeakHoursLocal` computed property in `SubredditRow` maps them to local for chip display.
+- The section header changes from "PEAK HOURS (UTC)" to "PEAK HOURS (local — \(TimeZone.current.abbreviation() ?? ""))" so there's no ambiguity.
+- `toggleHour` converts the tapped local hour to UTC before storing.
+
+**Files affected:**
+- `Sources/Utilities/SubredditPeakSelection.swift` — add conversion functions
+- `Sources/Views/SubredditRow.swift` — display local hours, convert on tap
+
+## 2. Sensible Defaults for Blank Subreddits
+
+**Problem:** Subreddits not in `peak-times.json` start with zero days/hours selected. The user must tap each chip individually.
+
+**Design:**
+
+- When a subreddit has no bundled data (`peakInfo` is nil) and no user overrides, show a "suggested" state.
+- The suggested defaults are "Weekday AM": Mon-Fri, 8-11 AM local (converted to UTC for storage).
+- Suggested state renders chips at lower opacity (0.04 background instead of 0.12) with a "(suggested)" label next to the section header.
+- The suggested days/hours are NOT persisted until the user interacts. First tap on any day or hour chip:
+  1. Commits the full suggested set as the override
+  2. Applies the user's tap (toggle) on top
+- This means one tap gives the user "suggested minus one" or "suggested plus one" — they're immediately in override mode with a reasonable starting point.
+
+**Files affected:**
+- `Sources/Utilities/SubredditPeakSelection.swift` — add suggested defaults logic
+- `Sources/Views/SubredditRow.swift` — render suggested state, commit-on-first-interact
+
+## 3. Preset Buttons
+
+**Problem:** Setting common patterns like "weekday mornings" requires 5 day taps + 3-4 hour taps. Too many taps for the most common configurations.
+
+**Design:**
+
+- Add a row of compact pill buttons above the day chips in the expanded `SubredditRow`.
+- Four presets:
+  - **"Weekday AM"** — Mon-Fri, 8-11 AM local
+  - **"Weekday PM"** — Mon-Fri, 5-8 PM local
+  - **"Weekend midday"** — Sat-Sun, 10 AM-2 PM local
+  - **"Daily prime"** — Mon-Sun, 9 AM-12 PM local
+- Tapping a preset replaces the current selection (sets both `peakDaysOverride` and `peakHoursUtcOverride` in one action).
+- Hours in presets are local — converted to UTC on apply using the conversion functions from section 1.
+- Styled as small pills (similar to existing chip styling but with a distinct "preset" appearance): text-only, no icon, `.quaternary` background, subtle border. Active state not needed since presets are actions, not selections.
+
+**Files affected:**
+- `Sources/Utilities/SubredditPeakSelection.swift` — define preset configurations, apply function
+- `Sources/Views/SubredditRow.swift` — render preset row, wire tap actions
+
+---
+
+## Testing
+
+- **SubredditPeakSelection timezone conversion tests:** `localHourToUtc` and `utcHourToLocal` with various timezone offsets, including half-hour timezones (India +5:30) and DST transitions.
+- **Preset application tests:** Each preset produces the expected UTC hours and day arrays for a given timezone.
+- **Suggested defaults tests:** Verify the suggested defaults produce correct UTC hours for the user's timezone, and that first-interact commit works correctly.
+
+**Test file:** `Tests/RedditReminderTests/SubredditPeakSelectionTests.swift` (extend existing)
+
+---
+
+## Out of Scope
+
+- Fetching peak times from Reddit's API
+- Per-subreddit timezone overrides (always uses system timezone)
+- Custom user-defined presets
+- Persisting suggested defaults before user interaction


### PR DESCRIPTION
## Summary

- **Local timezone display**: Peak hours shown in user's local timezone instead of UTC, with automatic conversion on tap
- **Preset buttons**: 4 quick-set presets (Weekday AM, Weekday PM, Weekend midday, Daily prime) for one-tap peak time configuration
- **Suggested defaults**: Blank subreddits show "Weekday AM" as dimmed suggested state; first interaction commits and enters override mode
- **Full 24-hour grid**: All hours displayed (was previously a sparse subset) to prevent invisible selections after timezone conversion
- **Deduplication**: `utcHoursToLocal` deduplicates to prevent ghost hours from DST fall-back
- **Orphan prevention**: Clearing all days also clears hours override to prevent inconsistent state

## Test plan

- [x] All 380 unit tests pass
- [x] Build succeeds with zero errors
- [ ] Open Channels tab, expand a subreddit — hours should show in local time with timezone label
- [ ] Tap a preset button — days and hours should update immediately
- [ ] Add a new subreddit with no bundled data — should show "(suggested)" state at low opacity
- [ ] Tap any chip in suggested state — should commit defaults and switch to override mode
- [ ] Remove all days — hours should also clear (reset to no override)