### PR TITLE
Add CLI command catalog

### DIFF
--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+enum CLICommandCatalog {
+  static func list() -> CLIResponse {
+    .success(data: .commandReferences(commands))
+  }
+
+  static func show(id input: String) throws -> CLIResponse {
+    let normalized = input.lowercased()
+    guard let command = commands.first(where: { $0.id == normalized }) else {
+      throw CLIError.notFound("Command not found: \(input)")
+    }
+    return .success(data: .commandReference(command))
+  }
+
+  static let commands: [CommandReferenceDTO] =
+    discoveryCommands
+    + captureCommands
+    + eventCommands
+    + projectCommands
+    + subredditCommands
+    + peakCommands
+
+  static let discoveryCommands: [CommandReferenceDTO] = [
+    command(
+      "context.show", "context", "show",
+      "Return a compact workspace snapshot for agent planning.",
+      flags: [flag("--limit", "N", "Maximum items per collection. Defaults to 20.")],
+      examples: ["redditreminder --json context show --limit 5"],
+      output: output("context", "Counts, projects, subreddits, queued captures, events, presets.")
+    ),
+    command(
+      "search.all", "search", "all",
+      "Search captures, events, projects, subreddits, and peak presets.",
+      flags: [
+        flag("--query", "TEXT", "Search text.", required: true),
+        flag("--limit", "N", "Maximum results. Defaults to 20."),
+      ],
+      examples: ["redditreminder --json search all --query launch --limit 10"],
+      output: output("searchResults", "Array of typed search hits.")
+    ),
+    command(
+      "commands.list", "commands", "list",
+      "Return metadata for every CLI command.",
+      examples: ["redditreminder --json commands list"],
+      output: output("commandReferences", "Array of command reference objects.")
+    ),
+    command(
+      "commands.show", "commands", "show",
+      "Return metadata for one CLI command.",
+      positionals: [arg("id", "Command id, for example captures.create.")],
+      examples: ["redditreminder --json commands show captures.create"],
+      output: output("commandReference", "One command reference object.")
+    ),
+  ]
+
+  static func command(
+    _ id: String,
+    _ domain: String,
+    _ command: String,
+    _ summary: String,
+    positionals: [CommandArgumentDTO] = [],
+    flags: [CommandFlagDTO] = [],
+    examples: [String],
+    output: CommandOutputDTO
+  ) -> CommandReferenceDTO {
+    CommandReferenceDTO(
+      id: id,
+      domain: domain,
+      command: command,
+      summary: summary,
+      positionals: positionals,
+      flags: flags,
+      examples: examples,
+      output: output)
+  }
+
+  static func arg(_ name: String, _ summary: String, required: Bool = true)
+    -> CommandArgumentDTO
+  {
+    CommandArgumentDTO(name: name, required: required, summary: summary)
+  }
+
+  static func flag(
+    _ name: String,
+    _ value: String?,
+    _ summary: String,
+    required: Bool = false,
+    repeatable: Bool = false
+  ) -> CommandFlagDTO {
+    CommandFlagDTO(
+      name: name,
+      value: value,
+      required: required,
+      repeatable: repeatable,
+      summary: summary)
+  }
+
+  static func output(_ data: String, _ summary: String) -> CommandOutputDTO {
+    CommandOutputDTO(data: data, summary: summary)
+  }
+
+  static func eventListFlags() -> [CommandFlagDTO] {
+    [
+      flag("--subreddit", "NAME_OR_ID", "Filter by subreddit."),
+      flag("--from", "ISO8601", "Filter one-off dates at or after this date."),
+      flag("--to", "ISO8601", "Filter one-off dates at or before this date."),
+      flag("--manual", nil, "Only manual events."),
+      flag("--generated", nil, "Only generated peak events."),
+      flag("--active", nil, "Only active events."),
+      flag("--inactive", nil, "Only inactive events."),
+    ]
+  }
+}

