### PR TITLE
Add agent-friendly CLI foundation

### DIFF
--- a/CLI/Sources/CLICaptureCreator.swift
+++ b/CLI/Sources/CLICaptureCreator.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct CLICaptureCreator {
+  let options: CLIOptions
+  let context: ModelContext
+
+  func create(input: CaptureCreateInput) throws -> CLIResponse {
+    let project = try input.project.map(findProject)
+    let subreddits = try input.subreddits.map(findSubreddit)
+    let mediaURLs = try input.mediaPaths.map(mediaURL)
+    let dueDate = try input.due.map(parseDate)
+
+    if options.dryRun {
+      return .success(
+        data: .dryRun(
+          "Would create capture with \(subreddits.count) subreddit(s), \(mediaURLs.count) media file(s), and \(dueDate == nil ? 0 : subreddits.count) due event(s)."
+        ))
+    }
+
+    let capture = Capture(
+      title: input.title,
+      text: input.text,
+      notes: input.notes,
+      links: input.links,
+      mediaRefs: [],
+      project: project,
+      subreddits: subreddits
+    )
+    context.insert(capture)
+
+    let mediaStore = MediaStore(rootDir: CLIStore.mediaRootURL(from: options.storePath))
+    do {
+      capture.mediaRefs = try CapturePersistenceActions.saveMediaFiles(
+        mediaURLs,
+        captureId: capture.id,
+        mediaStore: mediaStore
+      )
+      let events =
+        dueDate.map { createDueEvents(date: $0, capture: capture, subreddits: subreddits) }
+        ?? []
+      try context.save()
+      return .success(
+        data: .captureCreated(
+          CaptureCreateDTO(capture: CaptureDTO(capture), events: events.map(SubredditEventDTO.init))
+        ))
+    } catch {
+      mediaStore.deleteAll(captureId: capture.id)
+      context.delete(capture)
+      throw CLIError.runtime("Could not create capture: \(error.localizedDescription)")
+    }
+  }
+
+  private func findProject(_ input: String) throws -> Project {
+    let descriptor = FetchDescriptor<Project>(sortBy: [SortDescriptor(\.name)])
+    let projects = (try? context.fetch(descriptor)) ?? []
+    if let project = projects.first(where: {
+      $0.id.uuidString == input || $0.name.caseInsensitiveCompare(input) == .orderedSame
+    }) {
+      return project
+    }
+    throw CLIError.notFound("Project not found: \(input)")
+  }
+
+  private func findSubreddit(_ input: String) throws -> Subreddit {
+    let normalized = SubredditName.normalizedName(input) ?? input
+    let descriptor = FetchDescriptor<Subreddit>(sortBy: [SortDescriptor(\.sortOrder)])
+    let subreddits = (try? context.fetch(descriptor)) ?? []
+    if let subreddit = subreddits.first(where: {
+      $0.id.uuidString == input || $0.name.caseInsensitiveCompare(normalized) == .orderedSame
+    }) {
+      return subreddit
+    }
+    throw CLIError.notFound("Subreddit not found: \(input)")
+  }
+
+  private func mediaURL(_ path: String) throws -> URL {
+    let url = URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      throw CLIError.notFound("Media file not found: \(path)")
+    }
+    return url
+  }
+
+  private func parseDate(_ value: String) throws -> Date {
+    if let date = ISO8601DateFormatter().date(from: value) { return date }
+    throw CLIError.validation("Due date must be ISO-8601, for example 2026-05-02T15:00:00Z.")
+  }
+
+  private func createDueEvents(
+    date: Date,
+    capture: Capture,
+    subreddits: [Subreddit]
+  ) -> [SubredditEvent] {
+    subreddits.map { subreddit in
+      let event = SubredditEvent(
+        name: dueEventName(for: capture),
+        subreddit: subreddit,
+        oneOffDate: date,
+        reminderLeadMinutes: defaultLeadTimeMinutes,
+        isGeneratedFromHeuristics: false
+      )
+      context.insert(event)
+      return event
+    }
+  }
+
+  private func dueEventName(for capture: Capture) -> String {
+    let raw =
+      capture.title?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+      ? capture.title ?? ""
+      : capture.text
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return "Post: \(String(trimmed.prefix(48)))"
+  }
+
+  private var defaultLeadTimeMinutes: Int {
+    UserDefaults.standard.object(forKey: SettingsKey.defaultLeadTimeMinutes) as? Int ?? 60
+  }
+}

