### PR TITLE
Add CLI agent discovery commands

### DIFF
--- a/CLI/Sources/CLIArgumentParserConfig.swift
+++ b/CLI/Sources/CLIArgumentParserConfig.swift
@@ -44,4 +44,15 @@ extension CLIArgumentParser {
     }
     return input
   }
+
+  mutating func consumeSearchInput() throws -> SearchInput {
+    let query = try consumeRequiredValue(for: "--query")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { throw CLIError.usage("Missing value for --query.") }
+    return SearchInput(query: query, limit: try consumeLimit())
+  }
+
+  mutating func consumeContextInput() throws -> ContextInput {
+    ContextInput(limit: try consumeLimit())
+  }
 }

--- a/CLI/Sources/CLIArgumentParserHelpers.swift
+++ b/CLI/Sources/CLIArgumentParserHelpers.swift
@@ -40,4 +40,12 @@ extension CLIArgumentParser {
     }
     return number
   }
+
+  mutating func consumeLimit(default defaultValue: Int = 20) throws -> Int {
+    guard let value = consumeOptionalValue(for: "--limit") else { return defaultValue }
+    guard let limit = Int(value), limit > 0 else {
+      throw CLIError.usage("--limit must be a positive integer.")
+    }
+    return limit
+  }
 }

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -14,6 +14,8 @@ enum CLIResponseData: Encodable {
   case subredditVerification(SubredditVerificationDTO)
   case peakPresets([PeakPresetDTO])
   case peakInfo(PeakInfoDTO)
+  case searchResults([SearchResultDTO])
+  case context(ContextDTO)
   case dryRun(String)
 
   func encode(to encoder: Encoder) throws {
@@ -32,6 +34,8 @@ enum CLIResponseData: Encodable {
     case .subredditVerification(let value): try container.encode(value)
     case .peakPresets(let value): try container.encode(value)
     case .peakInfo(let value): try container.encode(value)
+    case .searchResults(let value): try container.encode(value)
+    case .context(let value): try container.encode(value)
     case .dryRun(let value): try container.encode(["message": value])
     }
   }

--- a/CLI/Sources/CLIDiscoveryManager.swift
+++ b/CLI/Sources/CLIDiscoveryManager.swift
@@ -1,0 +1,156 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct CLIDiscoveryManager {
+  let context: ModelContext
+  let heuristicsStore: HeuristicsStore
+
+  func search(input: SearchInput) -> CLIResponse {
+    let query = input.query.lowercased()
+    let results =
+      projectResults(query: query)
+      + subredditResults(query: query)
+      + captureResults(query: query)
+      + eventResults(query: query)
+      + peakPresetResults(query: query)
+    return .success(data: .searchResults(Array(results.prefix(input.limit))))
+  }
+
+  func showContext(input: ContextInput) -> CLIResponse {
+    let captures = fetchCaptures()
+    let projects = fetchProjects()
+    let subreddits = fetchSubreddits()
+    let events = fetchEvents()
+    let activeEvents = events.filter(\.isActive)
+    let queuedCaptures = captures.filter { $0.status == .queued }
+    let counts = ContextCountsDTO(
+      capturesQueued: queuedCaptures.count,
+      capturesPosted: captures.filter { $0.status == .posted }.count,
+      projectsActive: projects.filter { !$0.archived }.count,
+      projectsArchived: projects.filter(\.archived).count,
+      subreddits: subreddits.count,
+      eventsActive: activeEvents.count
+    )
+    let dto = ContextDTO(
+      generatedAt: CLIFormat.date(Date()),
+      counts: counts,
+      projects: Array(projects.prefix(input.limit)).map(ProjectDTO.init),
+      subreddits: Array(subreddits.prefix(input.limit)).map {
+        SubredditDTO($0, peakInfo: heuristicsStore.peakInfo(for: $0))
+      },
+      queuedCaptures: Array(queuedCaptures.prefix(input.limit)).map(CaptureDTO.init),
+      upcomingEvents: Array(activeEvents.prefix(input.limit)).map(EventDTO.init),
+      peakPresets: SubredditPeakSelection.presets.map(PeakPresetDTO.init)
+    )
+    return .success(data: .context(dto))
+  }
+
+  private func projectResults(query: String) -> [SearchResultDTO] {
+    fetchProjects().compactMap { project in
+      let text = [project.id.uuidString, project.name, project.projectDescription ?? "", project.color ?? ""]
+        .joined(separator: " ")
+      guard text.lowercased().contains(query) else { return nil }
+      return SearchResultDTO(
+        kind: "project",
+        id: project.id.uuidString,
+        title: project.name,
+        subtitle: project.archived ? "archived project" : "active project")
+    }
+  }
+
+  private func subredditResults(query: String) -> [SearchResultDTO] {
+    fetchSubreddits().compactMap { subreddit in
+      let peak = heuristicsStore.peakInfo(for: subreddit)
+      let text = [
+        subreddit.id.uuidString,
+        subreddit.name,
+        subreddit.postingChecklist ?? "",
+        peak?.peakDays.joined(separator: " ") ?? "",
+        peak?.peakHoursUtc.map(String.init).joined(separator: " ") ?? "",
+      ].joined(separator: " ")
+      guard text.lowercased().contains(query) else { return nil }
+      let summary = PeakSummaryDTO(subreddit: subreddit, peakInfo: peak)
+      return SearchResultDTO(
+        kind: "subreddit",
+        id: subreddit.id.uuidString,
+        title: subreddit.name,
+        subtitle: "peak \(summary.source): \(summary.days.joined(separator: ","))")
+    }
+  }
+
+  private func captureResults(query: String) -> [SearchResultDTO] {
+    fetchCaptures().compactMap { capture in
+      let text = [
+        capture.id.uuidString,
+        capture.title ?? "",
+        capture.text,
+        capture.notes ?? "",
+        capture.links.joined(separator: " "),
+        capture.project?.name ?? "",
+        capture.subreddits.map(\.name).joined(separator: " "),
+      ].joined(separator: " ")
+      guard text.lowercased().contains(query) else { return nil }
+      return SearchResultDTO(
+        kind: "capture",
+        id: capture.id.uuidString,
+        title: capture.title ?? capture.text,
+        subtitle: capture.status.rawValue)
+    }
+  }
+
+  private func eventResults(query: String) -> [SearchResultDTO] {
+    fetchEvents().compactMap { event in
+      let text = [
+        event.id.uuidString,
+        event.name,
+        event.subreddit?.name ?? "",
+        event.rrule ?? "",
+        event.generationKey ?? "",
+      ].joined(separator: " ")
+      guard text.lowercased().contains(query) else { return nil }
+      let source = event.isGeneratedFromHeuristics ? "generated" : "manual"
+      return SearchResultDTO(
+        kind: "event",
+        id: event.id.uuidString,
+        title: event.name,
+        subtitle: "\(source) \(event.isActive ? "active" : "inactive")")
+    }
+  }
+
+  private func peakPresetResults(query: String) -> [SearchResultDTO] {
+    SubredditPeakSelection.presets.compactMap { preset in
+      let text = [preset.label, preset.days.joined(separator: " "), preset.localHours.map(String.init).joined(separator: " ")]
+        .joined(separator: " ")
+      guard text.lowercased().contains(query) else { return nil }
+      return SearchResultDTO(
+        kind: "peakPreset",
+        id: preset.label,
+        title: preset.label,
+        subtitle: "\(preset.days.joined(separator: ",")) @ \(preset.localHours.map(String.init).joined(separator: ","))")
+    }
+  }
+
+  private func fetchCaptures() -> [Capture] {
+    let descriptor = FetchDescriptor<Capture>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
+    return (try? context.fetch(descriptor)) ?? []
+  }
+
+  private func fetchProjects() -> [Project] {
+    let descriptor = FetchDescriptor<Project>(sortBy: [SortDescriptor(\.name)])
+    return (try? context.fetch(descriptor)) ?? []
+  }
+
+  private func fetchSubreddits() -> [Subreddit] {
+    let descriptor = FetchDescriptor<Subreddit>(sortBy: [SortDescriptor(\.sortOrder)])
+    return (try? context.fetch(descriptor)) ?? []
+  }
+
+  private func fetchEvents() -> [SubredditEvent] {
+    let descriptor = FetchDescriptor<SubredditEvent>(sortBy: [
+      SortDescriptor(\.oneOffDate),
+      SortDescriptor(\.name),
+    ])
+    return (try? context.fetch(descriptor)) ?? []
+  }
+}

--- a/CLI/Sources/CLIDiscoveryTypes.swift
+++ b/CLI/Sources/CLIDiscoveryTypes.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct SearchInput {
+  let query: String
+  let limit: Int
+}
+
+struct ContextInput {
+  let limit: Int
+}
+
+struct SearchResultDTO: Encodable {
+  let kind: String
+  let id: String
+  let title: String
+  let subtitle: String?
+}
+
+struct ContextDTO: Encodable {
+  let generatedAt: String
+  let counts: ContextCountsDTO
+  let projects: [ProjectDTO]
+  let subreddits: [SubredditDTO]
+  let queuedCaptures: [CaptureDTO]
+  let upcomingEvents: [EventDTO]
+  let peakPresets: [PeakPresetDTO]
+}
+
+struct ContextCountsDTO: Encodable {
+  let capturesQueued: Int
+  let capturesPosted: Int
+  let projectsActive: Int
+  let projectsArchived: Int
+  let subreddits: Int
+  let eventsActive: Int
+}

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -46,6 +46,8 @@ enum CLICommand {
   case peaksGet(subreddit: String)
   case peaksSet(subreddit: String, days: [String], hours: [Int], timeZone: String?)
   case peaksReset(subreddit: String)
+  case searchAll(SearchInput)
+  case contextShow(ContextInput)
 
   init(domain: String, action: String, parser: inout CLIArgumentParser) throws {
     switch (domain, action) {
@@ -111,6 +113,10 @@ enum CLICommand {
       self = .peaksSet(subreddit: subreddit, days: days, hours: hours, timeZone: timeZone)
     case ("peaks", "reset"):
       self = .peaksReset(subreddit: try parser.consumeSubredditArgument())
+    case ("search", "all"):
+      self = .searchAll(try parser.consumeSearchInput())
+    case ("context", "show"):
+      self = .contextShow(try parser.consumeContextInput())
     default:
       throw CLIError.usage(CLIHelp.domain(domain))
     }

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -69,6 +69,11 @@ enum CLIPrinter {
     case .peakInfo(let info):
       return
         "\(info.subreddit.name): \(info.peak.days.joined(separator: ",")) @ local \(info.peak.hoursLocal.map(String.init).joined(separator: ","))"
+    case .searchResults(let results):
+      return results.map { "\($0.kind) \($0.id) \($0.title)" }.joined(separator: "\n")
+    case .context(let context):
+      return
+        "Context: \(context.counts.capturesQueued) queued captures, \(context.counts.subreddits) subreddits, \(context.counts.eventsActive) active events"
     case .dryRun(let message): return message
     }
   }
@@ -108,7 +113,7 @@ enum CLIHelp {
   static let root = """
     Usage: redditreminder [--json] [--pretty] [--dry-run] [--store PATH] <domain> <command>
 
-    Domains: captures, events, projects, subreddits, peaks
+    Domains: captures, events, projects, subreddits, peaks, search, context
     """
 
   static func domain(_ domain: String) -> String {
@@ -120,6 +125,8 @@ enum CLIHelp {
     case "projects": return "Usage: redditreminder projects list|search|create|update|delete"
     case "subreddits": return "Usage: redditreminder subreddits list|search|add|update|delete|verify"
     case "peaks": return "Usage: redditreminder peaks presets|get|set|reset"
+    case "search": return "Usage: redditreminder search all --query TEXT [--limit N]"
+    case "context": return "Usage: redditreminder context show [--limit N]"
     default: return root
     }
   }

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -71,6 +71,10 @@ final class CLIRunner {
       return try setPeakInfo(for: subreddit, days: days, hours: hours, timeZone: timeZone)
     case .peaksReset(let subreddit):
       return try resetPeakInfo(for: subreddit)
+    case .searchAll(let input):
+      return discoveryManager.search(input: input)
+    case .contextShow(let input):
+      return discoveryManager.showContext(input: input)
     }
   }
 
@@ -160,6 +164,10 @@ final class CLIRunner {
 
   private var subredditManager: CLISubredditManager {
     CLISubredditManager(options: options, context: context, heuristicsStore: heuristicsStore)
+  }
+
+  private var discoveryManager: CLIDiscoveryManager {
+    CLIDiscoveryManager(context: context, heuristicsStore: heuristicsStore)
   }
 }
 

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		BA3588948937708CD83AFEBC /* CLIOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14A6B7A047D5672F9159659 /* CLIOutput.swift */; };
 		BA3B263D9D03FA844568F913 /* EventSourceSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */; };
 		BEE74F03864389AD3A108EFE /* BackupSettingsPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61052DF5F8EFC70EA9076106 /* BackupSettingsPersistence.swift */; };