--- a/CLI/Sources/CLICommandCatalogCaptures.swift
+++ b/CLI/Sources/CLICommandCatalogCaptures.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+extension CLICommandCatalog {
+  static let captureCommands: [CommandReferenceDTO] = [
+    command(
+      "captures.list", "captures", "list",
+      "List queued and posted captures.",
+      flags: [flag("--query", "TEXT", "Optional search text.")],
+      examples: ["redditreminder --json captures list"],
+      output: output("captures", "Array of capture objects.")
+    ),
+    command(
+      "captures.search", "captures", "search",
+      "Search captures.",
+      flags: [flag("--query", "TEXT", "Search text.", required: true)],
+      examples: ["redditreminder --json captures search --query launch"],
+      output: output("captures", "Array of capture objects.")
+    ),
+    command(
+      "captures.create", "captures", "create",
+      "Create a queued capture, optionally with media and due events.",
+      flags: [
+        flag("--title", "TEXT", "Optional post title."),
+        flag("--text", "TEXT", "Post body. Trailing text is used when omitted."),
+        flag("--notes", "TEXT", "Private notes."),
+        flag("--link", "URL", "Add one link.", repeatable: true),
+        flag("--links", "A,B", "Comma-separated links."),
+        flag("--project", "NAME_OR_ID", "Existing project."),
+        flag("--subreddit", "NAME_OR_ID", "Existing subreddit.", repeatable: true),
+        flag("--subreddits", "A,B", "Comma-separated subreddits."),
+        flag("--media", "PATH", "Image path to copy into media store.", repeatable: true),
+        flag("--media-paths", "A,B", "Comma-separated image paths."),
+        flag("--due", "ISO8601", "Create one due event per selected subreddit."),
+      ],
+      examples: [
+        "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject"
+      ],
+      output: output("captureCreated", "Created capture plus due events.")
+    ),
+    command(
+      "captures.update", "captures", "update",
+      "Update a capture.",
+      positionals: [arg("id", "Capture UUID.")],
+      flags: [
+        flag("--title", "TEXT", "Set title."),
+        flag("--clear-title", nil, "Clear title."),
+        flag("--text", "TEXT", "Set body."),
+        flag("--notes", "TEXT", "Set notes."),
+        flag("--clear-notes", nil, "Clear notes."),
+        flag("--link", "URL", "Replace links with repeated values.", repeatable: true),
+        flag("--links", "A,B", "Replace links with comma-separated values."),
+        flag("--clear-links", nil, "Clear links."),
+        flag("--project", "NAME_OR_ID", "Set project."),
+        flag("--clear-project", nil, "Clear project."),
+        flag("--subreddit", "NAME_OR_ID", "Replace subreddits.", repeatable: true),
+        flag("--subreddits", "A,B", "Replace subreddits."),
+        flag("--clear-subreddits", nil, "Clear subreddits."),
+        flag("--media", "PATH", "Add media.", repeatable: true),
+        flag("--remove-media", "REF", "Remove stored media ref.", repeatable: true),
+        flag("--clear-media", nil, "Clear all media."),
+      ],
+      examples: ["redditreminder --json captures update CAPTURE_ID --title 'Updated'"],
+      output: output("capture", "Updated capture object.")
+    ),
+    command(
+      "captures.delete", "captures", "delete",
+      "Delete a capture.",
+      positionals: [arg("id", "Capture UUID.")],
+      examples: ["redditreminder --json captures delete CAPTURE_ID"],
+      output: output("deleted", "Deleted id.")
+    ),
+    command(
+      "captures.mark-posted", "captures", "mark-posted",
+      "Mark a capture as posted.",
+      positionals: [arg("id", "Capture UUID.")],
+      flags: [flag("--url", "URL", "Posted Reddit URL.")],
+      examples: ["redditreminder --json captures mark-posted CAPTURE_ID --url https://reddit.com/..."],
+      output: output("capture", "Updated capture object.")
+    ),
+    command(
+      "captures.mark-queued", "captures", "mark-queued",
+      "Move a posted capture back to queued.",
+      positionals: [arg("id", "Capture UUID.")],
+      examples: ["redditreminder --json captures mark-queued CAPTURE_ID"],
+      output: output("capture", "Updated capture object.")
+    ),
+  ]
+}