--- a/CLI/Sources/CLICaptureLifecycle.swift
+++ b/CLI/Sources/CLICaptureLifecycle.swift
@@ -1,0 +1,133 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct CLICaptureLifecycle {
+  let options: CLIOptions
+  let context: ModelContext
+
+  func update(input: CaptureUpdateInput) throws -> CLIResponse {
+    let capture = try findCapture(input.id)
+    let mediaStore = MediaStore(rootDir: CLIStore.mediaRootURL(from: options.storePath))
+
+    let title = input.clearTitle ? nil : input.title ?? capture.title
+    let text = input.text ?? capture.text
+    guard title?.isEmpty == false || !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      throw CLIError.validation("Capture must keep a title or text body.")
+    }
+
+    let project: Project?
+    if input.clearProject {
+      project = nil
+    } else {
+      project = try input.project.map(findProject) ?? capture.project
+    }
+
+    let subreddits: [Subreddit]
+    if input.clearSubreddits {
+      subreddits = []
+    } else if let inputSubreddits = input.subreddits {
+      subreddits = try inputSubreddits.map(findSubreddit)
+    } else {
+      subreddits = capture.subreddits
+    }
+
+    let removedMediaRefs = input.clearMedia ? capture.mediaRefs : input.removedMediaRefs
+    if options.dryRun {
+      return .success(data: .dryRun("Would update capture \(capture.id.uuidString)."))
+    }
+
+    let result = CaptureFormResult(
+      title: title,
+      text: text,
+      notes: input.clearNotes ? nil : input.notes ?? capture.notes,
+      links: input.clearLinks ? [] : input.links ?? capture.links,
+      project: project,
+      subreddits: subreddits,
+      mediaURLs: try input.mediaPaths.map(mediaURL),
+      removedMediaRefs: removedMediaRefs
+    )
+    guard
+      CapturePersistenceActions.updateCapture(
+        capture, with: result, modelContext: context, mediaStore: mediaStore)
+    else {
+      throw CLIError.runtime("Could not update capture \(capture.id.uuidString).")
+    }
+    return .success(data: .capture(CaptureDTO(capture)))
+  }
+
+  func delete(id: String) throws -> CLIResponse {
+    let capture = try findCapture(id)
+    if options.dryRun {
+      return .success(data: .dryRun("Would delete capture \(capture.id.uuidString)."))
+    }
+    let deletedId = capture.id.uuidString
+    let mediaStore = MediaStore(rootDir: CLIStore.mediaRootURL(from: options.storePath))
+    try CapturePersistenceActions.deleteCapture(
+      capture, modelContext: context, mediaStore: mediaStore)
+    return .success(data: .deleted(DeletedDTO(id: deletedId)))
+  }
+
+  func markPosted(id: String, url: String?) throws -> CLIResponse {
+    let capture = try findCapture(id)
+    if options.dryRun {
+      return .success(data: .dryRun("Would mark capture \(capture.id.uuidString) posted."))
+    }
+    capture.markAsPosted(postedURL: url)
+    try context.save()
+    return .success(data: .capture(CaptureDTO(capture)))
+  }
+
+  func markQueued(id: String) throws -> CLIResponse {
+    let capture = try findCapture(id)
+    if options.dryRun {
+      return .success(data: .dryRun("Would mark capture \(capture.id.uuidString) queued."))
+    }
+    capture.markAsQueued()
+    try context.save()
+    return .success(data: .capture(CaptureDTO(capture)))
+  }
+
+  private func findCapture(_ input: String) throws -> Capture {
+    let captures = (try? context.fetch(FetchDescriptor<Capture>())) ?? []
+    let matches = captures.filter { capture in
+      capture.id.uuidString == input
+        || capture.id.uuidString.lowercased().hasPrefix(input.lowercased())
+    }
+    if matches.count == 1, let capture = matches.first { return capture }
+    if matches.count > 1 { throw CLIError.validation("Capture id prefix is ambiguous: \(input)") }
+    throw CLIError.notFound("Capture not found: \(input)")
+  }
+
+  private func findProject(_ input: String) throws -> Project {
+    let projects =
+      (try? context.fetch(FetchDescriptor<Project>(sortBy: [SortDescriptor(\.name)]))) ?? []
+    if let project = projects.first(where: {
+      $0.id.uuidString == input || $0.name.caseInsensitiveCompare(input) == .orderedSame
+    }) {
+      return project
+    }
+    throw CLIError.notFound("Project not found: \(input)")
+  }
+
+  private func findSubreddit(_ input: String) throws -> Subreddit {
+    let normalized = SubredditName.normalizedName(input) ?? input
+    let subreddits =
+      (try? context.fetch(FetchDescriptor<Subreddit>(sortBy: [SortDescriptor(\.sortOrder)]))) ?? []
+    if let subreddit = subreddits.first(where: {
+      $0.id.uuidString == input || $0.name.caseInsensitiveCompare(normalized) == .orderedSame
+    }) {
+      return subreddit
+    }
+    throw CLIError.notFound("Subreddit not found: \(input)")
+  }
+
+  private func mediaURL(_ path: String) throws -> URL {
+    let url = URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      throw CLIError.notFound("Media file not found: \(path)")
+    }
+    return url
+  }
+}

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+enum CLIResponseData: Encodable {
+  case captures([CaptureDTO])
+  case captureCreated(CaptureCreateDTO)
+  case capture(CaptureDTO)
+  case deleted(DeletedDTO)
+  case projects([ProjectDTO])
+  case project(ProjectDTO)
+  case subreddits([SubredditDTO])
+  case subreddit(SubredditDTO)
+  case peakPresets([PeakPresetDTO])
+  case peakInfo(PeakInfoDTO)
+  case dryRun(String)
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .captures(let value): try container.encode(value)
+    case .captureCreated(let value): try container.encode(value)
+    case .capture(let value): try container.encode(value)
+    case .deleted(let value): try container.encode(value)
+    case .projects(let value): try container.encode(value)
+    case .project(let value): try container.encode(value)
+    case .subreddits(let value): try container.encode(value)
+    case .subreddit(let value): try container.encode(value)
+    case .peakPresets(let value): try container.encode(value)
+    case .peakInfo(let value): try container.encode(value)
+    case .dryRun(let value): try container.encode(["message": value])
+    }
+  }
+}
+
+struct CaptureCreateInput {
+  let title: String?
+  let text: String
+  let notes: String?
+  let links: [String]
+  let project: String?
+  let subreddits: [String]
+  let mediaPaths: [String]
+  let due: String?
+}
+
+struct CaptureUpdateInput {
+  let id: String
+  let title: String?
+  let clearTitle: Bool
+  let text: String?
+  let notes: String?
+  let clearNotes: Bool
+  let links: [String]?
+  let clearLinks: Bool
+  let project: String?
+  let clearProject: Bool
+  let subreddits: [String]?
+  let clearSubreddits: Bool
+  let mediaPaths: [String]
+  let removedMediaRefs: [String]
+  let clearMedia: Bool
+
+  var hasChanges: Bool {
+    title != nil || clearTitle || text != nil || notes != nil || clearNotes || links != nil
+      || clearLinks || project != nil || clearProject || subreddits != nil || clearSubreddits
+      || !mediaPaths.isEmpty || !removedMediaRefs.isEmpty || clearMedia
+  }
+}
+
+struct DeletedDTO: Encodable {
+  let id: String
+}
+
+struct CaptureCreateDTO: Encodable {
+  let capture: CaptureDTO
+  let events: [SubredditEventDTO]
+}
+
+struct CLIResponse: Encodable {
+  let ok: Bool
+  let data: CLIResponseData?
+  let warnings: [String]
+  let errors: [String]
+
+  static func success(data: CLIResponseData, warnings: [String] = []) -> CLIResponse {
+    CLIResponse(ok: true, data: data, warnings: warnings, errors: [])
+  }
+}
+
+struct CaptureDTO: Encodable {
+  let id: String
+  let title: String?
+  let text: String
+  let notes: String?
+  let links: [String]
+  let mediaRefs: [String]
+  let status: String
+  let createdAt: String
+  let postedAt: String?
+  let postedURL: String?
+  let project: ProjectRefDTO?
+  let subreddits: [SubredditRefDTO]
+
+  init(_ capture: Capture) {
+    id = capture.id.uuidString
+    title = capture.title
+    text = capture.text
+    notes = capture.notes
+    links = capture.links
+    mediaRefs = capture.mediaRefs
+    status = capture.status.rawValue
+    createdAt = CLIFormat.date(capture.createdAt)
+    postedAt = capture.postedAt.map(CLIFormat.date)
+    postedURL = capture.postedURL
+    project = capture.project.map(ProjectRefDTO.init)
+    subreddits = capture.subreddits.sorted { $0.sortOrder < $1.sortOrder }.map(SubredditRefDTO.init)
+  }
+}
+
+struct ProjectDTO: Encodable {
+  let id: String
+  let name: String
+  let description: String?
+  let color: String?
+  let archived: Bool
+  let createdAt: String
+
+  init(_ project: Project) {
+    id = project.id.uuidString
+    name = project.name
+    description = project.projectDescription
+    color = project.color
+    archived = project.archived
+    createdAt = CLIFormat.date(project.createdAt)
+  }
+}
+
+struct ProjectRefDTO: Encodable {
+  let id: String
+  let name: String
+
+  init(_ project: Project) {
+    id = project.id.uuidString
+    name = project.name
+  }
+}
+
+struct SubredditDTO: Encodable {
+  let id: String
+  let name: String
+  let sortOrder: Int
+  let postingChecklist: String?
+  let peak: PeakSummaryDTO
+
+  init(_ subreddit: Subreddit, peakInfo: PeakInfo?) {
+    id = subreddit.id.uuidString
+    name = subreddit.name
+    sortOrder = subreddit.sortOrder
+    postingChecklist = subreddit.postingChecklist
+    peak = PeakSummaryDTO(subreddit: subreddit, peakInfo: peakInfo)
+  }
+}
+
+struct SubredditRefDTO: Encodable {
+  let id: String
+  let name: String
+
+  init(_ subreddit: Subreddit) {
+    id = subreddit.id.uuidString
+    name = subreddit.name
+  }
+}
+
+struct PeakPresetDTO: Encodable {
+  let label: String
+  let days: [String]
+  let localHours: [Int]
+
+  init(_ preset: SubredditPeakSelection.PeakPreset) {
+    label = preset.label
+    days = preset.days
+    localHours = preset.localHours
+  }
+}
+
+struct PeakSummaryDTO: Encodable {
+  let source: String
+  let days: [String]
+  let hoursUtc: [Int]
+  let hoursLocal: [Int]
+
+  init(subreddit: Subreddit, peakInfo: PeakInfo?) {
+    if subreddit.peakDaysOverride != nil || subreddit.peakHoursUtcOverride != nil {
+      source = "override"
+    } else if peakInfo != nil {
+      source = "bundled"
+    } else {
+      source = "none"
+    }
+    days = peakInfo?.peakDays ?? []
+    hoursUtc = peakInfo?.peakHoursUtc ?? []
+    hoursLocal = SubredditPeakSelection.utcHoursToLocal(hoursUtc)
+  }
+}
+
+struct PeakInfoDTO: Encodable {
+  let subreddit: SubredditRefDTO
+  let peak: PeakSummaryDTO
+
+  init(subreddit: Subreddit, peakInfo: PeakInfo?) {
+    self.subreddit = SubredditRefDTO(subreddit)
+    peak = PeakSummaryDTO(subreddit: subreddit, peakInfo: peakInfo)
+  }
+}
+
+struct SubredditEventDTO: Encodable {
+  let id: String
+  let name: String
+  let subreddit: SubredditRefDTO?
+  let oneOffDate: String?
+
+  init(_ event: SubredditEvent) {
+    id = event.id.uuidString
+    name = event.name
+    subreddit = event.subreddit.map(SubredditRefDTO.init)
+    oneOffDate = event.oneOffDate.map(CLIFormat.date)
+  }
+}

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+struct CLIInvocation {
+  let options: CLIOptions
+  let command: CLICommand
+
+  init(arguments: [String]) throws {
+    var parser = CLIArgumentParser(arguments)
+    let options = try parser.consumeGlobalOptions()
+    guard let domain = parser.consumeValue() else { throw CLIError.usage(CLIHelp.root) }
+    guard let action = parser.consumeValue() else { throw CLIError.usage(CLIHelp.domain(domain)) }
+    command = try CLICommand(domain: domain, action: action, parser: &parser)
+    try parser.rejectRemaining()
+    self.options = options
+  }
+}
+
+struct CLIOptions {
+  var json = false
+  var pretty = false
+  var dryRun = false
+  var storePath: String?
+}
+
+enum CLICommand {
+  case capturesList(query: String?)
+  case captureCreate(CaptureCreateInput)
+  case captureUpdate(CaptureUpdateInput)
+  case captureDelete(id: String)
+  case captureMarkPosted(id: String, url: String?)
+  case captureMarkQueued(id: String)
+  case projectsList(query: String?)
+  case projectCreate(name: String)
+  case subredditsList(query: String?)
+  case subredditAdd(name: String)
+  case peaksPresets
+  case peaksGet(subreddit: String)
+  case peaksSet(subreddit: String, days: [String], hours: [Int], timeZone: String?)
+  case peaksReset(subreddit: String)
+
+  init(domain: String, action: String, parser: inout CLIArgumentParser) throws {
+    switch (domain, action) {
+    case ("captures", "list"):
+      self = .capturesList(query: parser.consumeOptionalValue(for: "--query"))
+    case ("captures", "search"):
+      self = .capturesList(query: try parser.consumeRequiredValue(for: "--query"))
+    case ("captures", "create"):
+      self = .captureCreate(try parser.consumeCaptureCreateInput())
+    case ("captures", "update"):
+      self = .captureUpdate(try parser.consumeCaptureUpdateInput())
+    case ("captures", "delete"):
+      self = .captureDelete(id: try parser.consumeRequiredArgument(label: "capture id"))
+    case ("captures", "mark-posted"):
+      let id = try parser.consumeRequiredArgument(label: "capture id")
+      self = .captureMarkPosted(id: id, url: parser.consumeOptionalValue(for: "--url"))
+    case ("captures", "mark-queued"):
+      self = .captureMarkQueued(id: try parser.consumeRequiredArgument(label: "capture id"))
+    case ("projects", "list"):
+      self = .projectsList(query: parser.consumeOptionalValue(for: "--query"))
+    case ("projects", "search"):
+      self = .projectsList(query: try parser.consumeRequiredValue(for: "--query"))
+    case ("projects", "create"):
+      self = .projectCreate(name: try parser.consumeTrailingName(label: "project name"))
+    case ("subreddits", "list"):
+      self = .subredditsList(query: parser.consumeOptionalValue(for: "--query"))
+    case ("subreddits", "search"):
+      self = .subredditsList(query: try parser.consumeRequiredValue(for: "--query"))
+    case ("subreddits", "add"):
+      self = .subredditAdd(name: try parser.consumeTrailingName(label: "subreddit name"))
+    case ("peaks", "presets"):
+      self = .peaksPresets
+    case ("peaks", "get"):
+      self = .peaksGet(subreddit: try parser.consumeSubredditArgument())
+    case ("peaks", "set"):
+      let subreddit = try parser.consumeSubredditArgument()
+      let days = try parser.consumeCSV(for: "--days")
+      let hours = try parser.consumeHours(for: "--hours")
+      let timeZone = parser.consumeOptionalValue(for: "--timezone")
+      self = .peaksSet(subreddit: subreddit, days: days, hours: hours, timeZone: timeZone)
+    case ("peaks", "reset"):
+      self = .peaksReset(subreddit: try parser.consumeSubredditArgument())
+    default:
+      throw CLIError.usage(CLIHelp.domain(domain))
+    }
+  }
+}
+
+struct CLIArgumentParser {
+  private var arguments: [String]
+
+  init(_ arguments: [String]) {
+    self.arguments = arguments
+  }
+
+  mutating func consumeGlobalOptions() throws -> CLIOptions {
+    var options = CLIOptions()
+    var index = 0
+    while index < arguments.count {
+      let argument = arguments[index]
+      switch argument {
+      case "--json":
+        options.json = true
+        arguments.remove(at: index)
+      case "--pretty":
+        options.pretty = true
+        options.json = true
+        arguments.remove(at: index)
+      case "--dry-run":
+        options.dryRun = true
+        arguments.remove(at: index)
+      case "--store":
+        guard arguments.indices.contains(index + 1) else {
+          throw CLIError.usage("Missing value for --store.")
+        }
+        options.storePath = arguments[index + 1]
+        arguments.removeSubrange(index...(index + 1))
+      default:
+        index += 1
+      }
+    }
+    return options
+  }
+
+  mutating func consumeValue() -> String? {
+    guard !arguments.isEmpty else { return nil }
+    return arguments.removeFirst()
+  }
+
+  mutating func consumeOptionalValue(for flag: String) -> String? {
+    guard let index = arguments.firstIndex(of: flag),
+      arguments.indices.contains(index + 1)
+    else { return nil }
+    let value = arguments[index + 1]
+    arguments.removeSubrange(index...(index + 1))
+    return value
+  }
+
+  mutating func consumeRepeatedValues(for flag: String) -> [String] {
+    var values: [String] = []
+    while let index = arguments.firstIndex(of: flag),
+      arguments.indices.contains(index + 1)
+    {
+      values.append(arguments[index + 1])
+      arguments.removeSubrange(index...(index + 1))
+    }
+    return values
+  }
+
+  mutating func consumeRequiredValue(for flag: String) throws -> String {
+    guard let value = consumeOptionalValue(for: flag), !value.isEmpty else {
+      throw CLIError.usage("Missing value for \(flag).")
+    }
+    return value
+  }
+
+  mutating func consumeTrailingName(label: String) throws -> String {
+    let value = arguments.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+    arguments.removeAll()
+    guard !value.isEmpty else { throw CLIError.usage("Missing \(label).") }
+    return value
+  }
+
+  mutating func consumeSubredditArgument() throws -> String {
+    if let value = consumeOptionalValue(for: "--subreddit") { return value }
+    guard let value = consumeValue() else { throw CLIError.usage("Missing subreddit.") }
+    return value
+  }
+
+  mutating func consumeRequiredArgument(label: String) throws -> String {
+    guard let value = consumeValue(), !value.isEmpty else {
+      throw CLIError.usage("Missing \(label).")
+    }
+    return value
+  }
+
+  mutating func consumeCSV(for flag: String) throws -> [String] {
+    try consumeRequiredValue(for: flag)
+      .split(separator: ",")
+      .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+      .filter { !$0.isEmpty }
+  }
+
+  mutating func consumeHours(for flag: String) throws -> [Int] {
+    let values = try consumeCSV(for: flag)
+    let hours = try values.map { value in
+      guard let hour = Int(value), (0...23).contains(hour) else {
+        throw CLIError.usage("Hours must be comma-separated integers from 0 through 23.")
+      }
+      return hour
+    }
+    return Array(Set(hours)).sorted()
+  }
+
+  mutating func consumeCaptureCreateInput() throws -> CaptureCreateInput {
+    let title = consumeOptionalValue(for: "--title")
+    let textFlag = consumeOptionalValue(for: "--text")
+    let notes = consumeOptionalValue(for: "--notes")
+    let project = consumeOptionalValue(for: "--project")
+    let due = consumeOptionalValue(for: "--due")
+    let links =
+      consumeRepeatedValues(for: "--link") + splitCSV(consumeOptionalValue(for: "--links"))
+    let subreddits =
+      consumeRepeatedValues(for: "--subreddit")
+      + splitCSV(consumeOptionalValue(for: "--subreddits"))
+    let mediaPaths =
+      consumeRepeatedValues(for: "--media") + splitCSV(consumeOptionalValue(for: "--media-paths"))
+    if let unexpected = arguments.first(where: { $0.hasPrefix("--") }) {
+      throw CLIError.usage("Unexpected capture create option: \(unexpected)")
+    }
+    let trailingText = arguments.joined(separator: " ").trimmingCharacters(
+      in: .whitespacesAndNewlines)
+    arguments.removeAll()
+
+    let input = CaptureCreateInput(
+      title: normalizedOptional(title),
+      text: (textFlag ?? trailingText).trimmingCharacters(in: .whitespacesAndNewlines),
+      notes: normalizedOptional(notes),
+      links: links,
+      project: normalizedOptional(project),
+      subreddits: subreddits,
+      mediaPaths: mediaPaths,
+      due: normalizedOptional(due)
+    )
+    guard input.title != nil || !input.text.isEmpty else {
+      throw CLIError.usage("Capture create requires --text, --title, or trailing text.")
+    }
+    return input
+  }
+
+  mutating func consumeCaptureUpdateInput() throws -> CaptureUpdateInput {
+    let id = try consumeRequiredArgument(label: "capture id")
+    let title = consumeOptionalValue(for: "--title")
+    let text = consumeOptionalValue(for: "--text")
+    let notes = consumeOptionalValue(for: "--notes")
+    let project = consumeOptionalValue(for: "--project")
+    let links =
+      consumeRepeatedValues(for: "--link") + splitCSV(consumeOptionalValue(for: "--links"))
+    let subreddits =
+      consumeRepeatedValues(for: "--subreddit")
+      + splitCSV(consumeOptionalValue(for: "--subreddits"))
+    let mediaPaths =
+      consumeRepeatedValues(for: "--media")
+      + splitCSV(consumeOptionalValue(for: "--media-paths"))
+    let removedMediaRefs =
+      consumeRepeatedValues(for: "--remove-media")
+      + splitCSV(consumeOptionalValue(for: "--remove-media-refs"))
+
+    let input = CaptureUpdateInput(
+      id: id,
+      title: normalizedOptional(title),
+      clearTitle: consumeFlag("--clear-title"),
+      text: normalizedOptional(text),
+      notes: normalizedOptional(notes),
+      clearNotes: consumeFlag("--clear-notes"),
+      links: links.isEmpty ? nil : links,
+      clearLinks: consumeFlag("--clear-links"),
+      project: normalizedOptional(project),
+      clearProject: consumeFlag("--clear-project"),
+      subreddits: subreddits.isEmpty ? nil : subreddits,
+      clearSubreddits: consumeFlag("--clear-subreddits"),
+      mediaPaths: mediaPaths,
+      removedMediaRefs: removedMediaRefs,
+      clearMedia: consumeFlag("--clear-media")
+    )
+    guard input.hasChanges else {
+      throw CLIError.usage("Capture update requires at least one field flag.")
+    }
+    return input
+  }
+
+  private func splitCSV(_ value: String?) -> [String] {
+    value?
+      .split(separator: ",")
+      .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty } ?? []
+  }
+
+  private func normalizedOptional(_ value: String?) -> String? {
+    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private mutating func consumeFlag(_ flag: String) -> Bool {
+    guard let index = arguments.firstIndex(of: flag) else { return false }
+    arguments.remove(at: index)
+    return true
+  }
+
+  func rejectRemaining() throws {
+    guard arguments.isEmpty else {
+      throw CLIError.usage("Unexpected arguments: \(arguments.joined(separator: " "))")
+    }
+  }
+}

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+enum CLIFormat {
+  static let encoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    return encoder
+  }()
+
+  static let prettyEncoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    return encoder
+  }()
+
+  static func date(_ date: Date) -> String {
+    ISO8601DateFormatter().string(from: date)
+  }
+}
+
+enum CLIPrinter {
+  static func print(_ response: CLIResponse, options: CLIOptions) {
+    if options.json {
+      let encoder = options.pretty ? CLIFormat.prettyEncoder : CLIFormat.encoder
+      let data = (try? encoder.encode(response)) ?? Data()
+      Swift.print(String(data: data, encoding: .utf8) ?? "{}")
+    } else {
+      Swift.print(humanSummary(response))
+    }
+  }
+
+  static func printError(_ error: CLIError) {
+    let response = CLIErrorResponse(
+      ok: false, data: Optional<String>.none, warnings: [], errors: [error.message])
+    let data = (try? CLIFormat.prettyEncoder.encode(response)) ?? Data()
+    fputs((String(data: data, encoding: .utf8) ?? "{\"ok\":false}") + "\n", stderr)
+  }
+
+  private static func humanSummary(_ response: CLIResponse) -> String {
+    guard response.ok else { return response.errors.joined(separator: "\n") }
+    guard let data = response.data else { return "OK" }
+    switch data {
+    case .captures(let captures):
+      return captures.map { "\($0.id) \($0.status) \($0.title ?? $0.text)" }.joined(separator: "\n")
+    case .captureCreated(let created):
+      return "Created capture \(created.capture.id)"
+    case .capture(let capture):
+      return "\(capture.id) \(capture.status) \(capture.title ?? capture.text)"
+    case .deleted(let deleted):
+      return "Deleted \(deleted.id)"
+    case .projects(let projects):
+      return projects.map { "\($0.id) \($0.name)" }.joined(separator: "\n")
+    case .project(let project): return "Created project \(project.name) (\(project.id))"
+    case .subreddits(let subreddits):
+      return subreddits.map { "\($0.id) \($0.name)" }.joined(separator: "\n")
+    case .subreddit(let subreddit): return "Added subreddit \(subreddit.name) (\(subreddit.id))"
+    case .peakPresets(let presets):
+      return presets.map {
+        "\($0.label): \($0.days.joined(separator: ",")) @ \($0.localHours.map(String.init).joined(separator: ","))"
+      }.joined(separator: "\n")
+    case .peakInfo(let info):
+      return
+        "\(info.subreddit.name): \(info.peak.days.joined(separator: ",")) @ local \(info.peak.hoursLocal.map(String.init).joined(separator: ","))"
+    case .dryRun(let message): return message
+    }
+  }
+}
+
+struct CLIErrorResponse: Encodable {
+  let ok: Bool
+  let data: String?
+  let warnings: [String]
+  let errors: [String]
+}
+
+enum CLIError: Error {
+  case usage(String)
+  case validation(String)
+  case notFound(String)
+  case runtime(String)
+
+  var message: String {
+    switch self {
+    case .usage(let value), .validation(let value), .notFound(let value), .runtime(let value):
+      return value
+    }
+  }
+
+  var exitCode: Int {
+    switch self {
+    case .usage: 64
+    case .validation: 65
+    case .notFound: 66
+    case .runtime: 1
+    }
+  }
+}
+
+enum CLIHelp {
+  static let root = """
+    Usage: redditreminder [--json] [--pretty] [--dry-run] [--store PATH] <domain> <command>
+
+    Domains: captures, projects, subreddits, peaks
+    """
+
+  static func domain(_ domain: String) -> String {
+    switch domain {
+    case "captures":
+      return
+        "Usage: redditreminder captures list|search|create|update|delete|mark-posted|mark-queued"
+    case "projects": return "Usage: redditreminder projects list|search|create"
+    case "subreddits": return "Usage: redditreminder subreddits list|search|add"
+    case "peaks": return "Usage: redditreminder peaks presets|get|set|reset"
+    default: return root
+    }
+  }
+}

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -1,0 +1,239 @@
+import Foundation
+import SwiftData
+
+@MainActor
+final class CLIRunner {
+  private let options: CLIOptions
+  private let container: ModelContainer
+  private let context: ModelContext
+  private let heuristicsStore: HeuristicsStore
+
+  init(options: CLIOptions) throws {
+    self.options = options
+    let schema = Schema([Project.self, Capture.self, Subreddit.self, SubredditEvent.self])
+    let configuration = ModelConfiguration(
+      "default",
+      schema: schema,
+      url: CLIStore.storeURL(from: options.storePath),
+      cloudKitDatabase: .none
+    )
+    container = try ModelContainer(for: schema, configurations: configuration)
+    context = ModelContext(container)
+    heuristicsStore = HeuristicsStore()
+  }
+
+  func run(command: CLICommand) throws -> CLIResponse {
+    switch command {
+    case .capturesList(let query):
+      return .success(data: .captures(fetchCaptures(matching: query).map(CaptureDTO.init)))
+    case .captureCreate(let input):
+      return try CLICaptureCreator(options: options, context: context).create(input: input)
+    case .captureUpdate(let input):
+      return try CLICaptureLifecycle(options: options, context: context).update(input: input)
+    case .captureDelete(let id):
+      return try CLICaptureLifecycle(options: options, context: context).delete(id: id)
+    case .captureMarkPosted(let id, let url):
+      return try CLICaptureLifecycle(options: options, context: context).markPosted(
+        id: id, url: url)
+    case .captureMarkQueued(let id):
+      return try CLICaptureLifecycle(options: options, context: context).markQueued(id: id)
+    case .projectsList(let query):
+      return .success(data: .projects(fetchProjects(matching: query).map(ProjectDTO.init)))
+    case .projectCreate(let name):
+      return try createProject(name: name)
+    case .subredditsList(let query):
+      let subreddits = fetchSubreddits(matching: query).map {
+        SubredditDTO($0, peakInfo: heuristicsStore.peakInfo(for: $0))
+      }
+      return .success(data: .subreddits(subreddits))
+    case .subredditAdd(let name):
+      return try addSubreddit(name: name)
+    case .peaksPresets:
+      return .success(data: .peakPresets(SubredditPeakSelection.presets.map(PeakPresetDTO.init)))
+    case .peaksGet(let subreddit):
+      return try peakInfo(for: subreddit)
+    case .peaksSet(let subreddit, let days, let hours, let timeZone):
+      return try setPeakInfo(for: subreddit, days: days, hours: hours, timeZone: timeZone)
+    case .peaksReset(let subreddit):
+      return try resetPeakInfo(for: subreddit)
+    }
+  }
+
+  private func fetchCaptures(matching query: String?) -> [Capture] {
+    let descriptor = FetchDescriptor<Capture>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+    )
+    let captures = (try? context.fetch(descriptor)) ?? []
+    return filter(captures, query: query) { capture in
+      [
+        capture.id.uuidString,
+        capture.title ?? "",
+        capture.text,
+        capture.notes ?? "",
+        capture.project?.name ?? "",
+        capture.subreddits.map(\.name).joined(separator: " "),
+      ].joined(separator: " ")
+    }
+  }
+
+  private func fetchProjects(matching query: String?) -> [Project] {
+    let descriptor = FetchDescriptor<Project>(sortBy: [SortDescriptor(\.name)])
+    return filter((try? context.fetch(descriptor)) ?? [], query: query) { project in
+      [project.id.uuidString, project.name, project.projectDescription ?? ""].joined(separator: " ")
+    }
+  }
+
+  private func fetchSubreddits(matching query: String?) -> [Subreddit] {
+    let descriptor = FetchDescriptor<Subreddit>(sortBy: [SortDescriptor(\.sortOrder)])
+    return filter((try? context.fetch(descriptor)) ?? [], query: query) { subreddit in
+      [subreddit.id.uuidString, subreddit.name, subreddit.postingChecklist ?? ""].joined(
+        separator: " ")
+    }
+  }
+
+  private func filter<T>(_ items: [T], query: String?, searchableText: (T) -> String) -> [T] {
+    guard let normalized = query?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+      !normalized.isEmpty
+    else { return items }
+    return items.filter { searchableText($0).lowercased().contains(normalized) }
+  }
+
+  private func createProject(name: String) throws -> CLIResponse {
+    let projects = fetchProjects(matching: nil)
+    guard let trimmed = ProjectPersistenceActions.normalizedName(name) else {
+      throw CLIError.validation("Project name cannot be empty.")
+    }
+    guard ProjectPersistenceActions.isNameAvailable(trimmed, projects: projects) else {
+      throw CLIError.validation("Project already exists: \(trimmed)")
+    }
+    if options.dryRun {
+      return .success(data: .dryRun("Would create project \(trimmed)."))
+    }
+    let project = Project(name: trimmed)
+    context.insert(project)
+    try context.save()
+    return .success(data: .project(ProjectDTO(project)))
+  }
+
+  private func addSubreddit(name input: String) throws -> CLIResponse {
+    let subreddits = fetchSubreddits(matching: nil)
+    let normalized = SubredditName.normalize(input)
+    guard case .success(let name) = normalized else {
+      if case .failure(let error) = normalized { throw CLIError.validation(error.message) }
+      throw CLIError.validation(SubredditName.ValidationError.empty.message)
+    }
+    guard !subreddits.contains(where: { $0.name.caseInsensitiveCompare(name) == .orderedSame })
+    else {
+      throw CLIError.validation(SubredditName.ValidationError.duplicate.message)
+    }
+    if options.dryRun {
+      return .success(data: .dryRun("Would add subreddit \(name)."))
+    }
+    let nextOrder = (subreddits.map(\.sortOrder).max() ?? -1) + 1
+    let subreddit = Subreddit(name: name, sortOrder: nextOrder)
+    context.insert(subreddit)
+    try context.save()
+    try heuristicsStore.syncGeneratedEvents(
+      for: subreddit,
+      context: context,
+      defaultLeadTimeMinutes: defaultLeadTimeMinutes
+    )
+    return .success(
+      data: .subreddit(SubredditDTO(subreddit, peakInfo: heuristicsStore.peakInfo(for: subreddit))))
+  }
+
+  private func peakInfo(for input: String) throws -> CLIResponse {
+    let subreddit = try findSubreddit(input)
+    return .success(
+      data: .peakInfo(
+        PeakInfoDTO(subreddit: subreddit, peakInfo: heuristicsStore.peakInfo(for: subreddit))))
+  }
+
+  private func setPeakInfo(
+    for input: String,
+    days: [String],
+    hours: [Int],
+    timeZone identifier: String?
+  ) throws -> CLIResponse {
+    let subreddit = try findSubreddit(input)
+    let validDays = Set(SubredditPeakSelection.dayKeys)
+    guard !days.isEmpty, days.allSatisfy({ validDays.contains($0) }) else {
+      throw CLIError.validation("Days must use mon,tue,wed,thu,fri,sat,sun.")
+    }
+    guard !hours.isEmpty else { throw CLIError.validation("At least one hour is required.") }
+
+    let timeZone = identifier.flatMap(TimeZone.init(identifier:)) ?? .current
+    if identifier != nil, TimeZone(identifier: identifier!) == nil {
+      throw CLIError.validation("Unknown timezone: \(identifier!)")
+    }
+    let appliedHours = hours.map { SubredditPeakSelection.localHourToUtc($0, timeZone: timeZone) }
+      .sorted()
+    if options.dryRun {
+      return .success(
+        data: .dryRun(
+          "Would set \(subreddit.name) peak days \(days.joined(separator: ",")) and local hours \(hours.map(String.init).joined(separator: ","))."
+        ))
+    }
+
+    subreddit.peakDaysOverride = days
+    subreddit.peakHoursUtcOverride = appliedHours
+    try heuristicsStore.syncGeneratedEvents(
+      for: subreddit,
+      context: context,
+      defaultLeadTimeMinutes: defaultLeadTimeMinutes
+    )
+    try context.save()
+    return .success(
+      data: .peakInfo(
+        PeakInfoDTO(subreddit: subreddit, peakInfo: heuristicsStore.peakInfo(for: subreddit))))
+  }
+
+  private func resetPeakInfo(for input: String) throws -> CLIResponse {
+    let subreddit = try findSubreddit(input)
+    if options.dryRun {
+      return .success(data: .dryRun("Would reset peak overrides for \(subreddit.name)."))
+    }
+    subreddit.peakDaysOverride = nil
+    subreddit.peakHoursUtcOverride = nil
+    try heuristicsStore.syncGeneratedEvents(
+      for: subreddit,
+      context: context,
+      defaultLeadTimeMinutes: defaultLeadTimeMinutes
+    )
+    try context.save()
+    return .success(
+      data: .peakInfo(
+        PeakInfoDTO(subreddit: subreddit, peakInfo: heuristicsStore.peakInfo(for: subreddit))))
+  }
+
+  private func findSubreddit(_ input: String) throws -> Subreddit {
+    let normalized = SubredditName.normalizedName(input) ?? input
+    let subreddits = fetchSubreddits(matching: nil)
+    if let subreddit = subreddits.first(where: {
+      $0.id.uuidString == input || $0.name.caseInsensitiveCompare(normalized) == .orderedSame
+    }) {
+      return subreddit
+    }
+    throw CLIError.notFound("Subreddit not found: \(input)")
+  }
+
+  private var defaultLeadTimeMinutes: Int {
+    UserDefaults.standard.object(forKey: SettingsKey.defaultLeadTimeMinutes) as? Int ?? 60
+  }
+}
+
+enum CLIStore {
+  static func storeURL(from path: String?) -> URL {
+    if let path, !path.isEmpty {
+      return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+    }
+    return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("default.store")
+  }
+
+  static func mediaRootURL(from path: String?) -> URL? {
+    guard let path, !path.isEmpty else { return nil }
+    return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+      .deletingLastPathComponent()
+      .appendingPathComponent("media")
+  }
+}

