### PR TITLE
Add CLI agent bootstrap

### DIFF
--- a/CLI/Sources/CLIAgentBootstrap.swift
+++ b/CLI/Sources/CLIAgentBootstrap.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum CLIAgentBootstrap {
+  static func show() -> CLIResponse {
+    .success(
+      data: .agentBootstrap(
+        AgentBootstrapDTO(
+          schemaVersion: 1,
+          toolName: "redditreminder",
+          summary:
+            "Cold-start guide for agents using the RedditReminder menu bar app through the CLI.",
+          recommendedStart: [
+            "redditreminder --json agent bootstrap",
+            "redditreminder --json context show --limit 10",
+            "redditreminder --json commands list",
+            "redditreminder --json recipes list",
+            "redditreminder --json recipes search --query dry-run",
+          ],
+          safety: [
+            "Prefer recipes before composing raw mutation commands.",
+            "Use --dry-run before mutations when the command supports it.",
+            "Ask for user confirmation before executing non-dry-run mutations.",
+            "Use --store PATH for isolated testing without touching app data.",
+          ],
+          discoveryCommands: [
+            "context.show",
+            "search.all",
+            "commands.list",
+            "commands.show",
+            "recipes.list",
+            "recipes.search",
+            "recipes.show",
+          ],
+          recipeCommands: [
+            "redditreminder --json recipes list",
+            "redditreminder --json recipes search --query media",
+            "redditreminder --json recipes search --query dry-run",
+            "redditreminder --json recipes show posting.create-with-media-dry-run",
+          ],
+          coreWorkflows: [
+            "posting.create-with-media",
+            "posting.create-with-media-dry-run",
+            "workspace.recommend-targets",
+            "subreddit.configure-peak-times",
+            "subreddit.configure-peak-times-dry-run",
+            "project.archive-dry-run",
+          ],
+          docs: [
+            "docs/cli.md",
+            "scripts/cli-smoke.sh",
+            "scripts/cli-catalog-check.py",
+          ])))
+  }
+}