--- a/CLI/Sources/CLICommandCatalogConfig.swift
+++ b/CLI/Sources/CLICommandCatalogConfig.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+extension CLICommandCatalog {
+  static let projectCommands: [CommandReferenceDTO] = [
+    command(
+      "projects.list", "projects", "list",
+      "List projects.",
+      flags: [flag("--query", "TEXT", "Optional search text.")],
+      examples: ["redditreminder --json projects list"],
+      output: output("projects", "Array of project objects.")
+    ),
+    command(
+      "projects.search", "projects", "search",
+      "Search projects.",
+      flags: [flag("--query", "TEXT", "Search text.", required: true)],
+      examples: ["redditreminder --json projects search --query launch"],
+      output: output("projects", "Array of project objects.")
+    ),
+    command(
+      "projects.create", "projects", "create",
+      "Create a project.",
+      positionals: [arg("name", "Project name.")],
+      examples: ["redditreminder --json projects create 'Launch Ideas'"],
+      output: output("project", "Created project object.")
+    ),
+    command(
+      "projects.update", "projects", "update",
+      "Update project metadata.",
+      positionals: [arg("id", "Project UUID or name.")],
+      flags: [
+        flag("--name", "TEXT", "Rename project."),
+        flag("--description", "TEXT", "Set description."),
+        flag("--clear-description", nil, "Clear description."),
+        flag("--color", "TEXT", "Set color."),
+        flag("--clear-color", nil, "Clear color."),
+        flag("--archive", nil, "Archive project."),
+        flag("--unarchive", nil, "Unarchive project."),
+      ],
+      examples: ["redditreminder --json projects update Launch --archive"],
+      output: output("project", "Updated project object.")
+    ),
+    command(
+      "projects.delete", "projects", "delete",
+      "Delete a project. Captures assigned to it are cascaded by the app model.",
+      positionals: [arg("id", "Project UUID or name.")],
+      examples: ["redditreminder --json projects delete Launch"],
+      output: output("deleted", "Deleted id.")
+    ),
+  ]
+
+  static let subredditCommands: [CommandReferenceDTO] = [
+    command(
+      "subreddits.list", "subreddits", "list",
+      "List subreddits with peak summaries.",
+      flags: [flag("--query", "TEXT", "Optional search text.")],
+      examples: ["redditreminder --json subreddits list"],
+      output: output("subreddits", "Array of subreddit objects.")
+    ),
+    command(
+      "subreddits.search", "subreddits", "search",
+      "Search subreddits.",
+      flags: [flag("--query", "TEXT", "Search text.", required: true)],
+      examples: ["redditreminder --json subreddits search --query swift"],
+      output: output("subreddits", "Array of subreddit objects.")
+    ),
+    command(
+      "subreddits.add", "subreddits", "add",
+      "Add a subreddit and generate bundled peak events.",
+      positionals: [arg("name", "Subreddit name or Reddit URL.")],
+      flags: [flag("--verify", nil, "Verify against Reddit before saving.")],
+      examples: ["redditreminder --json subreddits add --verify SideProject"],
+      output: output("subreddit", "Created subreddit object.")
+    ),
+    command(
+      "subreddits.update", "subreddits", "update",
+      "Update a subreddit name or posting checklist.",
+      positionals: [arg("id", "Subreddit UUID or name.")],
+      flags: [
+        flag("--name", "TEXT", "Rename subreddit."),
+        flag("--checklist", "TEXT", "Set posting checklist."),
+        flag("--clear-checklist", nil, "Clear posting checklist."),
+      ],
+      examples: ["redditreminder --json subreddits update SideProject --checklist 'Read rules'"],
+      output: output("subreddit", "Updated subreddit object.")
+    ),
+    command(
+      "subreddits.delete", "subreddits", "delete",
+      "Delete a subreddit, cascading events while preserving captures.",
+      positionals: [arg("id", "Subreddit UUID or name.")],
+      examples: ["redditreminder --json subreddits delete SideProject"],
+      output: output("deleted", "Deleted id.")
+    ),
+    command(
+      "subreddits.verify", "subreddits", "verify",
+      "Check whether Reddit exposes the subreddit about endpoint.",
+      positionals: [arg("name", "Subreddit name or Reddit URL.")],
+      examples: ["redditreminder --json subreddits verify SideProject"],
+      output: output("subredditVerification", "Verification result.")
+    ),
+  ]
+
+  static let peakCommands: [CommandReferenceDTO] = [
+    command(
+      "peaks.presets", "peaks", "presets",
+      "List bundled peak-time presets.",
+      examples: ["redditreminder --json peaks presets"],
+      output: output("peakPresets", "Array of preset objects.")
+    ),
+    command(
+      "peaks.get", "peaks", "get",
+      "Show peak-time configuration for a subreddit.",
+      positionals: [arg("subreddit", "Subreddit UUID or name.")],
+      examples: ["redditreminder --json peaks get SideProject"],
+      output: output("peakInfo", "Peak summary object.")
+    ),
+    command(
+      "peaks.set", "peaks", "set",
+      "Set peak days and local hours for a subreddit.",
+      positionals: [arg("subreddit", "Subreddit UUID or name.")],
+      flags: [
+        flag("--days", "mon,tue", "Comma-separated day keys.", required: true),
+        flag("--hours", "9,10", "Comma-separated local hours 0-23.", required: true),
+        flag("--timezone", "ID", "IANA timezone. Defaults to current timezone."),
+      ],
+      examples: ["redditreminder --json peaks set SideProject --days mon,wed --hours 9,10"],
+      output: output("peakInfo", "Updated peak summary object.")
+    ),
+    command(
+      "peaks.reset", "peaks", "reset",
+      "Clear custom peak overrides for a subreddit.",
+      positionals: [arg("subreddit", "Subreddit UUID or name.")],
+      examples: ["redditreminder --json peaks reset SideProject"],
+      output: output("peakInfo", "Updated peak summary object.")
+    ),
+  ]
+}

