### PR TITLE
Add dry-run CLI recipes

### DIFF
--- a/CLI/Sources/CLIRecipeCatalog.swift
+++ b/CLI/Sources/CLIRecipeCatalog.swift
@@ -33,7 +33,9 @@ enum CLIRecipeCatalog {
     ).joined(separator: " ")
   }
 
-  static let recipes: [RecipeReferenceDTO] = [
+  static let recipes: [RecipeReferenceDTO] = coreRecipes + dryRunRecipes
+
+  static let coreRecipes: [RecipeReferenceDTO] = [
     recipe(
       "posting.create-with-media",
       "Create a queued post with image media and a due posting window.",

--- a/CLI/Sources/CLIRecipeCatalogDryRun.swift
+++ b/CLI/Sources/CLIRecipeCatalogDryRun.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+extension CLIRecipeCatalog {
+  static let dryRunRecipes: [RecipeReferenceDTO] = [
+    recipe(
+      "posting.create-with-media-dry-run",
+      "Safely preview and then create a queued post with image media.",
+      goal: "Inspect state, preview capture creation with --dry-run, wait for confirmation, execute the create, and verify the result.",
+      inputs: [
+        input("title", "Post title."),
+        input("text", "Post body."),
+        input("mediaPath", "Local image path to attach."),
+        input("subreddit", "Existing subreddit name or id."),
+        input("due", "ISO8601 posting-window date."),
+        input("project", "Optional existing project name or id.", required: false),
+      ],
+      steps: [
+        step(
+          1, "context.show",
+          "Inspect current projects, subreddits, queued captures, and upcoming events.",
+          "redditreminder --json context show --limit 10"),
+        step(
+          2, "subreddits.search",
+          "Confirm the target subreddit exists before previewing the mutation.",
+          "redditreminder --json subreddits search --query SideProject"),
+        step(
+          3, "captures.create",
+          "Preview the capture creation without saving app data.",
+          "redditreminder --json --dry-run captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"),
+        step(
+          4, "captures.create",
+          "After user confirmation, create the capture and due posting-window event.",
+          "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"),
+        step(
+          5, "context.show",
+          "Verify the queued capture and event are visible.",
+          "redditreminder --json context show --limit 10"),
+      ],
+      examples: ["redditreminder --json recipes show posting.create-with-media-dry-run"],
+      relatedCommands: ["context.show", "subreddits.search", "captures.create"]
+    ),
+    recipe(
+      "subreddit.configure-peak-times-dry-run",
+      "Safely preview and then configure subreddit peak times.",
+      goal: "Verify the subreddit, inspect current peak settings, preview the peak override, wait for confirmation, apply it, and verify generated events.",
+      inputs: [
+        input("subreddit", "Existing subreddit name or id."),
+        input("days", "Comma-separated day keys such as mon,wed,fri."),
+        input("hours", "Comma-separated local hours 0-23."),
+        input("timezone", "Optional IANA timezone id.", required: false),
+      ],
+      steps: [
+        step(
+          1, "subreddits.verify",
+          "Optionally verify the subreddit exists on Reddit before changing local config.",
+          "redditreminder --json subreddits verify SideProject"),
+        step(
+          2, "peaks.get",
+          "Inspect the current effective peak configuration.",
+          "redditreminder --json peaks get SideProject"),
+        step(
+          3, "peaks.set",
+          "Preview the peak override without saving app data.",
+          "redditreminder --json --dry-run peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"),
+        step(
+          4, "peaks.set",
+          "After user confirmation, save the peak override and resync generated events.",
+          "redditreminder --json peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"),
+        step(
+          5, "peaks.get",
+          "Verify the updated effective peak configuration.",
+          "redditreminder --json peaks get SideProject"),
+      ],
+      examples: ["redditreminder --json recipes show subreddit.configure-peak-times-dry-run"],
+      relatedCommands: ["subreddits.verify", "peaks.get", "peaks.set"]
+    ),
+    recipe(
+      "project.archive-dry-run",
+      "Safely preview and then archive a project.",
+      goal: "Find the project, preview archival with --dry-run, wait for confirmation, archive it, and verify project state.",
+      inputs: [
+        input("project", "Existing project name or id."),
+      ],
+      steps: [
+        step(
+          1, "projects.search",
+          "Find the target project and confirm the intended id or name.",
+          "redditreminder --json projects search --query Launch"),
+        step(
+          2, "projects.update",
+          "Preview archiving the project without saving app data.",
+          "redditreminder --json --dry-run projects update Launch --archive"),
+        step(
+          3, "projects.update",
+          "After user confirmation, archive the project.",
+          "redditreminder --json projects update Launch --archive"),
+        step(
+          4, "projects.list",
+          "Verify the project is archived.",
+          "redditreminder --json projects list --query Launch"),
+      ],
+      examples: ["redditreminder --json recipes show project.archive-dry-run"],
+      relatedCommands: ["projects.search", "projects.update", "projects.list"]
+    ),
+  ]
+}

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		8BDBD62791F99A373564D5B3 /* CLIDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B81CF275655D5E1ECD5EC37 /* CLIDTOs.swift */; };
 		8BFB4386A5522097EAA5B7AC /* AppDelegateShortcutRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D483D5534D2A0BC4C03BC77B /* AppDelegateShortcutRegistrationTests.swift */; };
 		8DBE4AF4BC0B7AEBB360C5F5 /* ShortcutRecorderInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9D18BDF63A57734A4A6C7A /* ShortcutRecorderInput.swift */; };