--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -23,6 +23,12 @@ enum CLICommandCatalog {
 
   static let discoveryCommands: [CommandReferenceDTO] = [
     command(
+      "agent.bootstrap", "agent", "bootstrap",
+      "Return the cold-start guide for agents.",
+      examples: ["redditreminder --json agent bootstrap"],
+      output: output("agentBootstrap", "Versioned agent bootstrap guidance.")
+    ),
+    command(
       "context.show", "context", "show",
       "Return a compact workspace snapshot for agent planning.",
       flags: [flag("--limit", "N", "Maximum items per collection. Defaults to 20.")],

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -54,3 +54,15 @@ struct RecipeStepDTO: Encodable {
   let purpose: String
   let example: String
 }
+
+struct AgentBootstrapDTO: Encodable {
+  let schemaVersion: Int
+  let toolName: String
+  let summary: String
+  let recommendedStart: [String]
+  let safety: [String]
+  let discoveryCommands: [String]
+  let recipeCommands: [String]
+  let coreWorkflows: [String]
+  let docs: [String]
+}

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -20,6 +20,7 @@ enum CLIResponseData: Encodable {
   case commandReference(CommandReferenceDTO)
   case recipeReferences([RecipeReferenceDTO])
   case recipeReference(RecipeReferenceDTO)
+  case agentBootstrap(AgentBootstrapDTO)
   case dryRun(String)
 
   func encode(to encoder: Encoder) throws {
@@ -44,6 +45,7 @@ enum CLIResponseData: Encodable {
     case .commandReference(let value): try container.encode(value)
     case .recipeReferences(let value): try container.encode(value)
     case .recipeReference(let value): try container.encode(value)
+    case .agentBootstrap(let value): try container.encode(value)
     case .dryRun(let value): try container.encode(["message": value])
     }
   }

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -23,6 +23,7 @@ struct CLIOptions {
 }
 
 enum CLICommand {
+  case agentBootstrap
   case capturesList(query: String?)
   case captureCreate(CaptureCreateInput)
   case captureUpdate(CaptureUpdateInput)
@@ -56,6 +57,8 @@ enum CLICommand {
 
   init(domain: String, action: String, parser: inout CLIArgumentParser) throws {
     switch (domain, action) {
+    case ("agent", "bootstrap"):
+      self = .agentBootstrap
     case ("captures", "list"):
       self = .capturesList(query: parser.consumeOptionalValue(for: "--query"))
     case ("captures", "search"):

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -82,6 +82,8 @@ enum CLIPrinter {
       return recipes.map { "\($0.id) - \($0.summary)" }.joined(separator: "\n")
     case .recipeReference(let recipe):
       return "\(recipe.id) - \(recipe.summary)"
+    case .agentBootstrap(let bootstrap):
+      return "\(bootstrap.toolName) agent bootstrap - \(bootstrap.summary)"
     case .dryRun(let message): return message
     }
   }
@@ -121,11 +123,12 @@ enum CLIHelp {
   static let root = """
     Usage: redditreminder [--json] [--pretty] [--dry-run] [--store PATH] <domain> <command>
 
-    Domains: captures, events, projects, subreddits, peaks, search, context, commands, recipes
+    Domains: agent, captures, events, projects, subreddits, peaks, search, context, commands, recipes
     """
 
   static func domain(_ domain: String) -> String {
     switch domain {
+    case "agent": return "Usage: redditreminder agent bootstrap"
     case "captures":
       return
         "Usage: redditreminder captures list|search|create|update|delete|mark-posted|mark-queued"

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -24,6 +24,8 @@ final class CLIRunner {
 
   func run(command: CLICommand) async throws -> CLIResponse {
     switch command {
+    case .agentBootstrap:
+      return CLIAgentBootstrap.show()
     case .capturesList(let query):
       return .success(data: .captures(fetchCaptures(matching: query).map(CaptureDTO.init)))
     case .captureCreate(let input):

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		CFDA6CE34A7768D4CF33D759 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		D4C25F69F19FB5F035561B86 /* CaptureMediaAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256FB5A83C11819FC96533BA /* CaptureMediaAccessibility.swift */; };
 		D70537E281AB16807DE1E2FA /* CLICaptureCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */; };
+		D866DE76F83DD239C8C16BE6 /* CLIAgentBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF046679692C90640222864 /* CLIAgentBootstrap.swift */; };
 		D8C594251D6110586CEC8152 /* CaptureFormResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18096AB61A4D997C3C36A3AA /* CaptureFormResult.swift */; };
 		DA2B270CDFA18C60E33E913B /* KeyboardShortcutConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793582517DF597A0F96E2072 /* KeyboardShortcutConfig.swift */; };
 		DF5BC4B40F68E4D77656AD97 /* ShortcutRecorderInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECD53B7CA29C3F004D13EBB /* ShortcutRecorderInputTests.swift */; };
@@ -332,6 +333,7 @@
 		979105135C8B3C67FC080326 /* AppRefreshAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRefreshAction.swift; sourceTree = "<group>"; };
 		97F9B8849B7B1BFA35E198D7 /* CLIRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRunner.swift; sourceTree = "<group>"; };
 		9884E228CA7B8C32C3669A85 /* BackupMappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupMappers.swift; sourceTree = "<group>"; };
+		9BF046679692C90640222864 /* CLIAgentBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAgentBootstrap.swift; sourceTree = "<group>"; };
 		9C593329647C7A7C82103B02 /* CLIEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIEventManager.swift; sourceTree = "<group>"; };
 		9E2C8DBB12B2100D9B15CCA0 /* RedditReminderCLI */ = {isa = PBXFileReference; includeInIndex = 0; path = RedditReminderCLI; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FA306067C4690F4D1CDAC2D /* Subreddit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subreddit.swift; sourceTree = "<group>"; };
@@ -539,6 +541,7 @@
 		6BD3E7EA3F7D02FA08CCC4C4 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				9BF046679692C90640222864 /* CLIAgentBootstrap.swift */,
 				237DBF1605FF8CDD5CDD51A5 /* CLIArgumentParserCaptures.swift */,
 				C1DDFC92B31A2562246F8D58 /* CLIArgumentParserConfig.swift */,
 				5E937747CC61B8E422CE6018 /* CLIArgumentParserEvents.swift */,
@@ -847,6 +850,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA9B4D6D73A9BE87850EB6B1 /* AppRefreshAction.swift in Sources */,
+				D866DE76F83DD239C8C16BE6 /* CLIAgentBootstrap.swift in Sources */,
 				407571238A58E84A82F37D32 /* CLIArgumentParserCaptures.swift in Sources */,
 				7A921D8AE858EAC9BC2C9556 /* CLIArgumentParserConfig.swift in Sources */,
 				B9A0FFC6B8D690F11AC676EA /* CLIArgumentParserEvents.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,7 @@ JSON responses use this envelope:
 ## Agent Discovery
 
 ```sh
+redditreminder agent bootstrap --json
 redditreminder context show --json
 redditreminder context show --limit 5 --json
 redditreminder search all --query "launch" --json
@@ -53,6 +54,10 @@ redditreminder recipes show posting.create-with-media --json
 redditreminder recipes show posting.create-with-media-dry-run --json
 ```
 
+`agent bootstrap` is the cold-start entry point for Codex, Claude Code, and other
+agents. Once an agent knows the `redditreminder` binary name, bootstrap tells it
+which discovery commands to run next, where to find recipes, and how to handle
+mutations safely.
 `context show` returns a compact snapshot of the workspace: counts, projects,
 subreddits with peak summaries, queued captures, active events, and peak presets.
 `search all` searches captures, events, projects, subreddits, and peak presets so

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -47,6 +47,18 @@ def recipe_catalog(cli):
     return cli_json(cli, ["recipes", "list"])["data"]
 
 
+def validate_bootstrap(cli, command_ids):
+    bootstrap = cli_json(cli, ["agent", "bootstrap"])["data"]
+    if bootstrap.get("schemaVersion") != 1:
+        fail("agent bootstrap missing schemaVersion 1")
+    if bootstrap.get("toolName") != "redditreminder":
+        fail("agent bootstrap returned wrong toolName")
+    discovery = set(bootstrap.get("discoveryCommands", []))
+    unknown = sorted(discovery - command_ids)
+    if unknown:
+        fail(f"agent bootstrap references unknown commands: {', '.join(unknown)}")
+
+
 def validate_catalog(cli, catalog):
     ids = [command["id"] for command in catalog]
     duplicates = sorted({command_id for command_id in ids if ids.count(command_id) > 1})
@@ -125,6 +137,7 @@ def main():
     catalog = command_catalog(cli)
     validate_catalog(cli, catalog)
     catalog_ids = {command["id"] for command in catalog}
+    validate_bootstrap(cli, catalog_ids)
     recipes = recipe_catalog(cli)
     validate_recipes(cli, recipes, catalog_ids)
 

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -168,6 +168,10 @@ assert_contains "context counts" "$context_snapshot" '"counts":'
 assert_contains "context subreddits" "$context_snapshot" '"subreddits":['
 assert_contains "context peak presets" "$context_snapshot" '"peakPresets":['
 
+agent_bootstrap="$(run_json agent bootstrap)"
+assert_contains "agent bootstrap ok" "$agent_bootstrap" '"ok":true'
+assert_contains "agent bootstrap schema" "$agent_bootstrap" '"schemaVersion":1'
+
 commands_list="$(run_json commands list)"
 assert_contains "commands list ok" "$commands_list" '"ok":true'
 assert_contains "commands list captures create" "$commands_list" '"id":"captures.create"'


### PR DESCRIPTION
## Summary
- add `redditreminder agent bootstrap` as the cold-start CLI entry point for agents
- return a versioned JSON bootstrap payload with recommended first commands, safety guidance, recipes, workflows, and docs
- register `agent.bootstrap` in the command catalog and validate bootstrap references in catalog checks

## Verification
- `make cli-test`
- `./scripts/format-check.sh`
- `git diff --check`
- `build/Build/Products/Debug/redditreminder --json agent bootstrap | /usr/bin/python3 -m json.tool`