--- a/CLI/Sources/CLICommandCatalogEvents.swift
+++ b/CLI/Sources/CLICommandCatalogEvents.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+extension CLICommandCatalog {
+  static let eventCommands: [CommandReferenceDTO] = [
+    command(
+      "events.list", "events", "list",
+      "List posting events.",
+      flags: eventListFlags(),
+      examples: ["redditreminder --json events list --subreddit SideProject --active"],
+      output: output("events", "Array of event objects.")
+    ),
+    command(
+      "events.search", "events", "search",
+      "Search posting events.",
+      flags: [flag("--query", "TEXT", "Search text.", required: true)] + eventListFlags(),
+      examples: ["redditreminder --json events search --query launch --manual"],
+      output: output("events", "Array of event objects.")
+    ),
+    command(
+      "events.create", "events", "create",
+      "Create a manual one-off posting event.",
+      flags: [
+        flag("--subreddit", "NAME_OR_ID", "Existing subreddit.", required: true),
+        flag("--name", "TEXT", "Event name."),
+        flag("--date", "ISO8601", "Event date.", required: true),
+        flag("--lead-minutes", "N", "Reminder lead time."),
+      ],
+      examples: [
+        "redditreminder --json events create --subreddit SideProject --date 2026-05-02T18:00:00Z"
+      ],
+      output: output("event", "Created event object.")
+    ),
+    command(
+      "events.update", "events", "update",
+      "Update a manual event.",
+      positionals: [arg("id", "Event UUID or unambiguous prefix.")],
+      flags: [
+        flag("--name", "TEXT", "Set event name."),
+        flag("--date", "ISO8601", "Set one-off date."),
+        flag("--lead-minutes", "N", "Set reminder lead time."),
+        flag("--activate", nil, "Activate event."),
+        flag("--deactivate", nil, "Deactivate event."),
+      ],
+      examples: ["redditreminder --json events update EVENT_ID --deactivate"],
+      output: output("event", "Updated event object.")
+    ),
+    command(
+      "events.delete", "events", "delete",
+      "Delete a manual event.",
+      positionals: [arg("id", "Event UUID or unambiguous prefix.")],
+      examples: ["redditreminder --json events delete EVENT_ID"],
+      output: output("deleted", "Deleted id.")
+    ),
+  ]
+}

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct CommandReferenceDTO: Encodable {
+  let id: String
+  let domain: String
+  let command: String
+  let summary: String
+  let positionals: [CommandArgumentDTO]
+  let flags: [CommandFlagDTO]
+  let examples: [String]
+  let output: CommandOutputDTO
+}
+
+struct CommandArgumentDTO: Encodable {
+  let name: String
+  let required: Bool
+  let summary: String
+}
+
+struct CommandFlagDTO: Encodable {
+  let name: String
+  let value: String?
+  let required: Bool
+  let repeatable: Bool
+  let summary: String
+}
+
+struct CommandOutputDTO: Encodable {
+  let data: String
+  let summary: String
+}

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -16,6 +16,8 @@ enum CLIResponseData: Encodable {
   case peakInfo(PeakInfoDTO)
   case searchResults([SearchResultDTO])
   case context(ContextDTO)
+  case commandReferences([CommandReferenceDTO])
+  case commandReference(CommandReferenceDTO)
   case dryRun(String)
 
   func encode(to encoder: Encoder) throws {
@@ -36,6 +38,8 @@ enum CLIResponseData: Encodable {
     case .peakInfo(let value): try container.encode(value)
     case .searchResults(let value): try container.encode(value)
     case .context(let value): try container.encode(value)
+    case .commandReferences(let value): try container.encode(value)
+    case .commandReference(let value): try container.encode(value)
     case .dryRun(let value): try container.encode(["message": value])
     }
   }

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -48,6 +48,8 @@ enum CLICommand {
   case peaksReset(subreddit: String)
   case searchAll(SearchInput)
   case contextShow(ContextInput)
+  case commandsList
+  case commandsShow(id: String)
 
   init(domain: String, action: String, parser: inout CLIArgumentParser) throws {
     switch (domain, action) {
@@ -117,6 +119,10 @@ enum CLICommand {
       self = .searchAll(try parser.consumeSearchInput())
     case ("context", "show"):
       self = .contextShow(try parser.consumeContextInput())
+    case ("commands", "list"):
+      self = .commandsList
+    case ("commands", "show"):
+      self = .commandsShow(id: try parser.consumeRequiredArgument(label: "command id"))
     default:
       throw CLIError.usage(CLIHelp.domain(domain))
     }

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -74,6 +74,10 @@ enum CLIPrinter {
     case .context(let context):
       return
         "Context: \(context.counts.capturesQueued) queued captures, \(context.counts.subreddits) subreddits, \(context.counts.eventsActive) active events"
+    case .commandReferences(let commands):
+      return commands.map { "\($0.id) - \($0.summary)" }.joined(separator: "\n")
+    case .commandReference(let command):
+      return "\(command.id) - \(command.summary)"
     case .dryRun(let message): return message
     }
   }
@@ -113,7 +117,7 @@ enum CLIHelp {
   static let root = """
     Usage: redditreminder [--json] [--pretty] [--dry-run] [--store PATH] <domain> <command>
 
-    Domains: captures, events, projects, subreddits, peaks, search, context
+    Domains: captures, events, projects, subreddits, peaks, search, context, commands
     """
 
   static func domain(_ domain: String) -> String {
@@ -127,6 +131,7 @@ enum CLIHelp {
     case "peaks": return "Usage: redditreminder peaks presets|get|set|reset"
     case "search": return "Usage: redditreminder search all --query TEXT [--limit N]"
     case "context": return "Usage: redditreminder context show [--limit N]"
+    case "commands": return "Usage: redditreminder commands list|show"
     default: return root
     }
   }

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -75,6 +75,10 @@ final class CLIRunner {
       return discoveryManager.search(input: input)
     case .contextShow(let input):
       return discoveryManager.showContext(input: input)
+    case .commandsList:
+      return CLICommandCatalog.list()
+    case .commandsShow(let id):
+      return try CLICommandCatalog.show(id: id)
     }
   }
 

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1228389EE01C83EF49C3DEC8 /* AppRefreshAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979105135C8B3C67FC080326 /* AppRefreshAction.swift */; };
 		12B7E4C8F9AB781325FFC21F /* ProjectPersistenceActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD560BCF0F23A397D3EF341 /* ProjectPersistenceActions.swift */; };
 		130E73ADD3C89D99930823B0 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */; };
