### PR TITLE
Add CLI agent recipes

### DIFF
--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -52,6 +52,19 @@ enum CLICommandCatalog {
       examples: ["redditreminder --json commands show captures.create"],
       output: output("commandReference", "One command reference object.")
     ),
+    command(
+      "recipes.list", "recipes", "list",
+      "Return agent workflow recipes.",
+      examples: ["redditreminder --json recipes list"],
+      output: output("recipeReferences", "Array of recipe reference objects.")
+    ),
+    command(
+      "recipes.show", "recipes", "show",
+      "Return one agent workflow recipe.",
+      positionals: [arg("id", "Recipe id, for example posting.create-with-media.")],
+      examples: ["redditreminder --json recipes show posting.create-with-media"],
+      output: output("recipeReference", "One recipe reference object.")
+    ),
   ]
 
   static func command(

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -29,3 +29,26 @@ struct CommandOutputDTO: Encodable {
   let data: String
   let summary: String
 }
+
+struct RecipeReferenceDTO: Encodable {
+  let id: String
+  let summary: String
+  let goal: String
+  let inputs: [RecipeInputDTO]
+  let steps: [RecipeStepDTO]
+  let examples: [String]
+  let relatedCommands: [String]
+}
+
+struct RecipeInputDTO: Encodable {
+  let name: String
+  let required: Bool
+  let summary: String
+}
+
+struct RecipeStepDTO: Encodable {
+  let order: Int
+  let commandId: String
+  let purpose: String
+  let example: String
+}

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -18,6 +18,8 @@ enum CLIResponseData: Encodable {
   case context(ContextDTO)
   case commandReferences([CommandReferenceDTO])
   case commandReference(CommandReferenceDTO)
+  case recipeReferences([RecipeReferenceDTO])
+  case recipeReference(RecipeReferenceDTO)
   case dryRun(String)
 
   func encode(to encoder: Encoder) throws {
@@ -40,6 +42,8 @@ enum CLIResponseData: Encodable {
     case .context(let value): try container.encode(value)
     case .commandReferences(let value): try container.encode(value)
     case .commandReference(let value): try container.encode(value)
+    case .recipeReferences(let value): try container.encode(value)
+    case .recipeReference(let value): try container.encode(value)
     case .dryRun(let value): try container.encode(["message": value])
     }
   }

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -50,6 +50,8 @@ enum CLICommand {
   case contextShow(ContextInput)
   case commandsList
   case commandsShow(id: String)
+  case recipesList
+  case recipesShow(id: String)
 
   init(domain: String, action: String, parser: inout CLIArgumentParser) throws {
     switch (domain, action) {
@@ -123,6 +125,10 @@ enum CLICommand {
       self = .commandsList
     case ("commands", "show"):
       self = .commandsShow(id: try parser.consumeRequiredArgument(label: "command id"))
+    case ("recipes", "list"):
+      self = .recipesList
+    case ("recipes", "show"):
+      self = .recipesShow(id: try parser.consumeRequiredArgument(label: "recipe id"))
     default:
       throw CLIError.usage(CLIHelp.domain(domain))
     }

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -78,6 +78,10 @@ enum CLIPrinter {
       return commands.map { "\($0.id) - \($0.summary)" }.joined(separator: "\n")
     case .commandReference(let command):
       return "\(command.id) - \(command.summary)"
+    case .recipeReferences(let recipes):
+      return recipes.map { "\($0.id) - \($0.summary)" }.joined(separator: "\n")
+    case .recipeReference(let recipe):
+      return "\(recipe.id) - \(recipe.summary)"
     case .dryRun(let message): return message
     }
   }
@@ -117,7 +121,7 @@ enum CLIHelp {
   static let root = """
     Usage: redditreminder [--json] [--pretty] [--dry-run] [--store PATH] <domain> <command>
 
-    Domains: captures, events, projects, subreddits, peaks, search, context, commands
+    Domains: captures, events, projects, subreddits, peaks, search, context, commands, recipes
     """
 
   static func domain(_ domain: String) -> String {
@@ -132,6 +136,7 @@ enum CLIHelp {
     case "search": return "Usage: redditreminder search all --query TEXT [--limit N]"
     case "context": return "Usage: redditreminder context show [--limit N]"
     case "commands": return "Usage: redditreminder commands list|show"
+    case "recipes": return "Usage: redditreminder recipes list|show"
     default: return root
     }
   }

--- a/CLI/Sources/CLIRecipeCatalog.swift
+++ b/CLI/Sources/CLIRecipeCatalog.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+enum CLIRecipeCatalog {
+  static func list() -> CLIResponse {
+    .success(data: .recipeReferences(recipes))
+  }
+
+  static func show(id input: String) throws -> CLIResponse {
+    let normalized = input.lowercased()
+    guard let recipe = recipes.first(where: { $0.id == normalized }) else {
+      throw CLIError.notFound("Recipe not found: \(input)")
+    }
+    return .success(data: .recipeReference(recipe))
+  }
+
+  static let recipes: [RecipeReferenceDTO] = [
+    recipe(
+      "posting.create-with-media",
+      "Create a queued post with image media and a due posting window.",
+      goal: "Given a title, body, image path, subreddit, and due date, create the capture and its posting-window event.",
+      inputs: [
+        input("title", "Post title."),
+        input("text", "Post body."),
+        input("mediaPath", "Local image path to attach."),
+        input("subreddit", "Existing subreddit name or id."),
+        input("due", "ISO8601 posting-window date."),
+        input("project", "Optional existing project name or id.", required: false),
+      ],
+      steps: [
+        step(
+          1, "subreddits.search",
+          "Confirm the subreddit already exists in the workspace.",
+          "redditreminder --json subreddits search --query SideProject"),
+        step(
+          2, "captures.create",
+          "Create the queued capture, copy media, and add a due event.",
+          "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"),
+        step(
+          3, "context.show",
+          "Verify the queued capture and upcoming event are visible.",
+          "redditreminder --json context show --limit 5"),
+      ],
+      examples: ["redditreminder --json recipes show posting.create-with-media"],
+      relatedCommands: ["subreddits.search", "captures.create", "context.show"]
+    ),
+    recipe(
+      "workspace.recommend-targets",
+      "Inspect the workspace before recommending subreddits and times.",
+      goal: "Gather enough state to recommend where and when a draft should be posted without mutating data.",
+      inputs: [
+        input("topic", "Topic or launch text to search for."),
+        input("limit", "Maximum rows per context collection.", required: false),
+      ],
+      steps: [
+        step(
+          1, "context.show",
+          "Read projects, subreddits, peak summaries, queued captures, events, and presets.",
+          "redditreminder --json context show --limit 10"),
+        step(
+          2, "search.all",
+          "Find matching captures, events, projects, subreddits, and presets.",
+          "redditreminder --json search all --query launch --limit 10"),
+        step(
+          3, "peaks.presets",
+          "Inspect bundled peak-time patterns when a subreddit has no override.",
+          "redditreminder --json peaks presets"),
+      ],
+      examples: ["redditreminder --json recipes show workspace.recommend-targets"],
+      relatedCommands: ["context.show", "search.all", "peaks.presets"]
+    ),
+    recipe(
+      "subreddit.configure-peak-times",
+      "Add or verify a subreddit and configure its peak posting windows.",
+      goal: "Create a subreddit safely, then apply local peak days and hours used to generate posting events.",
+      inputs: [
+        input("subreddit", "Subreddit name or Reddit URL."),
+        input("days", "Comma-separated day keys such as mon,wed,fri."),
+        input("hours", "Comma-separated local hours 0-23."),
+        input("timezone", "Optional IANA timezone id.", required: false),
+      ],
+      steps: [
+        step(
+          1, "subreddits.verify",
+          "Check Reddit before saving if the user wants real-subreddit validation.",
+          "redditreminder --json subreddits verify SideProject"),
+        step(
+          2, "subreddits.add",
+          "Add the subreddit, using --verify when validation is required.",
+          "redditreminder --json subreddits add --verify SideProject"),
+        step(
+          3, "peaks.set",
+          "Apply local peak days and hours; generated events resync automatically.",
+          "redditreminder --json peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"),
+        step(
+          4, "peaks.get",
+          "Confirm the effective peak configuration.",
+          "redditreminder --json peaks get SideProject"),
+      ],
+      examples: ["redditreminder --json recipes show subreddit.configure-peak-times"],
+      relatedCommands: ["subreddits.verify", "subreddits.add", "peaks.set", "peaks.get"]
+    ),
+  ]
+
+  static func recipe(
+    _ id: String,
+    _ summary: String,
+    goal: String,
+    inputs: [RecipeInputDTO],
+    steps: [RecipeStepDTO],
+    examples: [String],
+    relatedCommands: [String]
+  ) -> RecipeReferenceDTO {
+    RecipeReferenceDTO(
+      id: id,
+      summary: summary,
+      goal: goal,
+      inputs: inputs,
+      steps: steps,
+      examples: examples,
+      relatedCommands: relatedCommands)
+  }
+
+  static func input(_ name: String, _ summary: String, required: Bool = true) -> RecipeInputDTO {
+    RecipeInputDTO(name: name, required: required, summary: summary)
+  }
+
+  static func step(
+    _ order: Int,
+    _ commandId: String,
+    _ purpose: String,
+    _ example: String
+  ) -> RecipeStepDTO {
+    RecipeStepDTO(order: order, commandId: commandId, purpose: purpose, example: example)
+  }
+}

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -79,6 +79,10 @@ final class CLIRunner {
       return CLICommandCatalog.list()
     case .commandsShow(let id):
       return try CLICommandCatalog.show(id: id)
+    case .recipesList:
+      return CLIRecipeCatalog.list()
+    case .recipesShow(let id):
+      return try CLIRecipeCatalog.show(id: id)
     }
   }
 

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		F4DE010F9076D36DD9D98288 /* AppModelContainerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4925806B8E7919B5E93D38D /* AppModelContainerFactory.swift */; };
 		F6781299CF04A1812240EAF0 /* DefaultSubreddits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD69E89EE2DA46D1776595 /* DefaultSubreddits.swift */; };
 		F9153795ADCFF105BE3F348A /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599273192FBCFDD93D1241B0 /* Project.swift */; };
+		F94C03AEBAB43FA4AB4910FD /* CLIRecipeCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4143AED39BD8255725DAC766 /* CLIRecipeCatalog.swift */; };
 		FBD66F35A1175B467D83C4B6 /* PreferencesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C958510062F2EAA969645F8 /* PreferencesViewTests.swift */; };
 		FE03D040E4D6926755545F71 /* RRuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */; };
 		FF322C47FE562D97B67F090E /* peak-times.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BDDF7799BF55CF7FFC730BA /* peak-times.json */; };