+		92CAD57D97C1526FA3C50242 /* CLIRecipeCatalogDryRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B8EDC6BDDBC291303F4BE8 /* CLIRecipeCatalogDryRun.swift */; };
 		9308DC394CD017D3E527EF59 /* MenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48A6922EC50A2426089E7A2 /* MenuBarControllerTests.swift */; };
 		9455C1014FD9C64F0B68D3F7 /* CLIFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32050796326D457C67C1870 /* CLIFilter.swift */; };
 		94636B0369D90D9FC93B2780 /* BackupMediaPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83951E8660A332C18651B94E /* BackupMediaPayloadTests.swift */; };
@@ -307,6 +308,7 @@
 		75FA87973FC3B43FDB7B37F8 /* PostingChecklistItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingChecklistItemsTests.swift; sourceTree = "<group>"; };
 		77F3C79809C4BF0DD2B05AF6 /* CLIDiscoveryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIDiscoveryManager.swift; sourceTree = "<group>"; };
 		787D3D5B9009F0ADFDC50CFF /* RedditReminderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedditReminderApp.swift; sourceTree = "<group>"; };
+		78B8EDC6BDDBC291303F4BE8 /* CLIRecipeCatalogDryRun.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRecipeCatalogDryRun.swift; sourceTree = "<group>"; };
 		793582517DF597A0F96E2072 /* KeyboardShortcutConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutConfig.swift; sourceTree = "<group>"; };
 		7D9810B901F7241E88A6D898 /* SubredditInputValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubredditInputValidation.swift; sourceTree = "<group>"; };
 		83951E8660A332C18651B94E /* BackupMediaPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMediaPayloadTests.swift; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 				B14A6B7A047D5672F9159659 /* CLIOutput.swift */,
 				85FE2A447522454CC9824DD4 /* CLIProjectManager.swift */,
 				4143AED39BD8255725DAC766 /* CLIRecipeCatalog.swift */,
+				78B8EDC6BDDBC291303F4BE8 /* CLIRecipeCatalogDryRun.swift */,
 				97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */,
 				9000531B86E8AB4A89157704 /* CLISubredditManager.swift */,
 				FACB9393BCF9FAB1070EEFD8 /* CLISubredditVerifier.swift */,
@@ -865,6 +868,7 @@
 				BA3588948937708CD83AFEBC /* CLIOutput.swift in Sources */,
 				B0C340A0AB5DE1005CC425FC /* CLIProjectManager.swift in Sources */,
 				F94C03AEBAB43FA4AB4910FD /* CLIRecipeCatalog.swift in Sources */,