--- a/CLI/Sources/RedditReminderCLI.swift
+++ b/CLI/Sources/RedditReminderCLI.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@main
+struct RedditReminderCLI {
+  static func main() async {
+    do {
+      let arguments = Array(CommandLine.arguments.dropFirst())
+      let invocation = try CLIInvocation(arguments: arguments)
+      let runner = try CLIRunner(options: invocation.options)
+      let response = try runner.run(command: invocation.command)
+      CLIPrinter.print(response, options: invocation.options)
+    } catch let error as CLIError {
+      CLIPrinter.printError(error)
+      Foundation.exit(Int32(error.exitCode))
+    } catch {
+      CLIPrinter.printError(.runtime(error.localizedDescription))
+      Foundation.exit(1)
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-.PHONY: build build-debug test ui-test install install-debug clean generate qa
+.PHONY: build build-debug build-cli test cli-test ui-test install install-debug install-cli clean generate qa
 
 APP_NAME := RedditReminder
+CLI_NAME := redditreminder
 PROJ := $(APP_NAME).xcodeproj
 BUILD_DIR := build
 INSTALL_DIR := $(HOME)/Applications
+BIN_DIR := $(HOME)/bin
 LABEL := com.neonwatty.$(APP_NAME)
 
 # Copy the built .app into INSTALL_DIR.  $(1) = configuration name (Release | Debug)
@@ -34,6 +36,18 @@ build-debug: generate
 	  ENABLE_HARDENED_RUNTIME=NO \
 	  OTHER_CODE_SIGN_FLAGS=
 
+build-cli: generate
+	xcodebuild build \
+	  -project $(PROJ) -scheme $(APP_NAME)CLI \
+	  -configuration Debug -destination 'platform=macOS' \
+	  -derivedDataPath $(BUILD_DIR) \
+	  CODE_SIGN_IDENTITY=- \
+	  CODE_SIGN_STYLE=Manual \
+	  DEVELOPMENT_TEAM= \
+	  ENABLE_DEBUG_DYLIB=NO \
+	  ENABLE_HARDENED_RUNTIME=NO \
+	  OTHER_CODE_SIGN_FLAGS=
+
 test: generate
 	xcodebuild test \
 	  -project $(PROJ) -scheme $(APP_NAME) \
@@ -45,6 +59,9 @@ test: generate
 	  ENABLE_DEBUG_DYLIB=NO \
 	  ENABLE_HARDENED_RUNTIME=NO \
 	  OTHER_CODE_SIGN_FLAGS=
+
+cli-test: build-cli
+	./scripts/cli-smoke.sh "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
 
 ui-test: generate
 	xcodebuild test \
@@ -69,6 +86,12 @@ install: build
 
 install-debug: build-debug
 	$(call copy_app,Debug)
+
+install-cli: build-cli
+	mkdir -p $(BIN_DIR)
+	cp $(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME) $(BIN_DIR)/$(CLI_NAME)
+	mkdir -p $(BIN_DIR)/RedditReminderResources
+	cp Resources/peak-times.json $(BIN_DIR)/RedditReminderResources/peak-times.json
 
 qa: install-debug
 	./scripts/qa.sh

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -12,11 +12,13 @@
 		03D259AE4EF62D35955D2D09 /* PopoverCaptureFiltering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C930E623DE20A82D94D4B3A /* PopoverCaptureFiltering.swift */; };
 		03D6222BEC9F6525C2727326 /* SubredditNameValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C81EDF4BBBB49EC3DEDA20 /* SubredditNameValidationTests.swift */; };
 		041E25F2F96423AFDC87DC12 /* RRuleHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7E48EB48E8F199029DC134 /* RRuleHelperTests.swift */; };