@@ -261,6 +262,7 @@
 		3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditRowHelpers.swift; sourceTree = "<group>"; };
 		409B11556A9191FFF70BA98B /* EventSourceSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSourceSummaryTests.swift; sourceTree = "<group>"; };
 		40A4D807E91E15E3C1B5275C /* UrgencyPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrgencyPresentationTests.swift; sourceTree = "<group>"; };
+		4143AED39BD8255725DAC766 /* CLIRecipeCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRecipeCatalog.swift; sourceTree = "<group>"; };
 		416AAA3BB8DC7EFE8E6CB262 /* PopoverContentRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentRoutes.swift; sourceTree = "<group>"; };
 		46EA039404A90BBBD3CECD15 /* RRuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleHelper.swift; sourceTree = "<group>"; };
 		4758BE68EE85AA3FA2EA4DC4 /* DefaultSubredditsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubredditsTests.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				4F701778EF6152A8C9E643D1 /* CLIInvocation.swift */,
 				B14A6B7A047D5672F9159659 /* CLIOutput.swift */,
 				85FE2A447522454CC9824DD4 /* CLIProjectManager.swift */,
+				4143AED39BD8255725DAC766 /* CLIRecipeCatalog.swift */,
 				97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */,
 				9000531B86E8AB4A89157704 /* CLISubredditManager.swift */,
 				FACB9393BCF9FAB1070EEFD8 /* CLISubredditVerifier.swift */,