+		13E7899C74330A230D4C5B35 /* CLICommandCatalogTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C6DAB7D790FE62A62D947F /* CLICommandCatalogTypes.swift */; };
 		1623A15BD009688470DBFF26 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050BB3D18ECE13E70E7CED42 /* NotificationService.swift */; };
 		1690FE987E73EE0BB803779E /* CLICaptureLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */; };
 		17050D203FEDB10BDE6F431A /* QAFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = B338E8D9C979B250564A392E /* QAFixtures.swift */; };
@@ -93,6 +94,7 @@
 		5B69D9E7F11752087138A0C6 /* RedditPostingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B419BD1AF2CF70DEC1509B /* RedditPostingActions.swift */; };
 		5B9E3F47EA4B9D3D5028C11A /* NotificationsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */; };
 		5C0D0E781F591772712EFB08 /* SubredditRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */; };
+		5C7C1DE86B921C9BEC82DED5 /* CLICommandCatalogConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0562480A128BF2812DB8536B /* CLICommandCatalogConfig.swift */; };
 		5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */; };
 		5E9E214B7FD7706B64F703BA /* PlannerTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3788B79517572C51854172CC /* PlannerTabView.swift */; };
 		5EC386BDC953ADC9C0C7FC1A /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
@@ -102,6 +104,7 @@
 		62761A56A55BD30D9D7FC87E /* PostingChecklistItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23399264919E264763449E07 /* PostingChecklistItems.swift */; };
 		632082721D97EB58E0370F81 /* CaptureLinksSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F38E7578683EAB7EC5530F4 /* CaptureLinksSection.swift */; };
 		637776DD2C3FE925B0CC3036 /* CaptureCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7D03EF7FAD1B0CBDC0A59 /* CaptureCardViewTests.swift */; };