+		07D9528B85B628997362E899 /* TimingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */; };
 		090F9D3B18C2B5C92FB9F5B7 /* EdgeCaseTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */; };
 		0A9365CFB7B1AB4C02CF61DB /* SubredditPeakSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */; };
 		0C53C021246A49333D8F111B /* NotificationSchedulerPermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C5DAE3A8EB7A0149E897CD /* NotificationSchedulerPermissionTests.swift */; };
 		0CA7BC0B1883C66A529F0E2A /* GeneralTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8FB1218EE842B7D518F5F /* GeneralTabView.swift */; };
 		0D450A66EF492AF4779AD92B /* PostHandoffViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB15AEFC17C70DC66CA4A05 /* PostHandoffViewHelpers.swift */; };
+		0E4254D9D56527BF0CD58E16 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1122ADEB6045619C303C31 /* MediaStore.swift */; };
 		0F535262B2F03B867CDD5510 /* BackupMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9884E228CA7B8C32C3669A85 /* BackupMappers.swift */; };
 		0FED0DF0846890CB2DEE1F53 /* PostHandoffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303FB325A99764563E4FB2AC /* PostHandoffView.swift */; };
 		1014F4F2B82E8F900DAB9773 /* CaptureHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDA0450B3C93FB0CCB13A7 /* CaptureHelpersTests.swift */; };