@@ -861,6 +864,7 @@
 				57B9C5EC4885B1A711755BCF /* CLIInvocation.swift in Sources */,
 				BA3588948937708CD83AFEBC /* CLIOutput.swift in Sources */,
 				B0C340A0AB5DE1005CC425FC /* CLIProjectManager.swift in Sources */,
+				F94C03AEBAB43FA4AB4910FD /* CLIRecipeCatalog.swift in Sources */,
 				653447F7059B945ECF9657B2 /* CLIRunner.swift in Sources */,
 				AD72D92BE212AF74D0BBDE44 /* CLISubredditManager.swift in Sources */,
 				414614EDB4705F4BAB10EAB7 /* CLISubredditVerifier.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,8 @@ redditreminder search all --query "launch" --json
 redditreminder search all --query "weekday" --limit 10 --json
 redditreminder commands list --json
 redditreminder commands show captures.create --json
+redditreminder recipes list --json
+redditreminder recipes show posting.create-with-media --json
 ```
 
 `context show` returns a compact snapshot of the workspace: counts, projects,
@@ -54,6 +56,8 @@ subreddits with peak summaries, queued captures, active events, and peak presets
 agents can inspect the widget state without guessing which domain to query first.
 `commands list` and `commands show` return structured command metadata for agents:
 command ids, positionals, flags, examples, and output data shapes.
+`recipes list` and `recipes show` return higher-level agent workflows: expected
+inputs, ordered command steps, example invocations, and related command ids.
 
 ## Captures
 

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -21,22 +21,30 @@ def parser_routes(repo_root):
     return {f"{domain}.{command}" for domain, command in matches}
 
 
-def command_catalog(cli):
+def cli_json(cli, arguments):
     with tempfile.TemporaryDirectory() as tmpdir:
         store = str(Path(tmpdir) / "redditreminder-cli.store")
         result = subprocess.run(
-            [cli, "--json", "--store", store, "commands", "list"],
+            [cli, "--json", "--store", store, *arguments],
             check=False,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
     if result.returncode != 0:
-        fail(f"commands list failed: {result.stderr.strip()}")
+        fail(f"{' '.join(arguments)} failed: {result.stderr.strip()}")
     payload = json.loads(result.stdout)
     if not payload.get("ok"):
-        fail("commands list returned ok=false")
-    return payload["data"]
+        fail(f"{' '.join(arguments)} returned ok=false")
+    return payload
+
+
+def command_catalog(cli):
+    return cli_json(cli, ["commands", "list"])["data"]
+
+
+def recipe_catalog(cli):
+    return cli_json(cli, ["recipes", "list"])["data"]
 
 
 def validate_catalog(cli, catalog):
@@ -67,6 +75,27 @@ def validate_catalog(cli, catalog):
             fail(f"commands show returned wrong id for {command_id}")
 
 
+def validate_recipes(cli, recipes, command_ids):
+    ids = [recipe["id"] for recipe in recipes]
+    duplicates = sorted({recipe_id for recipe_id in ids if ids.count(recipe_id) > 1})
+    if duplicates:
+        fail(f"duplicate recipe ids: {', '.join(duplicates)}")
+
+    for recipe in recipes:
+        recipe_id = recipe["id"]
+        for field in ("summary", "goal", "inputs", "steps", "examples", "relatedCommands"):
+            if not recipe.get(field):
+                fail(f"{recipe_id} missing {field}")
+        shown = cli_json(cli, ["recipes", "show", recipe_id])
+        if shown.get("data", {}).get("id") != recipe_id:
+            fail(f"recipes show returned wrong id for {recipe_id}")
+        related = set(recipe["relatedCommands"])
+        step_commands = {step["commandId"] for step in recipe["steps"]}
+        unknown = sorted((related | step_commands) - command_ids)
+        if unknown:
+            fail(f"{recipe_id} references unknown commands: {', '.join(unknown)}")
+
+
 def main():
     if len(sys.argv) != 2:
         fail("usage: cli-catalog-check.py PATH_TO_REDDITREMINDER_CLI")
@@ -77,6 +106,8 @@ def main():
     catalog = command_catalog(cli)
     validate_catalog(cli, catalog)
     catalog_ids = {command["id"] for command in catalog}
+    recipes = recipe_catalog(cli)
+    validate_recipes(cli, recipes, catalog_ids)
 
     missing = sorted(routes - catalog_ids)
     extra = sorted(catalog_ids - routes)
@@ -88,7 +119,7 @@ def main():
             details.append(f"catalog ids without parser routes: {', '.join(extra)}")
         fail("; ".join(details))
 
-    print(f"CLI command catalog covers {len(routes)} parser routes")
+    print(f"CLI command catalog covers {len(routes)} parser routes and {len(recipes)} recipes")
 
 
 if __name__ == "__main__":

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -167,6 +167,17 @@ assert_contains "commands show id" "$commands_show" '"id":"captures.create"'
 assert_contains "commands show media flag" "$commands_show" '"name":"--media"'
 assert_contains "commands show output kind" "$commands_show" '"data":"captureCreated"'
 
+recipes_list="$(run_json recipes list)"
+assert_contains "recipes list ok" "$recipes_list" '"ok":true'
+assert_contains "recipes list create media" "$recipes_list" '"id":"posting.create-with-media"'
+assert_contains "recipes list steps" "$recipes_list" '"steps":'
+
+recipes_show="$(run_json recipes show posting.create-with-media)"
+assert_contains "recipes show ok" "$recipes_show" '"ok":true'
+assert_contains "recipes show id" "$recipes_show" '"id":"posting.create-with-media"'
+assert_contains "recipes show capture command" "$recipes_show" '"commandId":"captures.create"'
+assert_contains "recipes show related commands" "$recipes_show" '"relatedCommands":'
+
 peak_reset="$(run_json peaks reset SideProject)"
 assert_contains "peak reset" "$peak_reset" '"ok":true'
 


### PR DESCRIPTION
## Summary
- add read-only recipes list/show commands for higher-level agent workflows
- include recipe inputs, ordered command steps, examples, and related command ids
- register recipes list/show in the command catalog
- extend CLI smoke and catalog checks to validate recipe command references

## Verification
- make cli-test
- make build-debug
- ./scripts/format-check.sh
- git diff --check