+		BFFFDEA5E6BAD356DC03006F /* CLIDiscoveryTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D057AC06C4DF9C7404C609 /* CLIDiscoveryTypes.swift */; };
 		C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */; };
 		CC6A10A2CEA907B520EEE2F3 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */; };
 		CCE3B3D5EE4B39D55222CA19 /* ResourcePackagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A9BB4582DA895A6C18C321 /* ResourcePackagingTests.swift */; };
@@ -167,6 +168,7 @@
 		DA2B270CDFA18C60E33E913B /* KeyboardShortcutConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793582517DF597A0F96E2072 /* KeyboardShortcutConfig.swift */; };
 		DF5BC4B40F68E4D77656AD97 /* ShortcutRecorderInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECD53B7CA29C3F004D13EBB /* ShortcutRecorderInputTests.swift */; };
 		DF685B7594B2CB10A5A81F3B /* PopoverChromeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5570C2EF1DD747B43C6F4ED /* PopoverChromeViewTests.swift */; };
+		E39C6204803369529EE71FA8 /* CLIDiscoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F3C79809C4BF0DD2B05AF6 /* CLIDiscoveryManager.swift */; };
 		E3F5BC123C653EDC86231434 /* CaptureHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */; };
 		E651BBE6C6C84CA44281F9B7 /* CLIArgumentParserHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2755BD3961DE8EA13B8A1E /* CLIArgumentParserHelpers.swift */; };
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
@@ -235,6 +237,7 @@
 		275F5DE20B1832CEA53FF535 /* SettingsOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOptionsTests.swift; sourceTree = "<group>"; };
 		288C13F7511FB37215593E12 /* CaptureMediaSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaSelection.swift; sourceTree = "<group>"; };
 		28906380DECDA56AD0DDE325 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
+		28D057AC06C4DF9C7404C609 /* CLIDiscoveryTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDiscoveryTypes.swift; sourceTree = "<group>"; };
 		2DCEE0DEE2D8B351D6357E71 /* BackupMediaPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMediaPayloads.swift; sourceTree = "<group>"; };
 		303FB325A99764563E4FB2AC /* PostHandoffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHandoffView.swift; sourceTree = "<group>"; };
 		317B217ED06D209DAFACA344 /* RedditReminderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RedditReminderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -294,6 +297,7 @@
 		736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICaptureLifecycle.swift; sourceTree = "<group>"; };
 		75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditPersistenceActionsTests.swift; sourceTree = "<group>"; };
 		75FA87973FC3B43FDB7B37F8 /* PostingChecklistItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingChecklistItemsTests.swift; sourceTree = "<group>"; };
+		77F3C79809C4BF0DD2B05AF6 /* CLIDiscoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDiscoveryManager.swift; sourceTree = "<group>"; };
 		787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderApp.swift; sourceTree = "<group>"; };
 		793582517DF597A0F96E2072 /* KeyboardShortcutConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutConfig.swift; sourceTree = "<group>"; };
 		7D9810B901F7241E88A6D898 /* SubredditInputValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditInputValidation.swift; sourceTree = "<group>"; };
@@ -527,6 +531,8 @@
 				8E2755BD3961DE8EA13B8A1E /* CLIArgumentParserHelpers.swift */,
 				B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */,
 				736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */,