@@ -24,6 +26,7 @@
 		1228389EE01C83EF49C3DEC8 /* AppRefreshAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979105135C8B3C67FC080326 /* AppRefreshAction.swift */; };
 		12B7E4C8F9AB781325FFC21F /* ProjectPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */; };
 		130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */; };
+		1690FE987E73EE0BB803779E /* CLICaptureLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
 		1775ADA388C6665458778DFD /* CaptureCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66BD5ED9BDB2CAF49B0A3B2 /* CaptureCardView.swift */; };
 		19F277D9FFDA1E43A857A149 /* SubredditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */; };
@@ -33,6 +36,7 @@
 		1FB2F2B5269BA2F36BF13259 /* TimingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */; };
 		2214090DA72A5B5AF58F6658 /* SubredditPeakTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93DE0D59B5DCB48FAA132EE /* SubredditPeakTimeTests.swift */; };
 		22F3520B3E768FD763F7A7D6 /* BackupMediaPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCEE0DEE2D8B351D6357E71 /* BackupMediaPayloads.swift */; };
+		24CE13CB130735741A139E6C /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
 		24F1E695ED63B7FB413361C5 /* TimingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727389070814347602E1AB3 /* TimingEngineTests.swift */; };
 		26A62F837CC395740AA9FB84 /* BackupSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD83B39B1CC5EC5FA398914C /* BackupSectionView.swift */; };
 		2957BBD6DAAF914CD3A0E08A /* BackupTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1041614D1D7B295800149206 /* BackupTestSupport.swift */; };
@@ -58,15 +62,19 @@
 		4571169CFBCD9757344904F2 /* PopoverContentRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416AAA3BB8DC7EFE8E6CB262 /* PopoverContentRoutes.swift */; };
 		458FB5824747FA87A87E8ACE /* CaptureMediaSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB705DF53B8D53CEFCD441D /* CaptureMediaSection.swift */; };
 		474176ACD33799B0C433D8C5 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A523CACB82BF88E46FD3E /* MenuBarController.swift */; };
+		48C23ABB8C2E8909DEF63032 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
+		48F5EEEDFD55C5C8295C130B /* peak-times.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BDDF7799BF55CF7FFC730BA /* peak-times.json */; };
 		4907C5B4B92A0039716F0727 /* SubredditCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A20FE04DD7075E02C7092 /* SubredditCRUDTests.swift */; };
 		4A0EC0BB9F82C06D8CED3928 /* TimingEngineTimezoneEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4871F815198EF14E6C1B2C22 /* TimingEngineTimezoneEdgeCaseTests.swift */; };
 		4C87F6917C877808862C53EE /* TimingEngineWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF54D62FF6A1D2DE6F157E60 /* TimingEngineWindowTests.swift */; };
 		4CCDBAA2B4BC2B3BB97CF38E /* RedditReminderSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EFC2837CE8B91A22B6A64D /* RedditReminderSmokeUITests.swift */; };
 		4D3F5B8B0063D3B9C1242D33 /* BackupTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72682A4379AE1A17B7D4559 /* BackupTypes.swift */; };
 		4D52E2A23BEE6747615CD993 /* SubredditRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCEA3C12E0C9865DA5A4656 /* SubredditRow.swift */; };
+		4D9DB70FE0646BD1F3E572A1 /* CapturePersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E440DAF06A5F755B0CFD41F7 /* CapturePersistenceActions.swift */; };
 		4E5E03721C36CF2033FB15BF /* CaptureWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975C23592B958F445105973E /* CaptureWindowView.swift */; };
 		4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599273192FBCFDD93D1241B0 /* Project.swift */; };
 		4F2AF8896DC44D8074BECAA5 /* TimingEngineRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA4ACEAB2D47066769A2A44 /* TimingEngineRefreshTests.swift */; };
+		4F2E26C8658C89145AA9F2DB /* ProjectPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */; };
 		53392764834D103A10C75C92 /* SubredditInputValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9810B901F7241E88A6D898 /* SubredditInputValidation.swift */; };
 		5417A38681E20BA30C06CD26 /* SettingsOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275F5DE20B1832CEA53FF535 /* SettingsOptionsTests.swift */; };
 		54CBDE5AFC27C95AF4C406DC /* DefaultSubredditsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4758BE68EE85AA3FA2EA4DC4 /* DefaultSubredditsTests.swift */; };
@@ -74,6 +82,7 @@
 		5631C865F36CC064CD9AF7A2 /* HeuristicsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */; };
 		57083A356FED5FCFCDCCB3BE /* RRuleEdgeCaseTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128860C77D6625EB89D5DFFF /* RRuleEdgeCaseTestSupport.swift */; };
 		57454FB537536D907117B756 /* RRuleOccurrenceEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6B2B1A559FEFF67B391F /* RRuleOccurrenceEdgeCaseTests.swift */; };
+		57B9C5EC4885B1A711755BCF /* CLIInvocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F701778EF6152A8C9E643D1 /* CLIInvocation.swift */; };
 		5861D63301E7DC2539BF8BCD /* CaptureMediaChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3C4FF9EDB23763DEF6DCBD /* CaptureMediaChips.swift */; };
 		59D5CBD905672F86F0295673 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1122ADEB6045619C303C31 /* MediaStore.swift */; };
 		5A2B495DD4D68A03E298A1BE /* QAFixturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25CB54C32FE0925CD459588 /* QAFixturesTests.swift */; };
@@ -82,32 +91,39 @@
 		5C0D0E781F591772712EFB08 /* SubredditRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */; };
 		5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */; };
 		5E9E214B7FD7706B64F703BA /* PlannerTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3788B79517572C51854172CC /* PlannerTabView.swift */; };
+		5EC386BDC953ADC9C0C7FC1A /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */; };
 		5F6AEF6B669D52EA62900F1A /* PopoverTimingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319AF7913AB415361A12500A /* PopoverTimingPresentationTests.swift */; };
 		61A0CF870F46A9CA5D4D825B /* CaptureCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02E746452EDD7B17443C493 /* CaptureCRUDTests.swift */; };
 		62761A56A55BD30D9D7FC87E /* PostingChecklistItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23399264919E264763449E07 /* PostingChecklistItems.swift */; };
 		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		637776DD2C3FE925B0CC3036 /* CaptureCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7D03EF7FAD1B0CBDC0A59 /* CaptureCardViewTests.swift */; };
+		653447F7059B945ECF9657B2 /* CLIRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
+		6589D2CB4C0EE68009254627 /* RedditReminderCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BD88A85812A32DB0D0EF9E /* RedditReminderCLI.swift */; };
 		6665F0F720DA51B85DEAF841 /* ModelEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ABCB2C47C7D7B2B9D3809B /* ModelEdgeCaseTests.swift */; };
 		690C38B0C986D2C9B9F268D5 /* PopoverChromeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C4CE3383CDFF1A7E03C00D /* PopoverChromeViews.swift */; };
 		6AB79B2FD74969002DBBC316 /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DDADF6ECF30ECDD255DED4 /* ChannelsView.swift */; };
 		6CA6C655DE7A6B84021C77CE /* BackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */; };
 		6D0A4C091A8F25EA682C95AC /* RedditReminderWorkflowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCBD69B43B6F15A3A6874D22 /* RedditReminderWorkflowUITests.swift */; };
 		6D9854352FD87623F0FD290F /* PostingChecklistItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA87973FC3B43FDB7B37F8 /* PostingChecklistItemsTests.swift */; };