+				92CAD57D97C1526FA3C50242 /* CLIRecipeCatalogDryRun.swift in Sources */,
 				653447F7059B945ECF9657B2 /* CLIRunner.swift in Sources */,
 				AD72D92BE212AF74D0BBDE44 /* CLISubredditManager.swift in Sources */,
 				414614EDB4705F4BAB10EAB7 /* CLISubredditVerifier.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,9 @@ redditreminder commands list --json
 redditreminder commands show captures.create --json
 redditreminder recipes list --json
 redditreminder recipes search --query "media" --json
+redditreminder recipes search --query "dry-run" --json
 redditreminder recipes show posting.create-with-media --json
+redditreminder recipes show posting.create-with-media-dry-run --json
 ```
 
 `context show` returns a compact snapshot of the workspace: counts, projects,
@@ -59,7 +61,8 @@ agents can inspect the widget state without guessing which domain to query first
 schema versions, command ids, positionals, flags, examples, and output data shapes.
 `recipes list`, `recipes search`, and `recipes show` return higher-level agent
 workflows: schema versions, expected inputs, ordered command steps, example
-invocations, and related command ids.
+invocations, and related command ids. Dry-run recipes document safer mutation
+patterns that preview changes before executing them.
 
 ## Captures
 

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -103,6 +103,16 @@ def validate_recipes(cli, recipes, command_ids):
     search_ids = {recipe["id"] for recipe in search["data"]}
     if "posting.create-with-media" not in search_ids:
         fail("recipes search did not return posting.create-with-media for media")
+    dry_run_search = cli_json(cli, ["recipes", "search", "--query", "dry-run"])
+    dry_run_ids = {recipe["id"] for recipe in dry_run_search["data"]}
+    expected_dry_run_ids = {
+        "posting.create-with-media-dry-run",
+        "subreddit.configure-peak-times-dry-run",
+        "project.archive-dry-run",
+    }
+    missing_dry_run_ids = sorted(expected_dry_run_ids - dry_run_ids)
+    if missing_dry_run_ids:
+        fail(f"recipes search missing dry-run recipes: {', '.join(missing_dry_run_ids)}")
 
 
 def main():

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -191,11 +191,21 @@ assert_contains "recipes search ok" "$recipes_search" '"ok":true'
 assert_contains "recipes search create media" "$recipes_search" '"id":"posting.create-with-media"'
 assert_not_contains "recipes search excludes peak recipe" "$recipes_search" '"id":"subreddit.configure-peak-times"'
 
+recipes_dry_run_search="$(run_json recipes search --query dry-run)"
+assert_contains "recipes dry-run search ok" "$recipes_dry_run_search" '"ok":true'
+assert_contains "recipes dry-run posting" "$recipes_dry_run_search" '"id":"posting.create-with-media-dry-run"'
+assert_contains "recipes dry-run project" "$recipes_dry_run_search" '"id":"project.archive-dry-run"'
+
 recipes_show="$(run_json recipes show posting.create-with-media)"
 assert_contains "recipes show ok" "$recipes_show" '"ok":true'
 assert_contains "recipes show id" "$recipes_show" '"id":"posting.create-with-media"'
 assert_contains "recipes show capture command" "$recipes_show" '"commandId":"captures.create"'
 assert_contains "recipes show related commands" "$recipes_show" '"relatedCommands":'
+
+recipes_dry_run_show="$(run_json recipes show posting.create-with-media-dry-run)"
+assert_contains "recipes dry-run show ok" "$recipes_dry_run_show" '"ok":true'
+assert_contains "recipes dry-run show id" "$recipes_dry_run_show" '"id":"posting.create-with-media-dry-run"'
+assert_contains "recipes dry-run step" "$recipes_dry_run_show" "--dry-run"
 
 peak_reset="$(run_json peaks reset SideProject)"
 assert_contains "peak reset" "$peak_reset" '"ok":true'


### PR DESCRIPTION
## Summary
- add dry-run-first recipe metadata for common agent mutations
- include safe preview workflows for capture creation, peak-time configuration, and project archiving
- split dry-run recipes into a dedicated catalog extension to keep files small
- extend recipe search, smoke, docs, and catalog validation coverage

## Verification
- make cli-test
- ./scripts/format-check.sh
- git diff --check
- recipes search --query dry-run returns the three dry-run recipes