### PR TITLE
Add CLI recipe search

### DIFF
--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -59,6 +59,13 @@ enum CLICommandCatalog {
       output: output("recipeReferences", "Array of recipe reference objects.")
     ),
     command(
+      "recipes.search", "recipes", "search",
+      "Search agent workflow recipes by intent text.",
+      flags: [flag("--query", "TEXT", "Search text.", required: true)],
+      examples: ["redditreminder --json recipes search --query media"],
+      output: output("recipeReferences", "Array of matching recipe reference objects.")
+    ),
+    command(
       "recipes.show", "recipes", "show",
       "Return one agent workflow recipe.",
       positionals: [arg("id", "Recipe id, for example posting.create-with-media.")],

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -51,6 +51,7 @@ enum CLICommand {
   case commandsList
   case commandsShow(id: String)
   case recipesList
+  case recipesSearch(query: String)
   case recipesShow(id: String)
 
   init(domain: String, action: String, parser: inout CLIArgumentParser) throws {
@@ -127,6 +128,8 @@ enum CLICommand {
       self = .commandsShow(id: try parser.consumeRequiredArgument(label: "command id"))
     case ("recipes", "list"):
       self = .recipesList
+    case ("recipes", "search"):
+      self = .recipesSearch(query: try parser.consumeRequiredValue(for: "--query"))
     case ("recipes", "show"):
       self = .recipesShow(id: try parser.consumeRequiredArgument(label: "recipe id"))
     default:

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -136,7 +136,7 @@ enum CLIHelp {
     case "search": return "Usage: redditreminder search all --query TEXT [--limit N]"
     case "context": return "Usage: redditreminder context show [--limit N]"
     case "commands": return "Usage: redditreminder commands list|show"
-    case "recipes": return "Usage: redditreminder recipes list|show"
+    case "recipes": return "Usage: redditreminder recipes list|search|show"
     default: return root
     }
   }

--- a/CLI/Sources/CLIRecipeCatalog.swift
+++ b/CLI/Sources/CLIRecipeCatalog.swift
@@ -5,12 +5,32 @@ enum CLIRecipeCatalog {
     .success(data: .recipeReferences(recipes))
   }
 
+  static func search(query: String) -> CLIResponse {
+    .success(
+      data: .recipeReferences(
+        CLIFilter.items(recipes, query: query, searchableText: searchableText)))
+  }
+
   static func show(id input: String) throws -> CLIResponse {
     let normalized = input.lowercased()
     guard let recipe = recipes.first(where: { $0.id == normalized }) else {
       throw CLIError.notFound("Recipe not found: \(input)")
     }
     return .success(data: .recipeReference(recipe))
+  }
+
+  private static func searchableText(for recipe: RecipeReferenceDTO) -> String {
+    (
+      [
+        recipe.id,
+        recipe.summary,
+        recipe.goal,
+        recipe.examples.joined(separator: " "),
+        recipe.relatedCommands.joined(separator: " "),
+      ]
+      + recipe.inputs.map { "\($0.name) \($0.summary)" }
+      + recipe.steps.map { "\($0.commandId) \($0.purpose) \($0.example)" }
+    ).joined(separator: " ")
   }
 
   static let recipes: [RecipeReferenceDTO] = [

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -81,6 +81,8 @@ final class CLIRunner {
       return try CLICommandCatalog.show(id: id)
     case .recipesList:
       return CLIRecipeCatalog.list()
+    case .recipesSearch(let query):
+      return CLIRecipeCatalog.search(query: query)
     case .recipesShow(let id):
       return try CLIRecipeCatalog.show(id: id)
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,7 @@ redditreminder search all --query "weekday" --limit 10 --json
 redditreminder commands list --json
 redditreminder commands show captures.create --json
 redditreminder recipes list --json
+redditreminder recipes search --query "media" --json
 redditreminder recipes show posting.create-with-media --json
 ```
 
@@ -56,8 +57,9 @@ subreddits with peak summaries, queued captures, active events, and peak presets
 agents can inspect the widget state without guessing which domain to query first.
 `commands list` and `commands show` return structured command metadata for agents:
 command ids, positionals, flags, examples, and output data shapes.
-`recipes list` and `recipes show` return higher-level agent workflows: expected
-inputs, ordered command steps, example invocations, and related command ids.
+`recipes list`, `recipes search`, and `recipes show` return higher-level agent
+workflows: expected inputs, ordered command steps, example invocations, and
+related command ids.
 
 ## Captures
 

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -95,6 +95,11 @@ def validate_recipes(cli, recipes, command_ids):
         if unknown:
             fail(f"{recipe_id} references unknown commands: {', '.join(unknown)}")
 
+    search = cli_json(cli, ["recipes", "search", "--query", "media"])
+    search_ids = {recipe["id"] for recipe in search["data"]}
+    if "posting.create-with-media" not in search_ids:
+        fail("recipes search did not return posting.create-with-media for media")
+
 
 def main():
     if len(sys.argv) != 2:

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -37,6 +37,18 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "FAIL: $label" >&2
+    echo "Expected output not to contain: $needle" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
 mkdir -p "$TMP_DIR/mock/r/SideProject" "$TMP_DIR/mock/r/MissingSub"
 printf '{"data":{"display_name_prefixed":"r/SideProject","title":"Side Project","subscribers":12345,"over18":false}}' \
   >"$TMP_DIR/mock/r/SideProject/about.json"
@@ -171,6 +183,11 @@ recipes_list="$(run_json recipes list)"
 assert_contains "recipes list ok" "$recipes_list" '"ok":true'
 assert_contains "recipes list create media" "$recipes_list" '"id":"posting.create-with-media"'
 assert_contains "recipes list steps" "$recipes_list" '"steps":'
+
+recipes_search="$(run_json recipes search --query media)"
+assert_contains "recipes search ok" "$recipes_search" '"ok":true'
+assert_contains "recipes search create media" "$recipes_search" '"id":"posting.create-with-media"'
+assert_not_contains "recipes search excludes peak recipe" "$recipes_search" '"id":"subreddit.configure-peak-times"'
 
 recipes_show="$(run_json recipes show posting.create-with-media)"
 assert_contains "recipes show ok" "$recipes_show" '"ok":true'


### PR DESCRIPTION
## Summary
- add recipes search --query TEXT for agent workflow discovery by intent
- search across recipe ids, summaries, goals, inputs, steps, examples, and related command ids
- register recipes.search in the command catalog and help text
- extend CLI smoke/catalog checks and docs

## Verification
- make cli-test
- ./scripts/format-check.sh
- git diff --check