+		6FFC18A2523F51D19AD8D618 /* SubredditPeakSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */; };
 		70D84AA4E08C4A543B99F834 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */; };
 		714D61E3C7BED6A5FEFED970 /* CaptureMediaEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12332E0A0899E73E2C0FD6E4 /* CaptureMediaEditingTests.swift */; };
 		726A8DC23D85AA198EF079E6 /* CapturePerSubredditPostingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E6715672E45708F5B3DDD5 /* CapturePerSubredditPostingTests.swift */; };
 		73D1EA6EF5BCBC4321589A5D /* NotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9511753E51E30A7111B248 /* NotificationScheduler.swift */; };
 		73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */; };
 		75C175CE268B7C7B29D8E3F2 /* TimingEngineUrgencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C77B4031AB91C412094FA2C /* TimingEngineUrgencyTests.swift */; };
+		779E118B9F47BB248E9D0111 /* SubredditEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614C7BEB91C550AD4F452CD5 /* SubredditEvent.swift */; };
 		7AB3BE6F02539F0147F73E23 /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */; };
 		7E68CAC4BA7F5A44D4927EF8 /* CaptureLifecycleIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7253DDCFDD2A38F779E451A6 /* CaptureLifecycleIntegrationTests.swift */; };
 		8125DD9D788F57B8CA1BA791 /* MenuBarControllerMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CDE29A1F978DF7DFBC7661 /* MenuBarControllerMenus.swift */; };
 		81C26D97123D840A9130AF7E /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB4E56FCDA7A1CB1F24566D /* Constants.swift */; };
+		826BEDF1383D5F91E5199EDE /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
 		8315863469F9A314E30B6344 /* EventBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB005E503FDAD90271DB0AE /* EventBannerView.swift */; };
 		87AE17FDA4B3C169B340C8AA /* SubredditEventCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFAC40DD76013F2B88EEC64 /* SubredditEventCRUDTests.swift */; };
 		8A950262833C2D936554FEE7 /* BackupPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BE11378DD3F2E280F890D6 /* BackupPreviewTests.swift */; };
+		8BDBD62791F99A373564D5B3 /* CLIDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B81CF275655D5E1ECD5EC37 /* CLIDTOs.swift */; };
 		8BFB4386A5522097EAA5B7AC /* AppDelegateShortcutRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D483D5534D2A0BC4C03BC77B /* AppDelegateShortcutRegistrationTests.swift */; };
 		8DBE4AF4BC0B7AEBB360C5F5 /* ShortcutRecorderInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9D18BDF63A57734A4A6C7A /* ShortcutRecorderInput.swift */; };
 		9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */; };
@@ -127,13 +143,17 @@
 		B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28906380DECDA56AD0DDE325 /* PreferencesView.swift */; };
 		B67A7C5D3004AC648F3BE6C9 /* AppDelegateQA.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89CCDB745C6D3B557E3342A /* AppDelegateQA.swift */; };
 		B78555115700D912FE912EAE /* CaptureMediaSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288C13F7511FB37215593E12 /* CaptureMediaSelection.swift */; };
+		BA3588948937708CD83AFEBC /* CLIOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14A6B7A047D5672F9159659 /* CLIOutput.swift */; };
 		BA3B263D9D03FA844568F913 /* EventSourceSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */; };
 		BEE74F03864389AD3A108EFE /* BackupSettingsPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61052DF5F8EFC70EA9076106 /* BackupSettingsPersistence.swift */; };
 		C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */; };
 		CC6A10A2CEA907B520EEE2F3 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */; };
 		CCE3B3D5EE4B39D55222CA19 /* ResourcePackagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A9BB4582DA895A6C18C321 /* ResourcePackagingTests.swift */; };
 		CE614FCDDCCDE1DA0C484E58 /* CaptureMediaSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B642ED62D86AC09680939A1 /* CaptureMediaSelectionTests.swift */; };
+		CFDA6CE34A7768D4CF33D759 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		D4C25F69F19FB5F035561B86 /* CaptureMediaAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256FB5A83C11819FC96533BA /* CaptureMediaAccessibility.swift */; };
+		D70537E281AB16807DE1E2FA /* CLICaptureCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */; };
+		D8C594251D6110586CEC8152 /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		DA2B270CDFA18C60E33E913B /* KeyboardShortcutConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793582517DF597A0F96E2072 /* KeyboardShortcutConfig.swift */; };
 		DF5BC4B40F68E4D77656AD97 /* ShortcutRecorderInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECD53B7CA29C3F004D13EBB /* ShortcutRecorderInputTests.swift */; };
 		DF685B7594B2CB10A5A81F3B /* PopoverChromeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5570C2EF1DD747B43C6F4ED /* PopoverChromeViewTests.swift */; };
@@ -142,6 +162,7 @@
 		E91A5DDE67643B2D081C9340 /* PopoverCaptureFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEA78C5D7E701E78352BF98 /* PopoverCaptureFilteringTests.swift */; };
 		E9EDB8A89099DE463C304AA7 /* AppRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */; };
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
+		EA9B4D6D73A9BE87850EB6B1 /* AppRefreshAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979105135C8B3C67FC080326 /* AppRefreshAction.swift */; };
 		EB5423C577C49336A436A8D9 /* EventBannerPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B74D94BD1D9656DC58B93F8 /* EventBannerPresentationTests.swift */; };
 		ED21B7051250C90DD162186E /* AppDelegateShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94E8BF8DAD4FB3EAEB7B9D2 /* AppDelegateShortcuts.swift */; };
 		EE2531711B88442E10595188 /* BackupRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5405DCCD365B6CCD48CAAD0D /* BackupRoundTripTests.swift */; };
@@ -151,6 +172,7 @@
 		F3CF29763AE56B1639138AA1 /* Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE4E14F7A70E1A66FA994A3 /* Capture.swift */; };
 		F4DE010F9076D36DD9D98288 /* AppModelContainerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4925806B8E7919B5E93D38D /* AppModelContainerFactory.swift */; };
 		F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */; };
+		F9153795ADCFF105BE3F348A /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599273192FBCFDD93D1241B0 /* Project.swift */; };
 		FBD66F35A1175B467D83C4B6 /* PreferencesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C958510062F2EAA969645F8 /* PreferencesViewTests.swift */; };
 		FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
 		FF322C47FE562D97B67F090E /* peak-times.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BDDF7799BF55CF7FFC730BA /* peak-times.json */; };
@@ -211,6 +233,7 @@
 		3788B79517572C51854172CC /* PlannerTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerTabView.swift; sourceTree = "<group>"; };
 		37AEC6DD3FA5A8034E07E6B9 /* NotificationSettingsOpenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsOpenerTests.swift; sourceTree = "<group>"; };
 		3878A1D04F7AC0E3D464CB7B /* CaptureLinksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksTests.swift; sourceTree = "<group>"; };
+		3B81CF275655D5E1ECD5EC37 /* CLIDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDTOs.swift; sourceTree = "<group>"; };
 		3BDDF7799BF55CF7FFC730BA /* peak-times.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "peak-times.json"; sourceTree = "<group>"; };
 		3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupImportValidationTests.swift; sourceTree = "<group>"; };
 		3D5124BE8F9D4637788D2557 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
@@ -229,9 +252,11 @@
 		4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubreddits.swift; sourceTree = "<group>"; };
 		4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLinksSection.swift; sourceTree = "<group>"; };
 		4F6BE81712D79E2725C4FC11 /* TimingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingEngine.swift; sourceTree = "<group>"; };
+		4F701778EF6152A8C9E643D1 /* CLIInvocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIInvocation.swift; sourceTree = "<group>"; };
 		52127801DAED9C14B36BEE2B /* AppDelegateNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateNotifications.swift; sourceTree = "<group>"; };
 		5405DCCD365B6CCD48CAAD0D /* BackupRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupRoundTripTests.swift; sourceTree = "<group>"; };
 		542C6F359C57A7214CC4B448 /* SubredditPersistenceActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActions.swift; sourceTree = "<group>"; };
+		54BD88A85812A32DB0D0EF9E /* RedditReminderCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderCLI.swift; sourceTree = "<group>"; };
 		560C97A16044A98AB4D11D63 /* HeuristicsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeuristicsStoreTests.swift; sourceTree = "<group>"; };
 		56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts.swift; sourceTree = "<group>"; };
 		599273192FBCFDD93D1241B0 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
@@ -253,6 +278,7 @@
 		70C20E318FF03A914D88CB08 /* SubredditPeakSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPeakSelection.swift; sourceTree = "<group>"; };
 		7253DDCFDD2A38F779E451A6 /* CaptureLifecycleIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureLifecycleIntegrationTests.swift; sourceTree = "<group>"; };
 		726D903A97B808C6ED572BCA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICaptureLifecycle.swift; sourceTree = "<group>"; };
 		75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActionsTests.swift; sourceTree = "<group>"; };
 		75FA87973FC3B43FDB7B37F8 /* PostingChecklistItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingChecklistItemsTests.swift; sourceTree = "<group>"; };
 		787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderApp.swift; sourceTree = "<group>"; };
@@ -274,7 +300,9 @@
 		90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		975C23592B958F445105973E /* CaptureWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureWindowView.swift; sourceTree = "<group>"; };
 		979105135C8B3C67FC080326 /* AppRefreshAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRefreshAction.swift; sourceTree = "<group>"; };
+		97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRunner.swift; sourceTree = "<group>"; };
 		9884E228CA7B8C32C3669A85 /* BackupMappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMappers.swift; sourceTree = "<group>"; };
+		9E2C8DBB12B2100D9B15CCA0 /* RedditReminderCLI */ = {isa = PBXFileReference; includeInIndex = 0; path = RedditReminderCLI; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FA306067C4690F4D1CDAC2D /* Subreddit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subreddit.swift; sourceTree = "<group>"; };
 		9FB2E1C9A8D9A636C13EEA0C /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		A25CB54C32FE0925CD459588 /* QAFixturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAFixturesTests.swift; sourceTree = "<group>"; };
@@ -287,7 +315,9 @@
 		AD3C4FF9EDB23763DEF6DCBD /* CaptureMediaChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaChips.swift; sourceTree = "<group>"; };
 		AE1122ADEB6045619C303C31 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		AEE4E14F7A70E1A66FA994A3 /* Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture.swift; sourceTree = "<group>"; };
+		B14A6B7A047D5672F9159659 /* CLIOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOutput.swift; sourceTree = "<group>"; };
 		B1ABCB2C47C7D7B2B9D3809B /* ModelEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelEdgeCaseTests.swift; sourceTree = "<group>"; };
+		B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICaptureCreator.swift; sourceTree = "<group>"; };
 		B31CB6F345C1C2B72D954744 /* SubredditPeakSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPeakSelectionTests.swift; sourceTree = "<group>"; };
 		B338E8D9C979B250564A392E /* QAFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAFixtures.swift; sourceTree = "<group>"; };
 		B3C81EDF4BBBB49EC3DEDA20 /* SubredditNameValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditNameValidationTests.swift; sourceTree = "<group>"; };
@@ -452,6 +482,7 @@
 			isa = PBXGroup;
 			children = (
 				8F3630C63EE6A3A37D6E680B /* RedditReminder.app */,
+				9E2C8DBB12B2100D9B15CCA0 /* RedditReminderCLI */,
 				317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */,
 				DFF5D9C0E578E3A6273498E5 /* RedditReminderUITests.xctest */,
 			);