+		6524163B6CD4A9E05F8AE337 /* CLICommandCatalogCaptures.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7532CAA943BDB70D1E3541 /* CLICommandCatalogCaptures.swift */; };
 		653447F7059B945ECF9657B2 /* CLIRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */; };
 		6559B6F6894A0EEE0C24A90A /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		6589D2CB4C0EE68009254627 /* RedditReminderCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BD88A85812A32DB0D0EF9E /* RedditReminderCLI.swift */; };
@@ -144,6 +147,7 @@
 		AD72D92BE212AF74D0BBDE44 /* CLISubredditManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9000531B86E8AB4A89157704 /* CLISubredditManager.swift */; };
 		AF81908B71E4E383D63467DD /* NotificationSettingsOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843A01564D830A81EEF54CF9 /* NotificationSettingsOpener.swift */; };
 		AFB9ADC77D8591C4C0C8724F /* CaptureMediaEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EA185EFDC5E3CF3A013B6D /* CaptureMediaEditing.swift */; };
+		B0B1FF17C923518B37F8412B /* CLICommandCatalogEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FB7AC7766A6364E04AFF37 /* CLICommandCatalogEvents.swift */; };
 		B0C340A0AB5DE1005CC425FC /* CLIProjectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85FE2A447522454CC9824DD4 /* CLIProjectManager.swift */; };
 		B0D0C0F6AAB6EDF25163D32B /* PlannerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99F26EE47E652BD2FEF295C /* PlannerPresentation.swift */; };
 		B10546669B16B587E5C2D40E /* NotificationSettingsOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AEC6DD3FA5A8034E07E6B9 /* NotificationSettingsOpenerTests.swift */; };
@@ -155,6 +159,7 @@
 		B9A0FFC6B8D690F11AC676EA /* CLIArgumentParserEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E937747CC61B8E422CE6018 /* CLIArgumentParserEvents.swift */; };
 		BA3588948937708CD83AFEBC /* CLIOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14A6B7A047D5672F9159659 /* CLIOutput.swift */; };
 		BA3B263D9D03FA844568F913 /* EventSourceSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */; };
+		BCC7F73AC96ABB112DB497F0 /* CLICommandCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F010AF0B52B3B20A9AF3FD10 /* CLICommandCatalog.swift */; };
 		BEE74F03864389AD3A108EFE /* BackupSettingsPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61052DF5F8EFC70EA9076106 /* BackupSettingsPersistence.swift */; };
 		BFFFDEA5E6BAD356DC03006F /* CLIDiscoveryTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D057AC06C4DF9C7404C609 /* CLIDiscoveryTypes.swift */; };
 		C09ACAB4043D4C29B0CCC0E7 /* OnboardingEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA51CEB234C228C79959816 /* OnboardingEmptyView.swift */; };
