### PR TITLE
Use icon buttons for menu card actions

### DIFF
--- a/Sources/Utilities/QAFixtures.swift
+++ b/Sources/Utilities/QAFixtures.swift
@@ -6,7 +6,7 @@ enum QAFixtures {
   static func seed(context: ModelContext, defaults: UserDefaults = .standard) {
     clearAll(context: context, defaults: defaults)
 
-    // 4 subreddits — some with peak overrides, some without
+    // Subreddits — some with peak overrides, some without.
     let sideProject = Subreddit(name: "r/SideProject", sortOrder: 0)
     let swiftUI = Subreddit(
       name: "r/SwiftUI",
@@ -20,24 +20,20 @@ enum QAFixtures {
       peakDaysOverride: ["tue", "thu"],
       peakHoursUtcOverride: [10, 11, 12, 13, 14]
     )
-    let iosProg = Subreddit(name: "r/iOSProgramming", sortOrder: 3)
     context.insert(sideProject)
     context.insert(swiftUI)
     context.insert(macOS)
-    context.insert(iosProg)
 
     // Projects
     let project = Project(name: "BullhornApp", projectDescription: "Social media scheduler")
-    let project2 = Project(name: "WeekendHacks", projectDescription: "Weekend side projects")
     context.insert(project)
-    context.insert(project2)
 
     // Archived project — exercises ProjectsTabView archive/unarchive flow
     let archivedProj = Project(name: "DeprecatedTool", projectDescription: "No longer maintained")
     archivedProj.archived = true
     context.insert(archivedProj)
 
-    // Captures — markdown text for preview toggle, notes, varied posted timestamps
+    // Captures — compact enough for manual QA, varied enough for smoke coverage.
     let c1 = Capture(
       text: "Just shipped **v2** with new *scheduling engine* — totally rebuilt",
       links: ["https://github.com/neonwatty/bullhorn/releases/v2.0"],
@@ -58,58 +54,24 @@ enum QAFixtures {
     )
     context.insert(c2)
 
-    let c3 = Capture(
-      text: "SwiftData + NSPanel: ~~tricky~~ lessons from building a floating sidebar",
-      project: project,
-      subreddits: [swiftUI]
-    )
-    context.insert(c3)
-
-    let c4 = Capture(
-      text: "How I use sticker bomb design in a native macOS app",
-      project: project,
-      subreddits: [macOS]
-    )
-    c4.markAsPosted()
-    c4.postedAt = Date().addingTimeInterval(-3 * 3600)  // 3 hours ago — tests relative time
-    context.insert(c4)
-
-    let c5 = Capture(
-      text: "XcodeGen + Makefile: reproducible macOS builds",
-      links: ["https://github.com/neonwatty/reddit-reminder/blob/main/Makefile"],
-      project: project,
-      subreddits: [swiftUI, macOS]
-    )
-    c5.markAsPosted()
-    c5.postedAt = Date().addingTimeInterval(-2 * 86400)  // 2 days ago — tests relative time
-    context.insert(c5)
-
-    let c6 = Capture(
-      text: "Weekend hack: building a [Reddit bot](https://example.com) in Swift",
-      notes: "Mention the rate-limiting challenges",
-      project: project2,
-      subreddits: [iosProg, sideProject]
-    )
-    context.insert(c6)
-
     // Posted capture under archived project — exercises PostedListView + archived project
-    let c7 = Capture(
+    let c3 = Capture(
       text: "Old tool: **deprecated** CLI for subreddit scraping",
       project: archivedProj,
-      subreddits: [iosProg]
+      subreddits: [swiftUI]
     )
-    c7.markAsPosted()
-    c7.postedAt = Date().addingTimeInterval(-7 * 86400)  // 1 week ago
-    context.insert(c7)
+    c3.markAsPosted()
+    c3.postedAt = Date().addingTimeInterval(-7 * 86400)  // 1 week ago
+    context.insert(c3)
 
     // No-project capture — exercises null project display path
-    let c8 = Capture(
+    let c4 = Capture(
       text: "Quick thought: *menu bar apps* are underrated on macOS",
       subreddits: [macOS, sideProject]
     )
-    context.insert(c8)
+    context.insert(c4)
 
-    // Events — mix of urgency levels for dot testing
+    // Events — mix of urgency levels for dot testing.
     let imminent = SubredditEvent(
       name: "SideProject Saturday",
       subreddit: sideProject,
@@ -123,14 +85,6 @@ enum QAFixtures {
       oneOffDate: Date().addingTimeInterval(6 * 3600)  // +6hr → medium (green dot)
     )
     context.insert(soonish)
-
-    let farOut = SubredditEvent(
-      name: "macOS Weekly",
-      subreddit: macOS,
-      // +7d -> none (no dot)
-      oneOffDate: Calendar.current.date(byAdding: .day, value: 7, to: Date())
-    )
-    context.insert(farOut)
 
     // Seed default project preference
     defaults.set(project.id.uuidString, forKey: SettingsKey.defaultProjectId)

--- a/Sources/Views/CaptureCardView.swift
+++ b/Sources/Views/CaptureCardView.swift
@@ -35,7 +35,6 @@ struct CaptureCardView: View {
           if let onOpenHandoff {
             hoverActionButton(
               systemName: "paperplane",
-              label: "Post",
               accessibilityLabel: Self.openHandoffAccessibilityLabel,
               action: onOpenHandoff
             )
@@ -44,7 +43,6 @@ struct CaptureCardView: View {
           if let onCopyText {
             hoverActionButton(
               systemName: "doc.on.doc",
-              label: "Copy",
               accessibilityLabel: Self.copyTextAccessibilityLabel,
               action: onCopyText
             )
@@ -53,32 +51,18 @@ struct CaptureCardView: View {
           if let onMarkPosted {
             hoverActionButton(
               systemName: "checkmark.circle",
-              label: "Done",
               accessibilityLabel: Self.markPostedAccessibilityLabel,
               action: onMarkPosted
             )
           }
 
           if let onDelete {
-            Button(action: onDelete) {
-              HStack(spacing: 3) {
-                Image(systemName: "trash")
-                  .font(.system(size: 10, weight: .medium))
-                Text("Delete")
-                  .font(.system(size: 10, weight: .medium))
-              }
-              .foregroundStyle(.red)
-              .padding(.horizontal, 6)
-              .padding(.vertical, 3)
-              .background(.quaternary.opacity(0.3))
-              .clipShape(RoundedRectangle(cornerRadius: 4))
-              .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help(Self.deleteAccessibilityLabel)
-            .accessibilityLabel(Self.deleteAccessibilityLabel)
-            .accessibilityIdentifier(
-              "captureCard.\(Self.deleteAccessibilityLabel.identifierSuffix)")
+            hoverActionButton(
+              systemName: "trash",
+              accessibilityLabel: Self.deleteAccessibilityLabel,
+              foregroundStyle: .red,
+              action: onDelete
+            )
           }
         }
 
@@ -162,20 +146,15 @@ struct CaptureCardView: View {
 
   private func hoverActionButton(
     systemName: String,
-    label: String,
     accessibilityLabel: String,
+    foregroundStyle: Color = .secondary,
     action: @escaping () -> Void
   ) -> some View {
     Button(action: action) {
-      HStack(spacing: 3) {
-        Image(systemName: systemName)
-          .font(.system(size: 10, weight: .medium))
-        Text(label)
-          .font(.system(size: 10, weight: .medium))
-      }
-      .foregroundStyle(.secondary)
-      .padding(.horizontal, 6)
-      .padding(.vertical, 3)
+      Image(systemName: systemName)
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(foregroundStyle)
+        .frame(width: 26, height: 26)
       .background(.quaternary.opacity(0.3))
       .clipShape(RoundedRectangle(cornerRadius: 4))
       .contentShape(Rectangle())

--- a/Tests/RedditReminderTests/QAFixturesTests.swift
+++ b/Tests/RedditReminderTests/QAFixturesTests.swift
@@ -11,10 +11,10 @@ import SwiftData
 
     QAFixtures.seed(context: context, defaults: defaults)
 
-    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 4)
-    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 3)
-    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 8)
-    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 3)
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 3)
+    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 2)
+    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 4)
+    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 2)
     #expect(defaults.string(forKey: SettingsKey.defaultProjectId) != nil)
 }
 


### PR DESCRIPTION
## Summary
- replace cramped text hover actions on capture cards with fixed-size icon buttons
- keep tooltips/accessibility labels and context-menu text for full action names
- trim debug QA seed data from 8 captures to 4 and update fixture count expectations

## Verification
- make build-debug
- xcodebuild test -project RedditReminder.xcodeproj -scheme RedditReminder -destination 'platform=macOS' -derivedDataPath build -only-testing:RedditReminderTests/QAFixturesTests CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= ENABLE_DEBUG_DYLIB=NO ENABLE_HARDENED_RUNTIME=NO OTHER_CODE_SIGN_FLAGS=  # completed, but selected 0 Swift Testing tests

## Notes
- Full make test was started, but the hosted test app/test runner hung after initial tests; it was stopped manually.