@@ -466,6 +497,20 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		6BD3E7EA3F7D02FA08CCC4C4 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */,
+				736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */,
+				3B81CF275655D5E1ECD5EC37 /* CLIDTOs.swift */,
+				4F701778EF6152A8C9E643D1 /* CLIInvocation.swift */,
+				B14A6B7A047D5672F9159659 /* CLIOutput.swift */,
+				97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */,
+				54BD88A85812A32DB0D0EF9E /* RedditReminderCLI.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		6F246EB2C15CE105D1068035 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -473,6 +518,14 @@
 				BC5638C6E3613905E02C4A7D /* RedditReminderUITests */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		73DF67DE84F71C1590D78B16 /* CLI */ = {
+			isa = PBXGroup;
+			children = (
+				6BD3E7EA3F7D02FA08CCC4C4 /* Sources */,
+			);
+			path = CLI;
 			sourceTree = "<group>";
 		};
 		BC5638C6E3613905E02C4A7D /* RedditReminderUITests */ = {
@@ -518,6 +571,7 @@
 		D3AF18859D0921DDF93FE64A = {
 			isa = PBXGroup;
 			children = (
+				73DF67DE84F71C1590D78B16 /* CLI */,
 				5116BAE79334CDDDA82241EC /* Resources */,
 				146831ADD0F602608D8F9BEA /* Sources */,
 				6F246EB2C15CE105D1068035 /* Tests */,
@@ -579,6 +633,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1BB2C9A406AAAAA0CAB3D538 /* RedditReminderCLI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F82328B229963BCEE7D80C8C /* Build configuration list for PBXNativeTarget "RedditReminderCLI" */;
+			buildPhases = (
+				1AF9F8A5C67B8D224CB1CB50 /* Sources */,
+				4A3C2375BECF7D8AAC3A6F93 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RedditReminderCLI;
+			packageProductDependencies = (
+			);
+			productName = RedditReminderCLI;
+			productReference = 9E2C8DBB12B2100D9B15CCA0 /* RedditReminderCLI */;
+			productType = "com.apple.product-type.tool";
+		};
 		2DE905B343BA95604DD1F3C9 /* RedditReminder */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4B62538EF381EE6A6507E4AB /* Build configuration list for PBXNativeTarget "RedditReminder" */;
@@ -642,6 +714,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					1BB2C9A406AAAAA0CAB3D538 = {
+						DevelopmentTeam = B3A6AN2HA4;
+						ProvisioningStyle = Automatic;
+					};
 					2DE905B343BA95604DD1F3C9 = {
 						DevelopmentTeam = B3A6AN2HA4;
 						ProvisioningStyle = Automatic;
@@ -672,6 +748,7 @@
 			projectRoot = "";
 			targets = (
 				2DE905B343BA95604DD1F3C9 /* RedditReminder */,
+				1BB2C9A406AAAAA0CAB3D538 /* RedditReminderCLI */,
 				C2D6AA8E625EF0CD6E6BF408 /* RedditReminderTests */,
 				A990D0C6BF3F1C6102E5820C /* RedditReminderUITests */,
 			);
@@ -679,6 +756,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4A3C2375BECF7D8AAC3A6F93 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48F5EEEDFD55C5C8295C130B /* peak-times.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E75953293745AAA4FBCF1096 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -696,6 +781,34 @@
 			files = (
 				4CCDBAA2B4BC2B3BB97CF38E /* RedditReminderSmokeUITests.swift in Sources */,
 				6D0A4C091A8F25EA682C95AC /* RedditReminderWorkflowUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1AF9F8A5C67B8D224CB1CB50 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA9B4D6D73A9BE87850EB6B1 /* AppRefreshAction.swift in Sources */,
+				D70537E281AB16807DE1E2FA /* CLICaptureCreator.swift in Sources */,
+				1690FE987E73EE0BB803779E /* CLICaptureLifecycle.swift in Sources */,
+				8BDBD62791F99A373564D5B3 /* CLIDTOs.swift in Sources */,
+				57B9C5EC4885B1A711755BCF /* CLIInvocation.swift in Sources */,
+				BA3588948937708CD83AFEBC /* CLIOutput.swift in Sources */,
+				653447F7059B945ECF9657B2 /* CLIRunner.swift in Sources */,
+				826BEDF1383D5F91E5199EDE /* Capture.swift in Sources */,
+				D8C594251D6110586CEC8152 /* CaptureFormResult.swift in Sources */,
+				4D9DB70FE0646BD1F3E572A1 /* CapturePersistenceActions.swift in Sources */,
+				48C23ABB8C2E8909DEF63032 /* Constants.swift in Sources */,
+				CFDA6CE34A7768D4CF33D759 /* HeuristicsStore.swift in Sources */,
+				0E4254D9D56527BF0CD58E16 /* MediaStore.swift in Sources */,
+				F9153795ADCFF105BE3F348A /* Project.swift in Sources */,
+				4F2E26C8658C89145AA9F2DB /* ProjectPersistenceActions.swift in Sources */,
+				24CE13CB130735741A139E6C /* RRuleHelper.swift in Sources */,
+				6589D2CB4C0EE68009254627 /* RedditReminderCLI.swift in Sources */,
+				5EC386BDC953ADC9C0C7FC1A /* Subreddit.swift in Sources */,
+				779E118B9F47BB248E9D0111 /* SubredditEvent.swift in Sources */,
+				6FFC18A2523F51D19AD8D618 /* SubredditPeakSelection.swift in Sources */,
+				07D9528B85B628997362E899 /* TimingEngine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -874,6 +987,21 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		09CA9A093A9D5205C9E0483F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.neonwatty.RedditReminderCLI;
+				PRODUCT_MODULE_NAME = RedditReminderCLI;
+				PRODUCT_NAME = redditreminder;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		7C2ECEEA56BD3DB349004439 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -888,6 +1016,21 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.neonwatty.RedditReminderUITests;
 				SDKROOT = macosx;
 				TEST_TARGET_NAME = RedditReminder;
+			};
+			name = Debug;
+		};
+		833F6F7328FE6C1BACAF0F3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.neonwatty.RedditReminderCLI;
+				PRODUCT_MODULE_NAME = RedditReminderCLI;
+				PRODUCT_NAME = redditreminder;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -1144,6 +1287,15 @@
 			buildConfigurations = (
 				7C2ECEEA56BD3DB349004439 /* Debug */,
 				943C10974B51C2E1536CBFFA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F82328B229963BCEE7D80C8C /* Build configuration list for PBXNativeTarget "RedditReminderCLI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				833F6F7328FE6C1BACAF0F3A /* Debug */,
+				09CA9A093A9D5205C9E0483F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/RedditReminder.xcodeproj/xcshareddata/xcschemes/RedditReminderCLI.xcscheme
+++ b/RedditReminder.xcodeproj/xcshareddata/xcschemes/RedditReminderCLI.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1BB2C9A406AAAAA0CAB3D538"
+               BuildableName = "RedditReminderCLI"
+               BlueprintName = "RedditReminderCLI"
+               ReferencedContainer = "container:RedditReminder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BB2C9A406AAAAA0CAB3D538"
+            BuildableName = "RedditReminderCLI"
+            BlueprintName = "RedditReminderCLI"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BB2C9A406AAAAA0CAB3D538"
+            BuildableName = "RedditReminderCLI"
+            BlueprintName = "RedditReminderCLI"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1BB2C9A406AAAAA0CAB3D538"
+            BuildableName = "RedditReminderCLI"
+            BlueprintName = "RedditReminderCLI"
+            ReferencedContainer = "container:RedditReminder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/Services/HeuristicsStore.swift
+++ b/Sources/Services/HeuristicsStore.swift
@@ -123,7 +123,9 @@ final class HeuristicsStore {
   }
 
   private func loadBundled(from bundle: Bundle) {
-    guard let url = bundle.url(forResource: "peak-times", withExtension: "json") else {
+    guard let url = bundle.url(forResource: "peak-times", withExtension: "json")
+      ?? Self.fallbackPeakTimesURL()
+    else {
       if logsMissingResource {
         NSLog("RedditReminder: peak-times.json not found in bundle")
       }
@@ -150,6 +152,19 @@ final class HeuristicsStore {
         bundled[sub] = PeakInfo(peakDays: days, peakHoursUtc: hours)
       }
     }
+  }
+
+  private static func fallbackPeakTimesURL() -> URL? {
+    let fileManager = FileManager.default
+    let currentDirectory = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+    let executableDirectory = URL(fileURLWithPath: CommandLine.arguments.first ?? "")
+      .deletingLastPathComponent()
+    let candidates = [
+      currentDirectory.appendingPathComponent("Resources/peak-times.json"),
+      executableDirectory.appendingPathComponent("Resources/peak-times.json"),
+      executableDirectory.appendingPathComponent("RedditReminderResources/peak-times.json"),
+    ]
+    return candidates.first { fileManager.fileExists(atPath: $0.path) }
   }
 
   private struct GeneratedEventSpec {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,127 @@
+# RedditReminder CLI
+
+`redditreminder` is the agent-friendly command-line interface for the menu bar app.
+It reads and writes the same SwiftData store as the app and supports JSON output for
+Codex, Claude Code, scripts, and shell pipelines.
+
+## Install
+
+```sh
+make install-cli
+```
+
+This installs:
+
+```txt
+~/bin/redditreminder
+~/bin/RedditReminderResources/peak-times.json
+```
+
+## Global Flags
+
+```sh
+--json          Emit a stable JSON response envelope.
+--pretty        Pretty-print JSON. Implies --json.
+--dry-run       Report the mutation that would happen without saving.
+--store PATH    Use a specific SwiftData store. Useful for tests.
+```
+
+JSON responses use this envelope:
+
+```json
+{
+  "ok": true,
+  "data": {},
+  "warnings": [],
+  "errors": []
+}
+```
+
+## Captures
+
+```sh
+redditreminder captures list --json
+redditreminder captures search --query "launch" --json
+redditreminder captures create --title "Launch post" --text "Post body" --project "Launch Ideas" --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z --json
+redditreminder captures update CAPTURE_ID --title "Updated title" --clear-notes --json
+redditreminder captures mark-posted CAPTURE_ID --url "https://reddit.com/r/SideProject/comments/abc" --json
+redditreminder captures mark-queued CAPTURE_ID --json
+redditreminder captures delete CAPTURE_ID --json
+```
+
+`captures create` accepts:
+
+```sh
+--title TEXT          Optional post title.
+--text TEXT           Post body. If omitted, trailing arguments become the body.
+--notes TEXT          Private notes.
+--link URL            Repeatable link value.
+--links A,B           Comma-separated links.
+--project NAME_OR_ID  Existing project name or UUID.
+--subreddit NAME      Repeatable existing subreddit name or UUID.
+--subreddits A,B      Comma-separated subreddits.
+--media PATH          Repeatable image path copied into the media store.
+--media-paths A,B     Comma-separated image paths.
+--due ISO8601         Creates one one-off posting-window event per chosen subreddit.
+```
+
+`captures update` accepts the same editable fields plus lifecycle-safe clearing flags:
+
+```sh
+--clear-title
+--clear-notes
+--clear-links
+--clear-project
+--clear-subreddits
+--remove-media REF       Repeatable stored media ref to remove.
+--remove-media-refs A,B  Comma-separated stored media refs.
+--clear-media
+```
+
+There is no separate due-date field on captures today. `--due` maps to the app's
+posting-window model by creating `SubredditEvent` rows for the selected subreddit(s).
+
+## Projects
+
+```sh
+redditreminder projects list --json
+redditreminder projects search --query "launch" --json
+redditreminder projects create "Launch Ideas" --json
+redditreminder --dry-run projects create "Launch Ideas" --json
+```
+
+## Subreddits
+
+```sh
+redditreminder subreddits list --json
+redditreminder subreddits search --query "swift" --json
+redditreminder subreddits add SideProject --json
+redditreminder subreddits add https://www.reddit.com/r/SwiftUI/comments/abc --json
+```
+
+Subreddit names are normalized the same way as the app UI. Duplicate names are
+rejected case-insensitively.
+
+## Peak Times
+
+```sh
+redditreminder peaks presets --json
+redditreminder peaks get SideProject --json
+redditreminder peaks set SideProject --days mon,wed,fri --hours 9,10,11 --json
+redditreminder peaks set SideProject --days sat,sun --hours 10,11 --timezone America/Phoenix --json
+redditreminder peaks reset SideProject --json
+```
+
+`peaks set` accepts local hours and stores UTC overrides, matching the app's peak
+time model. Generated posting-window events are resynced after set/reset.
+
+## Isolated Store Example
+
+Use `--store` to test commands without touching app data:
+
+```sh
+STORE="$(mktemp -d)/redditreminder.store"
+redditreminder --store "$STORE" --json projects create "Test Project"
+redditreminder --store "$STORE" --json subreddits add SideProject
+redditreminder --store "$STORE" --json peaks set SideProject --days mon --hours 9
+```

--- a/project.yml
+++ b/project.yml
@@ -20,6 +20,33 @@ settings:
     SWIFT_STRICT_CONCURRENCY: targeted
 
 targets:
+  RedditReminderCLI:
+    type: tool
+    platform: macOS
+    sources:
+      - path: CLI/Sources
+      - path: Sources/Models/Capture.swift
+      - path: Sources/Models/CaptureFormResult.swift
+      - path: Sources/Models/Project.swift
+      - path: Sources/Models/Subreddit.swift
+      - path: Sources/Models/SubredditEvent.swift
+      - path: Sources/Services/HeuristicsStore.swift
+      - path: Sources/Services/MediaStore.swift
+      - path: Sources/Services/TimingEngine.swift
+      - path: Sources/App/AppRefreshAction.swift
+      - path: Sources/Utilities/CapturePersistenceActions.swift
+      - path: Sources/Utilities/Constants.swift
+      - path: Sources/Utilities/ProjectPersistenceActions.swift
+      - path: Sources/Utilities/RRuleHelper.swift
+      - path: Sources/Utilities/SubredditPeakSelection.swift
+      - path: Resources/peak-times.json
+        buildPhase: resources
+    settings:
+      base:
+        PRODUCT_NAME: redditreminder
+        PRODUCT_MODULE_NAME: RedditReminderCLI
+        PRODUCT_BUNDLE_IDENTIFIER: com.neonwatty.RedditReminderCLI
+
   RedditReminder:
     type: application
     platform: macOS
@@ -67,6 +94,11 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.neonwatty.RedditReminderUITests
 
 schemes:
+  RedditReminderCLI:
+    build:
+      targets:
+        RedditReminderCLI: all
+
   RedditReminder:
     build:
       targets:

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLI="${1:-build/Build/Products/Debug/redditreminder}"
+TMP_DIR="$(mktemp -d)"
+STORE="$TMP_DIR/redditreminder-cli.store"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+run_json() {
+  "$CLI" --json --store "$STORE" "$@"
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL: $label" >&2
+    echo "Expected output to contain: $needle" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+projects_empty="$(run_json projects list)"
+assert_contains "empty projects list" "$projects_empty" '"ok":true'
+
+project_created="$(run_json projects create "Launch Ideas")"
+assert_contains "project create ok" "$project_created" '"ok":true'
+assert_contains "project create name" "$project_created" '"name":"Launch Ideas"'
+
+subreddit_created="$(run_json subreddits add SideProject)"
+assert_contains "subreddit add ok" "$subreddit_created" '"ok":true'
+assert_contains "subreddit normalized" "$subreddit_created" '"name":"r/SideProject"'
+
+if run_json subreddits add sideproject >/tmp/redditreminder-cli-duplicate.out 2>/tmp/redditreminder-cli-duplicate.err; then
+  echo "FAIL: duplicate subreddit add unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "duplicate subreddit rejected" "$(cat /tmp/redditreminder-cli-duplicate.err)" "already in your list"
+rm -f /tmp/redditreminder-cli-duplicate.out /tmp/redditreminder-cli-duplicate.err
+
+subreddit_search="$(run_json subreddits search --query side)"
+assert_contains "subreddit search" "$subreddit_search" '"name":"r/SideProject"'
+
+presets="$(run_json peaks presets)"
+assert_contains "peak presets" "$presets" '"label":"Weekday AM"'
+
+peak_set="$(run_json peaks set SideProject --days mon,wed --hours 9,10)"
+assert_contains "peak set ok" "$peak_set" '"ok":true'
+assert_contains "peak set source" "$peak_set" '"source":"override"'
+
+peak_get="$(run_json peaks get SideProject)"
+assert_contains "peak get" "$peak_get" '"source":"override"'
+
+peak_reset="$(run_json peaks reset SideProject)"
+assert_contains "peak reset" "$peak_reset" '"ok":true'
+
+IMAGE="$TMP_DIR/pixel.png"
+sips -s format png /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericApplicationIcon.icns --out "$IMAGE" >/dev/null
+
+capture_created="$(
+  run_json captures create \
+    --title "Launch post" \
+    --text "Post body" \
+    --notes "Private checklist" \
+    --link "https://example.com" \
+    --project "Launch Ideas" \
+    --subreddit SideProject \
+    --media "$IMAGE" \
+    --due "2026-05-02T18:00:00Z"
+)"
+assert_contains "capture create ok" "$capture_created" '"ok":true'
+assert_contains "capture create title" "$capture_created" '"title":"Launch post"'
+assert_contains "capture create media" "$capture_created" '"mediaRefs":["pixel.png"]'
+assert_contains "capture create due event" "$capture_created" '"oneOffDate":"2026-05-02T18:00:00Z"'
+capture_id="$(printf '%s\n' "$capture_created" | perl -0ne 'print $1 if /"capture":\{"createdAt":"[^"]+","id":"([^"]+)"/')"
+if [[ -z "$capture_id" || "$capture_id" == "$capture_created" ]]; then
+  echo "FAIL: could not parse capture id" >&2
+  echo "$capture_created" >&2
+  exit 1
+fi
+
+capture_updated="$(run_json captures update "$capture_id" --title "Updated launch post" --clear-notes --links "https://example.com/updated")"
+assert_contains "capture update ok" "$capture_updated" '"ok":true'
+assert_contains "capture update title" "$capture_updated" '"title":"Updated launch post"'
+assert_contains "capture update link" "$capture_updated" '"https://example.com/updated"'
+
+capture_posted="$(run_json captures mark-posted "$capture_id" --url "https://reddit.com/r/SideProject/comments/abc")"
+assert_contains "capture mark posted ok" "$capture_posted" '"ok":true'
+assert_contains "capture mark posted status" "$capture_posted" '"status":"posted"'
+assert_contains "capture mark posted url" "$capture_posted" '"postedURL":"https://reddit.com/r/SideProject/comments/abc"'
+
+capture_queued="$(run_json captures mark-queued "$capture_id")"
+assert_contains "capture mark queued ok" "$capture_queued" '"ok":true'
+assert_contains "capture mark queued status" "$capture_queued" '"status":"queued"'
+
+captures="$(run_json captures list)"
+assert_contains "captures list" "$captures" '"ok":true'
+assert_contains "captures list created" "$captures" '"title":"Updated launch post"'
+
+capture_deleted="$(run_json captures delete "$capture_id")"
+assert_contains "capture delete ok" "$capture_deleted" '"ok":true'
+assert_contains "capture delete id" "$capture_deleted" "\"id\":\"$capture_id\""
+
+deleted_search="$(run_json captures search --query "Updated launch post")"
+assert_contains "capture deleted search" "$deleted_search" '"data":[]'
+
+echo "CLI smoke passed"


### PR DESCRIPTION
## Summary
- Add a buildable redditreminder command-line target for agent-friendly app access.
- Support JSON/pretty output, dry-run, isolated --store paths, and install helpers.
- Expose search/list/create flows for projects and subreddits plus peak preset/get/set/reset workflows.
- Add captures create with title/text/notes/links/project/subreddits/media paths and --due one-off posting-window events.
- Add capture lifecycle commands: update, delete, mark-posted, and mark-queued.
- Document CLI usage and add an isolated smoke test covering capture media, due events, update, status changes, and delete.

## Verification
- make cli-test
- make build-debug
- ./scripts/format-check.sh
- Swift file size check across CLI and Sources: no files over 300 lines.