### PR TITLE
Add CLI catalog drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           filters: |
             code:
+              - 'CLI/**'
               - 'Sources/**'
               - 'Tests/**'
               - 'Resources/**'
@@ -160,6 +161,26 @@ jobs:
             coverage.json
           retention-days: 14
 
+  cli-tests:
+    name: CLI Tests
+    runs-on: macos-15
+    timeout-minutes: 15
+    needs: [detect-changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' ||
+       needs.detect-changes.outputs.code == 'true')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+      - name: Install xcodegen
+        run: brew install xcodegen
+      - name: Run CLI tests
+        run: make cli-test
+
   file-size-check:
     name: File Size Check
     runs-on: macos-latest
@@ -189,6 +210,7 @@ jobs:
       - lint
       - build
       - unit-tests
+      - cli-tests
       - file-size-check
     steps:
       - name: Check required jobs
@@ -196,10 +218,11 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_RESULT: ${{ needs.unit-tests.result }}
+          CLI_TEST_RESULT: ${{ needs.cli-tests.result }}
           SIZE_RESULT: ${{ needs.file-size-check.result }}
         run: |
-          echo "Lint: $LINT_RESULT, Build: $BUILD_RESULT, Tests: $TEST_RESULT, Size: $SIZE_RESULT"
-          for result in "$LINT_RESULT" "$BUILD_RESULT" "$TEST_RESULT" "$SIZE_RESULT"; do
+          echo "Lint: $LINT_RESULT, Build: $BUILD_RESULT, Tests: $TEST_RESULT, CLI: $CLI_TEST_RESULT, Size: $SIZE_RESULT"
+          for result in "$LINT_RESULT" "$BUILD_RESULT" "$TEST_RESULT" "$CLI_TEST_RESULT" "$SIZE_RESULT"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "A required job reported: $result"
               exit 1

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ test: generate
 
 cli-test: build-cli
 	./scripts/cli-smoke.sh "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
+	./scripts/cli-catalog-check.py "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
 
 ui-test: generate
 	xcodebuild test \

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def fail(message):
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def parser_routes(repo_root):
+    invocation = repo_root / "CLI" / "Sources" / "CLIInvocation.swift"
+    source = invocation.read_text()
+    matches = re.findall(r'case \("([^"]+)", "([^"]+)"\):', source)
+    if not matches:
+        fail("no parser routes found in CLIInvocation.swift")
+    return {f"{domain}.{command}" for domain, command in matches}
+
+
+def command_catalog(cli):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = str(Path(tmpdir) / "redditreminder-cli.store")
+        result = subprocess.run(
+            [cli, "--json", "--store", store, "commands", "list"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    if result.returncode != 0:
+        fail(f"commands list failed: {result.stderr.strip()}")
+    payload = json.loads(result.stdout)
+    if not payload.get("ok"):
+        fail("commands list returned ok=false")
+    return payload["data"]
+
+
+def validate_catalog(cli, catalog):
+    ids = [command["id"] for command in catalog]
+    duplicates = sorted({command_id for command_id in ids if ids.count(command_id) > 1})
+    if duplicates:
+        fail(f"duplicate command catalog ids: {', '.join(duplicates)}")
+
+    for command in catalog:
+        command_id = command["id"]
+        expected_id = f'{command["domain"]}.{command["command"]}'
+        if command_id != expected_id:
+            fail(f"{command_id} domain/command mismatch: expected {expected_id}")
+        for field in ("summary", "examples", "output"):
+            if not command.get(field):
+                fail(f"{command_id} missing {field}")
+        shown = subprocess.run(
+            [cli, "--json", "commands", "show", command_id],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if shown.returncode != 0:
+            fail(f"commands show failed for {command_id}: {shown.stderr.strip()}")
+        payload = json.loads(shown.stdout)
+        if payload.get("data", {}).get("id") != command_id:
+            fail(f"commands show returned wrong id for {command_id}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        fail("usage: cli-catalog-check.py PATH_TO_REDDITREMINDER_CLI")
+
+    cli = sys.argv[1]
+    repo_root = Path(__file__).resolve().parents[1]
+    routes = parser_routes(repo_root)
+    catalog = command_catalog(cli)
+    validate_catalog(cli, catalog)
+    catalog_ids = {command["id"] for command in catalog}
+
+    missing = sorted(routes - catalog_ids)
+    extra = sorted(catalog_ids - routes)
+    if missing or extra:
+        details = []
+        if missing:
+            details.append(f"missing catalog ids: {', '.join(missing)}")
+        if extra:
+            details.append(f"catalog ids without parser routes: {', '.join(extra)}")
+        fail("; ".join(details))
+
+    print(f"CLI command catalog covers {len(routes)} parser routes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CLI catalog guard that compares parser routes in CLIInvocation.swift with runtime commands list output
- validate catalog uniqueness, required metadata, id/domain/command consistency, and commands show for each id
- run the CLI smoke and catalog guard from make cli-test in CI
- include CLI/** in the CI path filter so CLI-only PRs run checks

## Verification
- make cli-test
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- git diff --check