+				77F3C79809C4BF0DD2B05AF6 /* CLIDiscoveryManager.swift */,
+				28D057AC06C4DF9C7404C609 /* CLIDiscoveryTypes.swift */,
 				3B81CF275655D5E1ECD5EC37 /* CLIDTOs.swift */,
 				9C593329647C7A7C82103B02 /* CLIEventManager.swift */,
 				C9AC123670C416604F87973B /* CLIEventTypes.swift */,
@@ -827,6 +833,8 @@
 				D70537E281AB16807DE1E2FA /* CLICaptureCreator.swift in Sources */,
 				1690FE987E73EE0BB803779E /* CLICaptureLifecycle.swift in Sources */,
 				8BDBD62791F99A373564D5B3 /* CLIDTOs.swift in Sources */,
+				E39C6204803369529EE71FA8 /* CLIDiscoveryManager.swift in Sources */,
+				BFFFDEA5E6BAD356DC03006F /* CLIDiscoveryTypes.swift in Sources */,
 				1A4FD7E60A3E022FD9BB3B69 /* CLIEventManager.swift in Sources */,
 				954EDB76CEE86E41F6C30BE5 /* CLIEventTypes.swift in Sources */,
 				9455C1014FD9C64F0B68D3F7 /* CLIFilter.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,20 @@ JSON responses use this envelope:
 }
 ```
 
+## Agent Discovery
+
+```sh
+redditreminder context show --json
+redditreminder context show --limit 5 --json
+redditreminder search all --query "launch" --json
+redditreminder search all --query "weekday" --limit 10 --json
+```
+
+`context show` returns a compact snapshot of the workspace: counts, projects,
+subreddits with peak summaries, queued captures, active events, and peak presets.
+`search all` searches captures, events, projects, subreddits, and peak presets so
+agents can inspect the widget state without guessing which domain to query first.
+
 ## Captures
 
 ```sh

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -146,6 +146,16 @@ rm -f /tmp/redditreminder-cli-generated-delete.out /tmp/redditreminder-cli-gener
 peak_get="$(run_json peaks get SideProject)"
 assert_contains "peak get" "$peak_get" '"source":"override"'
 
+global_search="$(run_json search all --query "Launch" --limit 10)"
+assert_contains "global search ok" "$global_search" '"ok":true'
+assert_contains "global search project" "$global_search" '"kind":"project"'
+
+context_snapshot="$(run_json context show --limit 5)"
+assert_contains "context ok" "$context_snapshot" '"ok":true'
+assert_contains "context counts" "$context_snapshot" '"counts":'
+assert_contains "context subreddits" "$context_snapshot" '"subreddits":['
+assert_contains "context peak presets" "$context_snapshot" '"peakPresets":['
+
 peak_reset="$(run_json peaks reset SideProject)"
 assert_contains "peak reset" "$peak_reset" '"ok":true'
 


### PR DESCRIPTION
## Summary
- add context show for a compact agent-readable workspace snapshot
- add search all --query to search captures, events, projects, subreddits, and peak presets from one command
- include counts, queued captures, active events, subreddits with peak summaries, projects, and peak presets in context output
- document the discovery commands and extend CLI smoke coverage

## Verification
- make cli-test
- make build-debug
- make test
- ./scripts/format-check.sh
- Swift file size check across CLI and Sources: no files over 300 lines
- isolated installed CLI search/context smoke