### PR TITLE
Add schema versions to CLI metadata

### DIFF
--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -85,6 +85,7 @@ enum CLICommandCatalog {
     output: CommandOutputDTO
   ) -> CommandReferenceDTO {
     CommandReferenceDTO(
+      schemaVersion: 1,
       id: id,
       domain: domain,
       command: command,

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct CommandReferenceDTO: Encodable {
+  let schemaVersion: Int
   let id: String
   let domain: String
   let command: String
@@ -31,6 +32,7 @@ struct CommandOutputDTO: Encodable {
 }
 
 struct RecipeReferenceDTO: Encodable {
+  let schemaVersion: Int
   let id: String
   let summary: String
   let goal: String

--- a/CLI/Sources/CLIRecipeCatalog.swift
+++ b/CLI/Sources/CLIRecipeCatalog.swift
@@ -131,6 +131,7 @@ enum CLIRecipeCatalog {
     relatedCommands: [String]
   ) -> RecipeReferenceDTO {
     RecipeReferenceDTO(
+      schemaVersion: 1,
       id: id,
       summary: summary,
       goal: goal,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,10 +56,10 @@ subreddits with peak summaries, queued captures, active events, and peak presets
 `search all` searches captures, events, projects, subreddits, and peak presets so
 agents can inspect the widget state without guessing which domain to query first.
 `commands list` and `commands show` return structured command metadata for agents:
-command ids, positionals, flags, examples, and output data shapes.
+schema versions, command ids, positionals, flags, examples, and output data shapes.
 `recipes list`, `recipes search`, and `recipes show` return higher-level agent
-workflows: expected inputs, ordered command steps, example invocations, and
-related command ids.
+workflows: schema versions, expected inputs, ordered command steps, example
+invocations, and related command ids.
 
 ## Captures
 

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -55,6 +55,8 @@ def validate_catalog(cli, catalog):
 
     for command in catalog:
         command_id = command["id"]
+        if command.get("schemaVersion") != 1:
+            fail(f"{command_id} missing schemaVersion 1")
         expected_id = f'{command["domain"]}.{command["command"]}'
         if command_id != expected_id:
             fail(f"{command_id} domain/command mismatch: expected {expected_id}")
@@ -83,6 +85,8 @@ def validate_recipes(cli, recipes, command_ids):
 
     for recipe in recipes:
         recipe_id = recipe["id"]
+        if recipe.get("schemaVersion") != 1:
+            fail(f"{recipe_id} missing schemaVersion 1")
         for field in ("summary", "goal", "inputs", "steps", "examples", "relatedCommands"):
             if not recipe.get(field):
                 fail(f"{recipe_id} missing {field}")

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -171,6 +171,7 @@ assert_contains "context peak presets" "$context_snapshot" '"peakPresets":['
 commands_list="$(run_json commands list)"
 assert_contains "commands list ok" "$commands_list" '"ok":true'
 assert_contains "commands list captures create" "$commands_list" '"id":"captures.create"'
+assert_contains "commands list schema" "$commands_list" '"schemaVersion":1'
 assert_contains "commands list output" "$commands_list" '"output":'
 
 commands_show="$(run_json commands show captures.create)"
@@ -182,6 +183,7 @@ assert_contains "commands show output kind" "$commands_show" '"data":"captureCre
 recipes_list="$(run_json recipes list)"
 assert_contains "recipes list ok" "$recipes_list" '"ok":true'
 assert_contains "recipes list create media" "$recipes_list" '"id":"posting.create-with-media"'
+assert_contains "recipes list schema" "$recipes_list" '"schemaVersion":1'
 assert_contains "recipes list steps" "$recipes_list" '"steps":'
 
 recipes_search="$(run_json recipes search --query media)"


### PR DESCRIPTION
## Summary
- add schemaVersion: 1 to command reference JSON
- add schemaVersion: 1 to recipe reference JSON
- require schemaVersion in CLI catalog validation
- document the versioned metadata shape and smoke-check it

## Verification
- make cli-test
- ./scripts/format-check.sh
- git diff --check
- manual schemaVersion check for commands.show and recipes.show