### PR TITLE
Consolidate workflows into menu popover

### DIFF
--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3DD479FBD3DE62E93690C4AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0972EE8B384E16C0A49F8555 /* AppDelegate.swift */; };
 		3E3AB083447626CC69DF693B /* SubredditPeakSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B31CB6F345C1C2B72D954744 /* SubredditPeakSelectionTests.swift */; };
 		42EF49CDAB403FE9D2C36047 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BB3D18ECE13E70E7CED42 /* NotificationService.swift */; };
+		4571169CFBCD9757344904F2 /* PopoverContentRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416AAA3BB8DC7EFE8E6CB262 /* PopoverContentRoutes.swift */; };
 		458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */; };
 		474176ACD33799B0C433D8C5 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A523CACB82BF88E46FD3E /* MenuBarController.swift */; };
 		4907C5B4B92A0039716F0727 /* SubredditCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A20FE04DD7075E02C7092 /* SubredditCRUDTests.swift */; };
@@ -216,6 +217,7 @@
 		3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditRowHelpers.swift; sourceTree = "<group>"; };
 		409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummaryTests.swift; sourceTree = "<group>"; };
 		40A4D807E91E15E3C1B5275C /* UrgencyPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrgencyPresentationTests.swift; sourceTree = "<group>"; };
+		416AAA3BB8DC7EFE8E6CB262 /* PopoverContentRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentRoutes.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4758BE68EE85AA3FA2EA4DC4 /* DefaultSubredditsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubredditsTests.swift; sourceTree = "<group>"; };
 		4871F815198EF14E6C1B2C22 /* TimingEngineTimezoneEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngineTimezoneEdgeCaseTests.swift; sourceTree = "<group>"; };
@@ -545,6 +547,7 @@
 				E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */,
 				C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */,
 				BA663A41B0593635EA0F77F0 /* PopoverContentEmptyStates.swift */,
+				416AAA3BB8DC7EFE8E6CB262 /* PopoverContentRoutes.swift */,
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
 				1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */,
 				303FB325A99764563E4FB2AC /* PostHandoffView.swift */,
@@ -826,6 +829,7 @@
 				690C38B0C986D2C9B9F268D5 /* PopoverChromeViews.swift in Sources */,
 				A45C2634E04FC8E88CD17018 /* PopoverContentActions.swift in Sources */,
 				F1ABAC22E330444576523F58 /* PopoverContentEmptyStates.swift in Sources */,