@@ -213,6 +218,7 @@
 		00BE11378DD3F2E280F890D6 /* BackupPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupPreviewTests.swift; sourceTree = "<group>"; };
 		04BBC25F859C9533DF9820A7 /* CaptureSubredditPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSubredditPicker.swift; sourceTree = "<group>"; };
 		050BB3D18ECE13E70E7CED42 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		0562480A128BF2812DB8536B /* CLICommandCatalogConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalogConfig.swift; sourceTree = "<group>"; };
 		0660CE7B44D0AAA9892ADBBD /* CRUDTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRUDTestSupport.swift; sourceTree = "<group>"; };
 		06AAE5BD6FAD212E9C9E5AAB /* CapturePersistenceActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePersistenceActionsTests.swift; sourceTree = "<group>"; };
 		07A63D3714291E8917CA1694 /* PopoverContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentView.swift; sourceTree = "<group>"; };
@@ -334,6 +340,7 @@
 		A94E8BF8DAD4FB3EAEB7B9D2 /* AppDelegateShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcuts.swift; sourceTree = "<group>"; };
 		ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		AD3C4FF9EDB23763DEF6DCBD /* CaptureMediaChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaChips.swift; sourceTree = "<group>"; };
+		AD7532CAA943BDB70D1E3541 /* CLICommandCatalogCaptures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalogCaptures.swift; sourceTree = "<group>"; };
 		AE1122ADEB6045619C303C31 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		AEE4E14F7A70E1A66FA994A3 /* Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture.swift; sourceTree = "<group>"; };
 		B14A6B7A047D5672F9159659 /* CLIOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOutput.swift; sourceTree = "<group>"; };
@@ -355,12 +362,14 @@
 		C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentActions.swift; sourceTree = "<group>"; };
 		C1DDFC92B31A2562246F8D58 /* CLIArgumentParserConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIArgumentParserConfig.swift; sourceTree = "<group>"; };
 		C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTestSupport.swift; sourceTree = "<group>"; };
+		C8C6DAB7D790FE62A62D947F /* CLICommandCatalogTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalogTypes.swift; sourceTree = "<group>"; };
 		C9AC123670C416604F87973B /* CLIEventTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIEventTypes.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
 		D08AEB86FFDCB22E4FB7E9F0 /* PlannerPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerPresentationTests.swift; sourceTree = "<group>"; };
 		D3E6715672E45708F5B3DDD5 /* CapturePerSubredditPostingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturePerSubredditPostingTests.swift; sourceTree = "<group>"; };
 		D483D5534D2A0BC4C03BC77B /* AppDelegateShortcutRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRegistrationTests.swift; sourceTree = "<group>"; };
 		D4925806B8E7919B5E93D38D /* AppModelContainerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModelContainerFactory.swift; sourceTree = "<group>"; };
+		D4FB7AC7766A6364E04AFF37 /* CLICommandCatalogEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalogEvents.swift; sourceTree = "<group>"; };
 		D5570C2EF1DD747B43C6F4ED /* PopoverChromeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverChromeViewTests.swift; sourceTree = "<group>"; };
 		D65088A443B0F0C62306146D /* BackupSettingsPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsPersistenceTests.swift; sourceTree = "<group>"; };
 		DCB15AEFC17C70DC66CA4A05 /* PostHandoffViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHandoffViewHelpers.swift; sourceTree = "<group>"; };
@@ -374,6 +383,7 @@
 		EB4A20FE04DD7075E02C7092 /* SubredditCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditCRUDTests.swift; sourceTree = "<group>"; };
 		EBC07E95FAB15C8EAB34E541 /* CaptureMediaAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaAccessibilityTests.swift; sourceTree = "<group>"; };
 		EC37D0F8A68C606C7A79ADA0 /* BackupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupServiceTests.swift; sourceTree = "<group>"; };
+		F010AF0B52B3B20A9AF3FD10 /* CLICommandCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalog.swift; sourceTree = "<group>"; };
 		F32050796326D457C67C1870 /* CLIFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIFilter.swift; sourceTree = "<group>"; };
 		F72682A4379AE1A17B7D4559 /* BackupTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupTypes.swift; sourceTree = "<group>"; };
 		F89CCDB745C6D3B557E3342A /* AppDelegateQA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateQA.swift; sourceTree = "<group>"; };
@@ -531,6 +541,11 @@
 				8E2755BD3961DE8EA13B8A1E /* CLIArgumentParserHelpers.swift */,
 				B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */,
 				736DAA72999AF48AFC9A849C /* CLICaptureLifecycle.swift */,