+				4571169CFBCD9757344904F2 /* PopoverContentRoutes.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
 				2D2A3ADE0E9F1C8BE10A948A /* PopoverTimingPresentation.swift in Sources */,
 				0FED0DF0846890CB2DEE1F53 /* PostHandoffView.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftData
+import SwiftUI
 @preconcurrency import UserNotifications
 
 @MainActor
@@ -92,6 +93,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    bootstrapApplication()
+
     if AppRuntime.shouldRegisterGlobalShortcut() {
       registerGlobalShortcut()
       shortcutObserver = NotificationCenter.default.addObserver(
@@ -113,6 +116,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     startRefreshLoop()
 
     NSLog("RedditReminder: launched, refresh loop started")
+  }
+
+  private func bootstrapApplication() {
+    let container: ModelContainer
+    do {
+      container = try AppModelContainerFactory.makeContainer()
+    } catch {
+      presentStoreUnavailableAlert(error: error)
+      return
+    }
+
+    wireMenuActions(container: container)
+    #if DEBUG
+      if ProcessInfo.processInfo.arguments.contains("--seed-qa") {
+        QAFixtures.seed(context: container.mainContext)
+      } else {
+        DefaultSubreddits.seedIfEmpty(context: container.mainContext)
+      }
+    #else
+      DefaultSubreddits.seedIfEmpty(context: container.mainContext)
+    #endif
+    runRefreshCycle()
+
+    let popoverView = PopoverContentView(
+      menuBarController: menuBarController,
+      notificationService: notificationService,
+      heuristicsStore: heuristicsStore,
+      onAppStateChanged: { [weak self] in self?.runRefreshCycle() }
+    )
+    .modelContainer(container)
+    menuBarController.setup(popoverContent: popoverView)
+  }
+
+  private func presentStoreUnavailableAlert(error: Error) {
+    let alert = NSAlert()
+    alert.alertStyle = .critical
+    alert.messageText = "RedditReminder cannot open its data store"
+    alert.informativeText = """
+      The app did not start with temporary storage because that could make new captures disappear when you quit.
+
+      \(error.localizedDescription)
+      """
+    alert.addButton(withTitle: "Reveal Data Folder")
+    alert.addButton(withTitle: "Quit")
+    if alert.runModal() == .alertFirstButtonReturn {
+      let directory = AppModelContainerFactory.appSupportDirectory
+      try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      NSWorkspace.shared.activateFileViewerSelecting([directory])
+    }
+    NSApp.terminate(nil)
   }
 
   func applicationDidBecomeActive(_ notification: Notification) {

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   private var refreshTask: Task<Void, Never>?
   private var shortcutObserver: NSObjectProtocol?
   var activeShortcutConfig: KeyboardShortcutConfig?
+  private var keepAliveWindow: NSWindow?
 
   override convenience init() {
     self.init(
@@ -93,6 +94,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
+    ProcessInfo.processInfo.disableAutomaticTermination(
+      "Keep RedditReminder menu bar app running"
+    )
+    setupKeepAliveWindow()
     bootstrapApplication()
 
     if AppRuntime.shouldRegisterGlobalShortcut() {
@@ -131,11 +136,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     #if DEBUG
       if ProcessInfo.processInfo.arguments.contains("--seed-qa") {
         QAFixtures.seed(context: container.mainContext)
-      } else {
-        DefaultSubreddits.seedIfEmpty(context: container.mainContext)
       }
-    #else
-      DefaultSubreddits.seedIfEmpty(context: container.mainContext)
     #endif
     runRefreshCycle()
 
@@ -147,6 +148,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     )
     .modelContainer(container)
     menuBarController.setup(popoverContent: popoverView)
+  }
+
+  private func setupKeepAliveWindow() {
+    guard keepAliveWindow == nil else { return }
+
+    let window = NSWindow(
+      contentRect: NSRect(x: -10_000, y: -10_000, width: 1, height: 1),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentView = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+    window.backgroundColor = .clear
+    window.alphaValue = 0.01
+    window.ignoresMouseEvents = true
+    window.isOpaque = false
+    window.isReleasedWhenClosed = false
+    window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+    window.orderFront(nil)
+    keepAliveWindow = window
   }
 
   private func presentStoreUnavailableAlert(error: Error) {
@@ -175,6 +196,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   func applicationWillTerminate(_ notification: Notification) {
     globalShortcut.unregister()
     refreshTask?.cancel()
+    keepAliveWindow?.close()
+    keepAliveWindow = nil
+    ProcessInfo.processInfo.enableAutomaticTermination(
+      "Keep RedditReminder menu bar app running"
+    )
     if let shortcutObserver {
       NotificationCenter.default.removeObserver(shortcutObserver)
     }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -270,44 +270,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   func wireMenuActions(container: ModelContainer) {
     modelContainer = container
     menuBarController.onNewCapture = { [weak self] in
-      self?.showNewCaptureWindow(container: container)
+      self?.menuBarController.requestNewCapture()
     }
     menuBarController.onOpenPreferences = { [weak self] in
-      self?.showPreferencesWindow(container: container)
+      self?.menuBarController.requestPreferences()
     }
-  }
-
-  private func showNewCaptureWindow(container: ModelContainer) {
-    let formView = CaptureWindowView(
-      mode: .create,
-      onSave: { [weak self] result in
-        guard let self else { return false }
-        let ok = CapturePersistenceActions.saveCapture(
-          result,
-          modelContext: container.mainContext,
-          mediaStore: mediaStore,
-          onAppStateChanged: { [weak self] in self?.runRefreshCycle() }
-        )
-        if ok {
-          menuBarController.closeCaptureWindow()
-          menuBarController.openPopover()
-        }
-        return ok
-      },
-      onCancel: { [weak self] in self?.menuBarController.closeCaptureWindow() }
-    )
-    .modelContainer(container)
-    menuBarController.showCaptureWindow(title: "New Capture", content: formView)
-  }
-
-  private func showPreferencesWindow(container: ModelContainer) {
-    let prefsView = PreferencesView(
-      notificationService: notificationService,
-      heuristicsStore: heuristicsStore,
-      onAppStateChanged: { [weak self] in self?.runRefreshCycle() }
-    )
-    .modelContainer(container)
-    menuBarController.showPreferencesWindow(content: prefsView)
   }
 
   private var defaultLeadTimeMinutes: Int {

--- a/Sources/App/AppDelegateQA.swift
+++ b/Sources/App/AppDelegateQA.swift
@@ -108,7 +108,6 @@ import SwiftData
         }
         guard !testCaptures.isEmpty else { return true }
 
-        menuBarController.closePostHandoffWindow()
         menuBarController.dismissPopover()
 
         for capture in testCaptures {

--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -1,77 +1,13 @@
 import AppKit
-import SwiftData
 import SwiftUI
 
 @main
 struct RedditReminderApp: App {
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-  private let container: ModelContainer?
-  private let startupError: Error?
-
-  init() {
-    do {
-      container = try AppModelContainerFactory.makeContainer()
-      startupError = nil
-    } catch {
-      container = nil
-      startupError = error
-    }
-  }
-
   var body: some Scene {
-    WindowGroup("RedditReminderKeepalive") {
-      Color.clear
-        .frame(width: 1, height: 1)
-        .onAppear {
-          if let startupError {
-            presentStoreUnavailableAlert(error: startupError)
-            return
-          }
-
-          guard let container else { return }
-
-          appDelegate.wireMenuActions(container: container)
-          #if DEBUG
-            if ProcessInfo.processInfo.arguments.contains("--seed-qa") {
-              QAFixtures.seed(context: container.mainContext)
-            } else {
-              DefaultSubreddits.seedIfEmpty(context: container.mainContext)
-            }
-          #else
-            DefaultSubreddits.seedIfEmpty(context: container.mainContext)
-          #endif
-          appDelegate.runRefreshCycle()
-          let popoverView = PopoverContentView(
-            menuBarController: appDelegate.menuBarController,
-            notificationService: appDelegate.notificationService,
-            heuristicsStore: appDelegate.heuristicsStore,
-            onAppStateChanged: { [weak appDelegate] in appDelegate?.runRefreshCycle() }
-          )
-          .modelContainer(container)
-          appDelegate.menuBarController.setup(popoverContent: popoverView)
-        }
+    Settings {
+      EmptyView()
     }
-    .defaultSize(width: 1, height: 1)
-    .windowStyle(.hiddenTitleBar)
-  }
-
-  private func presentStoreUnavailableAlert(error: Error) {
-    let alert = NSAlert()
-    alert.alertStyle = .critical
-    alert.messageText = "RedditReminder cannot open its data store"
-    alert.informativeText = """
-      The app did not start with temporary storage because that could make new captures disappear when you quit.
-
-      \(error.localizedDescription)
-      """
-    alert.addButton(withTitle: "Reveal Data Folder")
-    alert.addButton(withTitle: "Quit")
-    if alert.runModal() == .alertFirstButtonReturn {
-      let directory = AppModelContainerFactory.appSupportDirectory
-      try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-      NSWorkspace.shared.activateFileViewerSelecting([directory])
-    }
-    NSApp.terminate(nil)
   }
 }

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -26,5 +26,7 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2026 Jeremy Watt</string>
+	<key>NSSupportsAutomaticTermination</key>
+	<false/>
 </dict>
 </plist>

--- a/Sources/Services/MenuBarController.swift
+++ b/Sources/Services/MenuBarController.swift
@@ -3,18 +3,17 @@ import SwiftUI
 
 @MainActor
 @Observable
-final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
+final class MenuBarController: NSObject, NSPopoverDelegate {
   static let settingsMenuItemTitle = "Settings…"
 
   var badgeCount: Int = 0
   var isUrgent: Bool = false
   var isPopoverVisible: Bool = false
+  var newCaptureRequestCount: Int = 0
+  var preferencesRequestCount: Int = 0
 
   private var statusItem: NSStatusItem?
   private var popover: NSPopover?
-  private var captureWindow: NSWindow?
-  private var preferencesWindow: NSWindow?
-  private var postHandoffWindow: NSWindow?
 
   /// Called from PopoverContentView to open new capture; wired to ⌘N.
   var onNewCapture: (() -> Void)?
@@ -47,7 +46,7 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
     }
 
     let pop = NSPopover()
-    pop.contentSize = NSSize(width: 350, height: 480)
+    pop.contentSize = NSSize(width: 460, height: 620)
     pop.behavior = .transient
     pop.animates = true
     pop.contentViewController = NSHostingController(rootView: popoverContent)
@@ -81,95 +80,14 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
     isPopoverVisible = true
   }
 
-  func showCaptureWindow(title: String = "New Capture", content: some View) {
-    // Always recreate window content so edit-after-edit shows fresh data
-    if let existing = captureWindow {
-      existing.title = title
-      existing.contentView = NSHostingView(rootView: content)
-      existing.makeKeyAndOrderFront(nil)
-      dismissPopover()
-      return
-    }
-
-    let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 420, height: 540),
-      styleMask: [.titled, .closable],
-      backing: .buffered,
-      defer: false
-    )
-    window.title = title
-    window.center()
-    window.contentView = NSHostingView(rootView: content)
-    window.isReleasedWhenClosed = false
-    window.delegate = self
-    window.makeKeyAndOrderFront(nil)
-
-    dismissPopover()
-    self.captureWindow = window
+  func requestNewCapture() {
+    newCaptureRequestCount += 1
+    openPopover()
   }
 
-  func closeCaptureWindow() {
-    captureWindow?.close()
-    captureWindow = nil
-  }
-
-  func showPostHandoffWindow(title: String = "Post Handoff", content: some View) {
-    if let existing = postHandoffWindow {
-      existing.title = title
-      existing.contentView = NSHostingView(rootView: content)
-      existing.makeKeyAndOrderFront(nil)
-      dismissPopover()
-      return
-    }
-
-    let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 560, height: 620),
-      styleMask: [.titled, .closable, .miniaturizable],
-      backing: .buffered,
-      defer: false
-    )
-    window.title = title
-    window.center()
-    window.contentView = NSHostingView(rootView: content)
-    window.isReleasedWhenClosed = false
-    window.delegate = self
-    window.makeKeyAndOrderFront(nil)
-
-    dismissPopover()
-    self.postHandoffWindow = window
-  }
-
-  func closePostHandoffWindow() {
-    postHandoffWindow?.close()
-    postHandoffWindow = nil
-  }
-
-  func showPreferencesWindow(content: some View) {
-    if let existing = preferencesWindow {
-      existing.makeKeyAndOrderFront(nil)
-      return
-    }
-
-    let window = NSWindow(
-      contentRect: NSRect(x: 0, y: 0, width: 500, height: 440),
-      styleMask: [.titled, .closable, .miniaturizable],
-      backing: .buffered,
-      defer: false
-    )
-    window.title = "RedditReminder Preferences"
-    window.center()
-    window.contentView = NSHostingView(rootView: content)
-    window.isReleasedWhenClosed = false
-    window.delegate = self
-    window.makeKeyAndOrderFront(nil)
-
-    dismissPopover()
-    self.preferencesWindow = window
-  }
-
-  func closePreferencesWindow() {
-    preferencesWindow?.close()
-    preferencesWindow = nil
+  func requestPreferences() {
+    preferencesRequestCount += 1
+    openPopover()
   }
 
   func dismissPopover() {
@@ -211,21 +129,6 @@ final class MenuBarController: NSObject, NSPopoverDelegate, NSWindowDelegate {
   nonisolated func popoverDidClose(_ notification: Notification) {
     Task { @MainActor in
       self.isPopoverVisible = false
-    }
-  }
-
-  // MARK: - NSWindowDelegate
-
-  nonisolated func windowWillClose(_ notification: Notification) {
-    let window = notification.object as? NSWindow
-    Task { @MainActor in
-      if window === self.captureWindow {
-        self.captureWindow = nil
-      } else if window === self.preferencesWindow {
-        self.preferencesWindow = nil
-      } else if window === self.postHandoffWindow {
-        self.postHandoffWindow = nil
-      }
     }
   }
 

--- a/Sources/Utilities/QAFixtures.swift
+++ b/Sources/Utilities/QAFixtures.swift
@@ -6,7 +6,7 @@ enum QAFixtures {
   static func seed(context: ModelContext, defaults: UserDefaults = .standard) {
     clearAll(context: context, defaults: defaults)
 
-    // 4 subreddits — some with peak overrides, some without
+    // Subreddits — some with peak overrides, some without.
     let sideProject = Subreddit(name: "r/SideProject", sortOrder: 0)
     let swiftUI = Subreddit(
       name: "r/SwiftUI",
@@ -20,24 +20,20 @@ enum QAFixtures {
       peakDaysOverride: ["tue", "thu"],
       peakHoursUtcOverride: [10, 11, 12, 13, 14]
     )
-    let iosProg = Subreddit(name: "r/iOSProgramming", sortOrder: 3)
     context.insert(sideProject)
     context.insert(swiftUI)
     context.insert(macOS)
-    context.insert(iosProg)
 
     // Projects
     let project = Project(name: "BullhornApp", projectDescription: "Social media scheduler")
-    let project2 = Project(name: "WeekendHacks", projectDescription: "Weekend side projects")
     context.insert(project)
-    context.insert(project2)
 
     // Archived project — exercises ProjectsTabView archive/unarchive flow
     let archivedProj = Project(name: "DeprecatedTool", projectDescription: "No longer maintained")
     archivedProj.archived = true
     context.insert(archivedProj)
 
-    // Captures — markdown text for preview toggle, notes, varied posted timestamps
+    // Captures — compact enough for manual QA, varied enough for smoke coverage.
     let c1 = Capture(
       text: "Just shipped **v2** with new *scheduling engine* — totally rebuilt",
       links: ["https://github.com/neonwatty/bullhorn/releases/v2.0"],
@@ -58,58 +54,24 @@ enum QAFixtures {
     )
     context.insert(c2)
 
-    let c3 = Capture(
-      text: "SwiftData + NSPanel: ~~tricky~~ lessons from building a floating sidebar",
-      project: project,
-      subreddits: [swiftUI]
-    )
-    context.insert(c3)
-
-    let c4 = Capture(
-      text: "How I use sticker bomb design in a native macOS app",
-      project: project,
-      subreddits: [macOS]
-    )
-    c4.markAsPosted()
-    c4.postedAt = Date().addingTimeInterval(-3 * 3600)  // 3 hours ago — tests relative time
-    context.insert(c4)
-
-    let c5 = Capture(
-      text: "XcodeGen + Makefile: reproducible macOS builds",
-      links: ["https://github.com/neonwatty/reddit-reminder/blob/main/Makefile"],
-      project: project,
-      subreddits: [swiftUI, macOS]
-    )
-    c5.markAsPosted()
-    c5.postedAt = Date().addingTimeInterval(-2 * 86400)  // 2 days ago — tests relative time
-    context.insert(c5)
-
-    let c6 = Capture(
-      text: "Weekend hack: building a [Reddit bot](https://example.com) in Swift",
-      notes: "Mention the rate-limiting challenges",
-      project: project2,
-      subreddits: [iosProg, sideProject]
-    )
-    context.insert(c6)
-
     // Posted capture under archived project — exercises PostedListView + archived project
-    let c7 = Capture(
+    let c3 = Capture(
       text: "Old tool: **deprecated** CLI for subreddit scraping",
       project: archivedProj,
-      subreddits: [iosProg]
+      subreddits: [swiftUI]
     )
-    c7.markAsPosted()
-    c7.postedAt = Date().addingTimeInterval(-7 * 86400)  // 1 week ago
-    context.insert(c7)
+    c3.markAsPosted()
+    c3.postedAt = Date().addingTimeInterval(-7 * 86400)  // 1 week ago
+    context.insert(c3)
 
     // No-project capture — exercises null project display path
-    let c8 = Capture(
+    let c4 = Capture(
       text: "Quick thought: *menu bar apps* are underrated on macOS",
       subreddits: [macOS, sideProject]
     )
-    context.insert(c8)
+    context.insert(c4)
 
-    // Events — mix of urgency levels for dot testing
+    // Events — mix of urgency levels for dot testing.
     let imminent = SubredditEvent(
       name: "SideProject Saturday",
       subreddit: sideProject,
@@ -123,14 +85,6 @@ enum QAFixtures {
       oneOffDate: Date().addingTimeInterval(6 * 3600)  // +6hr → medium (green dot)
     )
     context.insert(soonish)
-
-    let farOut = SubredditEvent(
-      name: "macOS Weekly",
-      subreddit: macOS,
-      // +7d -> none (no dot)
-      oneOffDate: Calendar.current.date(byAdding: .day, value: 7, to: Date())
-    )
-    context.insert(farOut)
 
     // Seed default project preference
     defaults.set(project.id.uuidString, forKey: SettingsKey.defaultProjectId)

--- a/Sources/Views/CaptureCardView.swift
+++ b/Sources/Views/CaptureCardView.swift
@@ -35,7 +35,6 @@ struct CaptureCardView: View {
           if let onOpenHandoff {
             hoverActionButton(
               systemName: "paperplane",
-              label: "Post",
               accessibilityLabel: Self.openHandoffAccessibilityLabel,
               action: onOpenHandoff
             )
@@ -44,7 +43,6 @@ struct CaptureCardView: View {
           if let onCopyText {
             hoverActionButton(
               systemName: "doc.on.doc",
-              label: "Copy",
               accessibilityLabel: Self.copyTextAccessibilityLabel,
               action: onCopyText
             )
@@ -53,32 +51,18 @@ struct CaptureCardView: View {
           if let onMarkPosted {
             hoverActionButton(
               systemName: "checkmark.circle",
-              label: "Done",
               accessibilityLabel: Self.markPostedAccessibilityLabel,
               action: onMarkPosted
             )
           }
 
           if let onDelete {
-            Button(action: onDelete) {
-              HStack(spacing: 3) {
-                Image(systemName: "trash")
-                  .font(.system(size: 10, weight: .medium))
-                Text("Delete")
-                  .font(.system(size: 10, weight: .medium))
-              }
-              .foregroundStyle(.red)
-              .padding(.horizontal, 6)
-              .padding(.vertical, 3)
-              .background(.quaternary.opacity(0.3))
-              .clipShape(RoundedRectangle(cornerRadius: 4))
-              .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help(Self.deleteAccessibilityLabel)
-            .accessibilityLabel(Self.deleteAccessibilityLabel)
-            .accessibilityIdentifier(
-              "captureCard.\(Self.deleteAccessibilityLabel.identifierSuffix)")
+            hoverActionButton(
+              systemName: "trash",
+              accessibilityLabel: Self.deleteAccessibilityLabel,
+              foregroundStyle: .red,
+              action: onDelete
+            )
           }
         }
 
@@ -162,20 +146,15 @@ struct CaptureCardView: View {
 
   private func hoverActionButton(
     systemName: String,
-    label: String,
     accessibilityLabel: String,
+    foregroundStyle: Color = .secondary,
     action: @escaping () -> Void
   ) -> some View {
     Button(action: action) {
-      HStack(spacing: 3) {
-        Image(systemName: systemName)
-          .font(.system(size: 10, weight: .medium))
-        Text(label)
-          .font(.system(size: 10, weight: .medium))
-      }
-      .foregroundStyle(.secondary)
-      .padding(.horizontal, 6)
-      .padding(.vertical, 3)
+      Image(systemName: systemName)
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(foregroundStyle)
+        .frame(width: 26, height: 26)
       .background(.quaternary.opacity(0.3))
       .clipShape(RoundedRectangle(cornerRadius: 4))
       .contentShape(Rectangle())

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -144,7 +144,7 @@ struct CaptureWindowView: View {
         .padding(16)
       }
     }
-    .frame(width: 420, height: 540)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onAppear { populateFromMode() }
   }
 

--- a/Sources/Views/PopoverContentActions.swift
+++ b/Sources/Views/PopoverContentActions.swift
@@ -3,77 +3,20 @@ import SwiftUI
 
 extension PopoverContentView {
   func openNewCapture() {
-    openCaptureWindow(mode: .create)
+    route = .captureCreate
+    showPosted = false
   }
 
   func openCaptureForEditing(_ capture: Capture) {
-    openCaptureWindow(mode: .edit(capture))
-  }
-
-  func openCaptureWindow(mode: CaptureWindowView.Mode) {
-    let (title, successMsg): (String, String) =
-      switch mode {
-      case .create: ("New Capture", "Draft saved")
-      case .edit: ("Edit Capture", "Draft updated")
-      }
-    let formView = CaptureWindowView(
-      mode: mode,
-      onSave: { result in
-        let ok: Bool =
-          switch mode {
-          case .create: saveCapture(result)
-          case .edit(let capture): updateCapture(capture, with: result)
-          }
-        if ok {
-          menuBarController.closeCaptureWindow()
-          showToastAfterReopen(successMsg)
-        }
-        return ok
-      },
-      onCancel: { menuBarController.closeCaptureWindow() }
-    ).modelContainer(modelContext.container)
-    menuBarController.showCaptureWindow(title: title, content: formView)
+    route = .captureEdit(capture)
   }
 
   func openPreferences() {
-    let prefsView = PreferencesView(
-      notificationService: notificationService,
-      heuristicsStore: heuristicsStore,
-      onAppStateChanged: onAppStateChanged
-    )
-    .modelContainer(modelContext.container)
-    menuBarController.showPreferencesWindow(content: prefsView)
+    route = .preferences
   }
 
   func openPostHandoff(for capture: Capture) {
-    let view = PostHandoffView(
-      capture: capture,
-      checklistItems: postingChecklistItems(for: capture),
-      onCopyTitle: { copyPostTitle(for: capture) },
-      onCopyBody: { copyPostBody(for: capture) },
-      onCopyLinks: { copyPostLinks(for: capture) },
-      onCopyAll: { copyPostHandoffText(for: capture) },
-      onOpenSubmit: { openRedditSubmitPage(for: capture) },
-      onMarkPosted: { markCaptureAsPosted(capture) },
-      onClose: { menuBarController.closePostHandoffWindow() },
-      onMarkSubredditPosted: { subredditId in
-        capture.markSubredditAsPosted(subredditId)
-        do { try modelContext.save() } catch {
-          NSLog("RedditReminder: mark subreddit posted failed: \(error)")
-          modelContext.rollback()
-        }
-        onAppStateChanged()
-      },
-      onMarkSubredditUnposted: { subredditId in
-        capture.markSubredditAsUnposted(subredditId)
-        do { try modelContext.save() } catch {
-          NSLog("RedditReminder: unmark subreddit posted failed: \(error)")
-          modelContext.rollback()
-        }
-        onAppStateChanged()
-      }
-    )
-    menuBarController.showPostHandoffWindow(title: handoffWindowTitle(for: capture), content: view)
+    route = .postHandoff(capture)
   }
 
   @discardableResult
@@ -274,12 +217,7 @@ extension PopoverContentView {
     return alert.runModal() == .alertFirstButtonReturn
   }
 
-  private func handoffWindowTitle(for capture: Capture) -> String {
-    let title = RedditPostingActions.titleText(for: capture)
-    return title.isEmpty ? "Post Handoff" : "Post Handoff: \(title)"
-  }
-
-  private func postingChecklistItems(for capture: Capture) -> [String] {
+  func postingChecklistItems(for capture: Capture) -> [String] {
     capture.subreddits.flatMap { subreddit in
       PostingChecklistItems.cleaned(from: subreddit.postingChecklist)
     }

--- a/Sources/Views/PopoverContentRoutes.swift
+++ b/Sources/Views/PopoverContentRoutes.swift
@@ -1,0 +1,115 @@
+import SwiftData
+import SwiftUI
+
+extension PopoverContentView {
+  func captureForm(mode: CaptureWindowView.Mode) -> some View {
+    CaptureWindowView(
+      mode: mode,
+      onSave: { result in
+        let didSave: Bool =
+          switch mode {
+          case .create:
+            saveCapture(result)
+          case .edit(let capture):
+            updateCapture(capture, with: result)
+          }
+        guard didSave else { return false }
+        route = .root
+        showPosted = false
+        showToast(mode.isCreate ? "Draft saved" : "Draft updated")
+        return true
+      },
+      onCancel: { route = .root }
+    )
+    .modelContainer(modelContext.container)
+  }
+
+  func postHandoff(_ capture: Capture) -> some View {
+    PostHandoffView(
+      capture: capture,
+      checklistItems: postingChecklistItems(for: capture),
+      onCopyTitle: { copyPostTitle(for: capture) },
+      onCopyBody: { copyPostBody(for: capture) },
+      onCopyLinks: { copyPostLinks(for: capture) },
+      onCopyAll: { copyPostHandoffText(for: capture) },
+      onOpenSubmit: { openRedditSubmitPage(for: capture) },
+      onMarkPosted: { markCaptureAsPosted(capture) },
+      onClose: { route = .root },
+      onMarkSubredditPosted: { subredditId in
+        capture.markSubredditAsPosted(subredditId)
+        do { try modelContext.save() } catch {
+          NSLog("RedditReminder: mark subreddit posted failed: \(error)")
+          modelContext.rollback()
+        }
+        onAppStateChanged()
+      },
+      onMarkSubredditUnposted: { subredditId in
+        capture.markSubredditAsUnposted(subredditId)
+        do { try modelContext.save() } catch {
+          NSLog("RedditReminder: unmark subreddit posted failed: \(error)")
+          modelContext.rollback()
+        }
+        onAppStateChanged()
+      }
+    )
+  }
+
+  func detailScreen<Content: View>(
+    title: String,
+    systemName: String,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 10) {
+        Button(action: { route = .root }) {
+          Image(systemName: "chevron.left")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: 26, height: 26)
+        }
+        .buttonStyle(.plain)
+        .help("Back")
+        .accessibilityLabel("Back")
+
+        Image(systemName: systemName)
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(AppColors.redditOrange)
+
+        Text(title)
+          .font(.system(size: 13, weight: .semibold))
+
+        Spacer()
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 12)
+      .overlay(alignment: .bottom) { Divider() }
+
+      content()
+    }
+  }
+
+  func handlePendingMenuRequests() {
+    handleNewCaptureRequest()
+    handlePreferencesRequest()
+  }
+
+  func handleNewCaptureRequest() {
+    guard menuBarController.newCaptureRequestCount > handledNewCaptureRequestCount else { return }
+    handledNewCaptureRequestCount = menuBarController.newCaptureRequestCount
+    route = .captureCreate
+    showPosted = false
+  }
+
+  func handlePreferencesRequest() {
+    guard menuBarController.preferencesRequestCount > handledPreferencesRequestCount else { return }
+    handledPreferencesRequestCount = menuBarController.preferencesRequestCount
+    route = .preferences
+  }
+}
+
+extension CaptureWindowView.Mode {
+  fileprivate var isCreate: Bool {
+    if case .create = self { return true }
+    return false
+  }
+}

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -28,8 +28,8 @@ struct PopoverContentView: View {
   @State var toastTask: Task<Void, Never>?
   @State var showPosted: Bool = false
   @State var route: PopoverRoute = .root
-  @State private var handledNewCaptureRequestCount: Int = 0
-  @State private var handledPreferencesRequestCount: Int = 0
+  @State var handledNewCaptureRequestCount: Int = 0
+  @State var handledPreferencesRequestCount: Int = 0
 
   private var activeEvents: [SubredditEvent] {
     PopoverTimingPresentation.activeEvents(from: allEvents)
@@ -230,116 +230,5 @@ struct PopoverContentView: View {
     return PopoverFooterView(text: text)
   }
 
-  private func captureForm(mode: CaptureWindowView.Mode) -> some View {
-    CaptureWindowView(
-      mode: mode,
-      onSave: { result in
-        let didSave: Bool =
-          switch mode {
-          case .create:
-            saveCapture(result)
-          case .edit(let capture):
-            updateCapture(capture, with: result)
-          }
-        guard didSave else { return false }
-        route = .root
-        showPosted = false
-        showToast(mode.isCreate ? "Draft saved" : "Draft updated")
-        return true
-      },
-      onCancel: { route = .root }
-    )
-    .modelContainer(modelContext.container)
-  }
-
-  private func postHandoff(_ capture: Capture) -> some View {
-    PostHandoffView(
-      capture: capture,
-      checklistItems: postingChecklistItems(for: capture),
-      onCopyTitle: { copyPostTitle(for: capture) },
-      onCopyBody: { copyPostBody(for: capture) },
-      onCopyLinks: { copyPostLinks(for: capture) },
-      onCopyAll: { copyPostHandoffText(for: capture) },
-      onOpenSubmit: { openRedditSubmitPage(for: capture) },
-      onMarkPosted: { markCaptureAsPosted(capture) },
-      onClose: { route = .root },
-      onMarkSubredditPosted: { subredditId in
-        capture.markSubredditAsPosted(subredditId)
-        do { try modelContext.save() } catch {
-          NSLog("RedditReminder: mark subreddit posted failed: \(error)")
-          modelContext.rollback()
-        }
-        onAppStateChanged()
-      },
-      onMarkSubredditUnposted: { subredditId in
-        capture.markSubredditAsUnposted(subredditId)
-        do { try modelContext.save() } catch {
-          NSLog("RedditReminder: unmark subreddit posted failed: \(error)")
-          modelContext.rollback()
-        }
-        onAppStateChanged()
-      }
-    )
-  }
-
-  private func detailScreen<Content: View>(
-    title: String,
-    systemName: String,
-    @ViewBuilder content: () -> Content
-  ) -> some View {
-    VStack(spacing: 0) {
-      HStack(spacing: 10) {
-        Button(action: { route = .root }) {
-          Image(systemName: "chevron.left")
-            .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(.secondary)
-            .frame(width: 26, height: 26)
-        }
-        .buttonStyle(.plain)
-        .help("Back")
-        .accessibilityLabel("Back")
-
-        Image(systemName: systemName)
-          .font(.system(size: 13, weight: .semibold))
-          .foregroundStyle(AppColors.redditOrange)
-
-        Text(title)
-          .font(.system(size: 13, weight: .semibold))
-
-        Spacer()
-      }
-      .padding(.horizontal, 16)
-      .padding(.vertical, 12)
-      .overlay(alignment: .bottom) { Divider() }
-
-      content()
-    }
-  }
-
-  private func handlePendingMenuRequests() {
-    handleNewCaptureRequest()
-    handlePreferencesRequest()
-  }
-
-  private func handleNewCaptureRequest() {
-    guard menuBarController.newCaptureRequestCount > handledNewCaptureRequestCount else { return }
-    handledNewCaptureRequestCount = menuBarController.newCaptureRequestCount
-    route = .captureCreate
-    showPosted = false
-  }
-
-  private func handlePreferencesRequest() {
-    guard menuBarController.preferencesRequestCount > handledPreferencesRequestCount else { return }
-    handledPreferencesRequestCount = menuBarController.preferencesRequestCount
-    route = .preferences
-  }
-
   // Actions live in PopoverContentActions.swift.
-}
-
-extension CaptureWindowView.Mode {
-  fileprivate var isCreate: Bool {
-    if case .create = self { return true }
-    return false
-  }
 }

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -1,6 +1,14 @@
 import SwiftData
 import SwiftUI
 
+enum PopoverRoute {
+  case root
+  case captureCreate
+  case captureEdit(Capture)
+  case preferences
+  case postHandoff(Capture)
+}
+
 struct PopoverContentView: View {
   let menuBarController: MenuBarController
   let notificationService: NotificationService
@@ -18,7 +26,10 @@ struct PopoverContentView: View {
   @State private var searchText: String = ""
   @State var toast: Toast?
   @State var toastTask: Task<Void, Never>?
-  @State private var showPosted: Bool = false
+  @State var showPosted: Bool = false
+  @State var route: PopoverRoute = .root
+  @State private var handledNewCaptureRequestCount: Int = 0
+  @State private var handledPreferencesRequestCount: Int = 0
 
   private var activeEvents: [SubredditEvent] {
     PopoverTimingPresentation.activeEvents(from: allEvents)
@@ -38,10 +49,28 @@ struct PopoverContentView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      header
-      if !captures.isEmpty { searchBar }
-      if showPosted { postedContent } else { queuedContent }
-      footer
+      switch route {
+      case .root:
+        header
+        if !captures.isEmpty { searchBar }
+        if showPosted { postedContent } else { queuedContent }
+        footer
+      case .captureCreate:
+        captureForm(mode: .create)
+      case .captureEdit(let capture):
+        captureForm(mode: .edit(capture))
+      case .preferences:
+        detailScreen(title: "Settings", systemName: "gearshape") {
+          PreferencesView(
+            notificationService: notificationService,
+            heuristicsStore: heuristicsStore,
+            onAppStateChanged: onAppStateChanged
+          )
+          .modelContainer(modelContext.container)
+        }
+      case .postHandoff(let capture):
+        postHandoff(capture)
+      }
     }
     .overlay(alignment: .top) {
       if let toast {
@@ -49,9 +78,16 @@ struct PopoverContentView: View {
       }
     }
     .background(AppColors.popoverBg)
-    .frame(width: 350).frame(maxHeight: (NSScreen.main?.visibleFrame.height ?? 800) * 0.85)
+    .frame(width: 460).frame(maxHeight: (NSScreen.main?.visibleFrame.height ?? 800) * 0.85)
     .onAppear {
+      handlePendingMenuRequests()
       refreshTiming()
+    }
+    .onChange(of: menuBarController.newCaptureRequestCount) {
+      handleNewCaptureRequest()
+    }
+    .onChange(of: menuBarController.preferencesRequestCount) {
+      handlePreferencesRequest()
     }
     .onChange(of: captureTimingSignature) {
       refreshTiming()
@@ -194,5 +230,116 @@ struct PopoverContentView: View {
     return PopoverFooterView(text: text)
   }
 
+  private func captureForm(mode: CaptureWindowView.Mode) -> some View {
+    CaptureWindowView(
+      mode: mode,
+      onSave: { result in
+        let didSave: Bool =
+          switch mode {
+          case .create:
+            saveCapture(result)
+          case .edit(let capture):
+            updateCapture(capture, with: result)
+          }
+        guard didSave else { return false }
+        route = .root
+        showPosted = false
+        showToast(mode.isCreate ? "Draft saved" : "Draft updated")
+        return true
+      },
+      onCancel: { route = .root }
+    )
+    .modelContainer(modelContext.container)
+  }
+
+  private func postHandoff(_ capture: Capture) -> some View {
+    PostHandoffView(
+      capture: capture,
+      checklistItems: postingChecklistItems(for: capture),
+      onCopyTitle: { copyPostTitle(for: capture) },
+      onCopyBody: { copyPostBody(for: capture) },
+      onCopyLinks: { copyPostLinks(for: capture) },
+      onCopyAll: { copyPostHandoffText(for: capture) },
+      onOpenSubmit: { openRedditSubmitPage(for: capture) },
+      onMarkPosted: { markCaptureAsPosted(capture) },
+      onClose: { route = .root },
+      onMarkSubredditPosted: { subredditId in
+        capture.markSubredditAsPosted(subredditId)
+        do { try modelContext.save() } catch {
+          NSLog("RedditReminder: mark subreddit posted failed: \(error)")
+          modelContext.rollback()
+        }
+        onAppStateChanged()
+      },
+      onMarkSubredditUnposted: { subredditId in
+        capture.markSubredditAsUnposted(subredditId)
+        do { try modelContext.save() } catch {
+          NSLog("RedditReminder: unmark subreddit posted failed: \(error)")
+          modelContext.rollback()
+        }
+        onAppStateChanged()
+      }
+    )
+  }
+
+  private func detailScreen<Content: View>(
+    title: String,
+    systemName: String,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 10) {
+        Button(action: { route = .root }) {
+          Image(systemName: "chevron.left")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: 26, height: 26)
+        }
+        .buttonStyle(.plain)
+        .help("Back")
+        .accessibilityLabel("Back")
+
+        Image(systemName: systemName)
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(AppColors.redditOrange)
+
+        Text(title)
+          .font(.system(size: 13, weight: .semibold))
+
+        Spacer()
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 12)
+      .overlay(alignment: .bottom) { Divider() }
+
+      content()
+    }
+  }
+
+  private func handlePendingMenuRequests() {
+    handleNewCaptureRequest()
+    handlePreferencesRequest()
+  }
+
+  private func handleNewCaptureRequest() {
+    guard menuBarController.newCaptureRequestCount > handledNewCaptureRequestCount else { return }
+    handledNewCaptureRequestCount = menuBarController.newCaptureRequestCount
+    route = .captureCreate
+    showPosted = false
+  }
+
+  private func handlePreferencesRequest() {
+    guard menuBarController.preferencesRequestCount > handledPreferencesRequestCount else { return }
+    handledPreferencesRequestCount = menuBarController.preferencesRequestCount
+    route = .preferences
+  }
+
   // Actions live in PopoverContentActions.swift.
+}
+
+extension CaptureWindowView.Mode {
+  fileprivate var isCreate: Bool {
+    if case .create = self { return true }
+    return false
+  }
 }

--- a/Sources/Views/PostHandoffView.swift
+++ b/Sources/Views/PostHandoffView.swift
@@ -41,7 +41,7 @@ struct PostHandoffView: View {
       }
       footer
     }
-    .frame(width: 560, height: 620)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(AppColors.popoverBg)
   }
 

--- a/Sources/Views/PreferencesView.swift
+++ b/Sources/Views/PreferencesView.swift
@@ -62,7 +62,7 @@ struct PreferencesView: View {
         )
       }
     }
-    .frame(width: 500, height: 440)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 

--- a/Tests/RedditReminderTests/QAFixturesTests.swift
+++ b/Tests/RedditReminderTests/QAFixturesTests.swift
@@ -11,10 +11,10 @@ import SwiftData
 
     QAFixtures.seed(context: context, defaults: defaults)
 
-    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 4)
-    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 3)
-    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 8)
-    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 3)
+    #expect(try context.fetchCount(FetchDescriptor<Subreddit>()) == 3)
+    #expect(try context.fetchCount(FetchDescriptor<Project>()) == 2)
+    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 4)
+    #expect(try context.fetchCount(FetchDescriptor<SubredditEvent>()) == 2)
     #expect(defaults.string(forKey: SettingsKey.defaultProjectId) != nil)
 }
 

--- a/Tests/RedditReminderUITests/RedditReminderSmokeUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderSmokeUITests.swift
@@ -14,7 +14,7 @@ final class RedditReminderSmokeUITests: XCTestCase {
         app = nil
     }
 
-    func testKeyboardCommandsOpenPrimaryWindows() throws {
+    func testKeyboardCommandsOpenPopoverScreens() throws {
         app.launch()
         XCTAssertTrue(
             app.wait(for: .runningForeground, timeout: 5)
@@ -23,9 +23,9 @@ final class RedditReminderSmokeUITests: XCTestCase {
 
         app.activate()
         app.typeKey("n", modifierFlags: .command)
-        XCTAssertTrue(app.windows["New Capture"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.textFields["captureWindow.title"].waitForExistence(timeout: 3))
 
         app.typeKey(",", modifierFlags: .command)
-        XCTAssertTrue(app.windows["RedditReminder Preferences"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["preferences.tab.Channels"].waitForExistence(timeout: 3))
     }
 }

--- a/Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift
@@ -14,7 +14,7 @@ final class RedditReminderWorkflowUITests: XCTestCase {
         app = nil
     }
 
-    func testCreateCaptureWindowAppears() throws {
+    func testCreateCapturePopoverAppears() throws {
         app.launch()
         XCTAssertTrue(
             app.wait(for: .runningForeground, timeout: 5)
@@ -24,16 +24,13 @@ final class RedditReminderWorkflowUITests: XCTestCase {
         app.activate()
         app.typeKey("n", modifierFlags: .command)
 
-        let captureWindow = app.windows["New Capture"]
-        XCTAssertTrue(captureWindow.waitForExistence(timeout: 3))
+        let titleField = app.textFields["captureWindow.title"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
 
-        let titleField = captureWindow.textFields["captureWindow.title"]
-        XCTAssertTrue(titleField.exists)
-
-        let saveButton = captureWindow.buttons["captureWindow.save"]
+        let saveButton = app.buttons["captureWindow.save"]
         XCTAssertTrue(saveButton.exists)
 
-        let cancelButton = captureWindow.buttons["captureWindow.cancel"]
+        let cancelButton = app.buttons["captureWindow.cancel"]
         XCTAssertTrue(cancelButton.exists)
     }
 
@@ -47,13 +44,10 @@ final class RedditReminderWorkflowUITests: XCTestCase {
         app.activate()
         app.typeKey(",", modifierFlags: .command)
 
-        let prefsWindow = app.windows["RedditReminder Preferences"]
-        XCTAssertTrue(prefsWindow.waitForExistence(timeout: 3))
-
         let tabs = ["Channels", "Planner", "Projects", "General", "Backup", "Notifications"]
         for tab in tabs {
-            let tabButton = prefsWindow.buttons["preferences.tab.\(tab)"]
-            XCTAssertTrue(tabButton.waitForExistence(timeout: 2), "Tab '\(tab)' should exist")
+            let tabButton = app.buttons["preferences.tab.\(tab)"]
+            XCTAssertTrue(tabButton.waitForExistence(timeout: 3), "Tab '\(tab)' should exist")
             tabButton.click()
             // Brief pause for tab content to load
             Thread.sleep(forTimeInterval: 0.3)

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,7 @@ targets:
       path: Sources/Info.plist
       properties:
         LSUIElement: true
+        NSSupportsAutomaticTermination: false
         CFBundleName: RedditReminder
         CFBundleDisplayName: RedditReminder
         CFBundleIdentifier: com.neonwatty.RedditReminder

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -381,100 +381,82 @@ assert_true "AXPress status item → popover opens" "$vis"
 vis=$(set_popover_state "false")
 assert_false "AXPress again → popover closes" "$vis"
 
-# ─── 3. New Capture window (File > New Capture) ───────────────────
+# ─── 3. New Capture popover route (File > New Capture) ────────────
 
 echo ""
-bold "3. New Capture window"
+bold "3. New Capture popover route"
 echo ""
 
-# Open popover first (triggers PopoverContentView.onAppear which wires up callbacks)
-set_popover_state "true" >/dev/null
-sleep 1  # extra time for SwiftUI onAppear to wire callbacks
-
+set_popover_state "false" >/dev/null
 click_menu_item "File" "New Capture"
-exists=$(wait_for_named_window "New Capture" "true")
-assert_true "File > New Capture opens window" "$exists"
+vis=$(wait_for_popover "true")
+assert_true "File > New Capture opens popover" "$vis"
+exists=$(wait_for_named_window "New Capture" "false")
+assert_false "File > New Capture does not open a window" "$exists"
 
-if [ "$exists" = "true" ]; then
-    w=$(named_window_width "New Capture")
-    assert_eq "Capture window width" "420" "$w"
-
-    close_window "New Capture"
-    exists_after=$(wait_for_named_window "New Capture" "false")
-    assert_false "Close button dismisses Capture window" "$exists_after"
-fi
-
-# ─── 4. Preferences window ────────────────────────────────────────
+# ─── 4. Settings popover route ────────────────────────────────────
 
 echo ""
-bold "4. Preferences window"
+bold "4. Settings popover route"
 echo ""
 
+set_popover_state "false" >/dev/null
 click_menu_item "RedditReminder" "Settings…"
-exists=$(wait_for_named_window "RedditReminder Preferences" "true")
-assert_true "Settings menu opens Preferences window" "$exists"
+vis=$(wait_for_popover "true")
+assert_true "Settings menu opens popover" "$vis"
+exists=$(wait_for_named_window "RedditReminder Preferences" "false")
+assert_false "Settings menu does not open Preferences window" "$exists"
 
-if [ "$exists" = "true" ]; then
-    w=$(named_window_width "RedditReminder Preferences")
-    assert_eq "Preferences window width" "500" "$w"
-
-    close_window "RedditReminder Preferences"
-    exists_after=$(wait_for_named_window "RedditReminder Preferences" "false")
-    assert_false "Close button dismisses Preferences window" "$exists_after"
-fi
-
-# ─── 5. Popover dismisses when windows open ───────────────────────
+# ─── 5. Popover stays as the only workflow surface ────────────────
 
 echo ""
-bold "5. Popover auto-dismiss"
+bold "5. Single-surface workflow"
 echo ""
 
-# Open popover
 vis=$(set_popover_state "true")
-assert_true "Popover is open before New Capture" "$vis"
-
-# Open capture window — popover should dismiss
-click_menu_item "File" "New Capture"
-vis=$(wait_for_popover "false")
-assert_false "Popover dismissed when Capture opens" "$vis"
-
-close_window "New Capture"
-
-# ─── 6. Capture window reuse ──────────────────────────────────────
-
-echo ""
-bold "6. Capture window reuse"
-echo ""
-
-# Open, close, open again
-click_menu_item "File" "New Capture"
-exists1=$(wait_for_named_window "New Capture" "true")
-assert_true "First New Capture window opens" "$exists1"
-
-close_window "New Capture"
+assert_true "Popover opens before route changes" "$vis"
 
 click_menu_item "File" "New Capture"
-exists2=$(wait_for_named_window "New Capture" "true")
-assert_true "Second New Capture opens after close" "$exists2"
+vis=$(wait_for_popover "true")
+assert_true "Popover remains visible for New Capture" "$vis"
+exists=$(wait_for_named_window "New Capture" "false")
+assert_false "No Capture window appears from route change" "$exists"
 
-close_window "New Capture"
-
-# ─── 7. Preferences window reuse ──────────────────────────────────
+# ─── 6. New Capture route reuse ───────────────────────────────────
 
 echo ""
-bold "7. Preferences window reuse"
+bold "6. New Capture route reuse"
 echo ""
 
+set_popover_state "false" >/dev/null
+click_menu_item "File" "New Capture"
+vis1=$(wait_for_popover "true")
+assert_true "First New Capture route opens popover" "$vis1"
+
+set_popover_state "false" >/dev/null
+click_menu_item "File" "New Capture"
+vis2=$(wait_for_popover "true")
+assert_true "Second New Capture route opens after close" "$vis2"
+count=$(wait_for_named_window_count "New Capture" "0")
+assert_eq "No New Capture windows created" "0" "$count"
+
+# ─── 7. Settings route reuse ──────────────────────────────────────
+
+echo ""
+bold "7. Settings route reuse"
+echo ""
+
+set_popover_state "false" >/dev/null
 click_menu_item "RedditReminder" "Settings…"
-exists=$(wait_for_named_window "RedditReminder Preferences" "true")
-assert_true "First Preferences window opens" "$exists"
+vis=$(wait_for_popover "true")
+assert_true "First Settings route opens popover" "$vis"
 
-# Open again — should reuse, not duplicate
+set_popover_state "false" >/dev/null
 click_menu_item "RedditReminder" "Settings…"
-count=$(wait_for_named_window_count "RedditReminder Preferences" "1")
-assert_eq "Only one Preferences window (reuse)" "1" "$count"
-
-close_window "RedditReminder Preferences"
+vis=$(wait_for_popover "true")
+assert_true "Second Settings route opens after close" "$vis"
+count=$(wait_for_named_window_count "RedditReminder Preferences" "0")
+assert_eq "No Preferences windows created" "0" "$count"
 
 # ─── 8. QA fixtures ───────────────────────────────────────────────
 
@@ -605,11 +587,13 @@ assert_running "App restarts after kill"
 vis=$(set_popover_state "true")
 assert_true "Popover opens after restart" "$vis"
 
-# Verify menu shortcuts still work after restart
+# Verify menu actions still work after restart
+set_popover_state "false" >/dev/null
 click_menu_item "File" "New Capture"
-exists=$(wait_for_named_window "New Capture" "true")
-assert_true "New Capture works after restart" "$exists"
-close_window "New Capture"
+vis=$(wait_for_popover "true")
+assert_true "New Capture route works after restart" "$vis"
+exists=$(wait_for_named_window "New Capture" "false")
+assert_false "No New Capture window after restart" "$exists"
 
 # Close popover
 set_popover_state "false" >/dev/null


### PR DESCRIPTION
## Summary
- route New Capture, Settings, edit, and post handoff flows inside the menu bar popover
- remove separate NSWindow workflow surfaces from MenuBarController
- update UI and QA tests for popover-only behavior

## Verification
- make build-debug
- make install-debug
- make qa (ALL 34 TESTS PASSED)

Local app store was reset after QA so the installed app starts empty.