+				F010AF0B52B3B20A9AF3FD10 /* CLICommandCatalog.swift */,
+				AD7532CAA943BDB70D1E3541 /* CLICommandCatalogCaptures.swift */,
+				0562480A128BF2812DB8536B /* CLICommandCatalogConfig.swift */,
+				D4FB7AC7766A6364E04AFF37 /* CLICommandCatalogEvents.swift */,
+				C8C6DAB7D790FE62A62D947F /* CLICommandCatalogTypes.swift */,
 				77F3C79809C4BF0DD2B05AF6 /* CLIDiscoveryManager.swift */,
 				28D057AC06C4DF9C7404C609 /* CLIDiscoveryTypes.swift */,
 				3B81CF275655D5E1ECD5EC37 /* CLIDTOs.swift */,
@@ -832,6 +847,11 @@
 				E651BBE6C6C84CA44281F9B7 /* CLIArgumentParserHelpers.swift in Sources */,
 				D70537E281AB16807DE1E2FA /* CLICaptureCreator.swift in Sources */,
 				1690FE987E73EE0BB803779E /* CLICaptureLifecycle.swift in Sources */,
+				BCC7F73AC96ABB112DB497F0 /* CLICommandCatalog.swift in Sources */,
+				6524163B6CD4A9E05F8AE337 /* CLICommandCatalogCaptures.swift in Sources */,
+				5C7C1DE86B921C9BEC82DED5 /* CLICommandCatalogConfig.swift in Sources */,
+				B0B1FF17C923518B37F8412B /* CLICommandCatalogEvents.swift in Sources */,
+				13E7899C74330A230D4C5B35 /* CLICommandCatalogTypes.swift in Sources */,
 				8BDBD62791F99A373564D5B3 /* CLIDTOs.swift in Sources */,
 				E39C6204803369529EE71FA8 /* CLIDiscoveryManager.swift in Sources */,
 				BFFFDEA5E6BAD356DC03006F /* CLIDiscoveryTypes.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,12 +44,16 @@ redditreminder context show --json
 redditreminder context show --limit 5 --json
 redditreminder search all --query "launch" --json
 redditreminder search all --query "weekday" --limit 10 --json
+redditreminder commands list --json
+redditreminder commands show captures.create --json
 ```
 
 `context show` returns a compact snapshot of the workspace: counts, projects,
 subreddits with peak summaries, queued captures, active events, and peak presets.
 `search all` searches captures, events, projects, subreddits, and peak presets so
 agents can inspect the widget state without guessing which domain to query first.
+`commands list` and `commands show` return structured command metadata for agents:
+command ids, positionals, flags, examples, and output data shapes.
 
 ## Captures
 

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -156,6 +156,17 @@ assert_contains "context counts" "$context_snapshot" '"counts":'
 assert_contains "context subreddits" "$context_snapshot" '"subreddits":['
 assert_contains "context peak presets" "$context_snapshot" '"peakPresets":['
 
+commands_list="$(run_json commands list)"
+assert_contains "commands list ok" "$commands_list" '"ok":true'
+assert_contains "commands list captures create" "$commands_list" '"id":"captures.create"'
+assert_contains "commands list output" "$commands_list" '"output":'
+
+commands_show="$(run_json commands show captures.create)"
+assert_contains "commands show ok" "$commands_show" '"ok":true'
+assert_contains "commands show id" "$commands_show" '"id":"captures.create"'
+assert_contains "commands show media flag" "$commands_show" '"name":"--media"'
+assert_contains "commands show output kind" "$commands_show" '"data":"captureCreated"'
+
 peak_reset="$(run_json peaks reset SideProject)"
 assert_contains "peak reset" "$peak_reset" '"ok":true'
 


### PR DESCRIPTION
## Summary
- add commands list/show for structured agent-facing CLI metadata
- document command ids, positionals, flags, examples, and output data shapes
- add CLI smoke coverage for catalog discovery

## Verification
- make cli-test
- make build-debug
- ./scripts/format-check.sh
- make test
- make install-cli
- ~/bin/redditreminder commands list --json
- ~/bin/redditreminder commands show captures.create --json