### PR TITLE
Expand CLI agent bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# RedditReminder Agent Guide
+
+Use the `redditreminder` CLI for all agent interaction with the menu bar app.
+The CLI reads and writes the same SwiftData store as the app and emits stable
+JSON for Codex, Claude Code, scripts, and shell pipelines.
+
+## Start Here
+
+```sh
+redditreminder --json agent bootstrap
+```
+
+If `redditreminder` is not on `PATH`, install or build it:
+
+```sh
+make install-cli
+~/bin/redditreminder --json agent bootstrap
+```
+
+For local repo testing without installing:
+
+```sh
+make build-cli
+build/Build/Products/Debug/redditreminder --json agent bootstrap
+```
+
+## Agent Rules
+
+- Prefer `agent bootstrap`, `commands list`, and `recipes list` before guessing
+  syntax.
+- Prefer recipe flows over raw mutation commands.
+- Use `--json` for machine-readable output.
+- Use `--dry-run` before mutations when supported.
+- Ask for user confirmation before executing non-dry-run mutations.
+- Use `--store PATH` for isolated tests so app data is not changed.
+
+## Discovery Flow
+
+```sh
+redditreminder --json context show --limit 10
+redditreminder --json commands list
+redditreminder --json commands show captures.create
+redditreminder --json recipes list
+redditreminder --json recipes search --query dry-run
+redditreminder --json recipes show posting.create-with-media-dry-run
+```
+
+`agent bootstrap` includes command schemas and recipe schemas directly, so an
+agent can usually form valid commands from that single response. Use
+`commands show ID` or `recipes show ID` when a focused schema is easier to work
+with than the full bootstrap payload.
+
+## Common Workflows
+
+- Search workspace state: `redditreminder --json search all --query "launch"`
+- Create a project: `redditreminder --json projects create "Launch Ideas"`
+- Add a subreddit safely: `redditreminder --json subreddits add --verify SideProject`
+- Configure peaks: `redditreminder --json peaks set SideProject --days mon,wed --hours 9,10`
+- Preview a mutation: `redditreminder --json --dry-run projects create "Draft"`
+
+## Verification
+
+Run agent-focused CLI checks with:
+
+```sh
+make cli-test
+```

--- a/CLI/Sources/CLIAgentBootstrap.swift
+++ b/CLI/Sources/CLIAgentBootstrap.swift
@@ -5,10 +5,18 @@ enum CLIAgentBootstrap {
     .success(
       data: .agentBootstrap(
         AgentBootstrapDTO(
-          schemaVersion: 1,
+          schemaVersion: 2,
           toolName: "redditreminder",
           summary:
             "Cold-start guide for agents using the RedditReminder menu bar app through the CLI.",
+          installCommands: [
+            "make install-cli",
+            "make build-cli",
+          ],
+          binaryLocations: [
+            "~/bin/redditreminder",
+            "build/Build/Products/Debug/redditreminder",
+          ],
           recommendedStart: [
             "redditreminder --json agent bootstrap",
             "redditreminder --json context show --limit 10",
@@ -45,9 +53,13 @@ enum CLIAgentBootstrap {
             "subreddit.configure-peak-times-dry-run",
             "project.archive-dry-run",
           ],
+          commandSchemas: CLICommandCatalog.commands,
+          recipeSchemas: CLIRecipeCatalog.recipes,
           docs: [
+            "AGENTS.md",
             "docs/cli.md",
             "scripts/cli-smoke.sh",
+            "scripts/cli-agent-smoke.sh",
             "scripts/cli-catalog-check.py",
           ])))
   }

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -59,10 +59,14 @@ struct AgentBootstrapDTO: Encodable {
   let schemaVersion: Int
   let toolName: String
   let summary: String
+  let installCommands: [String]
+  let binaryLocations: [String]
   let recommendedStart: [String]
   let safety: [String]
   let discoveryCommands: [String]
   let recipeCommands: [String]
   let coreWorkflows: [String]
+  let commandSchemas: [CommandReferenceDTO]
+  let recipeSchemas: [RecipeReferenceDTO]
   let docs: [String]
 }

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ test: generate
 
 cli-test: build-cli
 	./scripts/cli-smoke.sh "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
+	./scripts/cli-agent-smoke.sh "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
 	./scripts/cli-catalog-check.py "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
 
 ui-test: generate

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,8 +56,9 @@ redditreminder recipes show posting.create-with-media-dry-run --json
 
 `agent bootstrap` is the cold-start entry point for Codex, Claude Code, and other
 agents. Once an agent knows the `redditreminder` binary name, bootstrap tells it
-which discovery commands to run next, where to find recipes, and how to handle
-mutations safely.
+which discovery commands to run next, where to find recipes, how to handle
+mutations safely, and includes command and recipe schemas in the same response.
+`AGENTS.md` is the repo-level bootstrap guide for agents starting from source.
 `context show` returns a compact snapshot of the workspace: counts, projects,
 subreddits with peak summaries, queued captures, active events, and peak presets.
 `search all` searches captures, events, projects, subreddits, and peak presets so

--- a/scripts/cli-agent-smoke.sh
+++ b/scripts/cli-agent-smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLI="${1:-build/Build/Products/Debug/redditreminder}"
+TMP_DIR="$(mktemp -d)"
+STORE="$TMP_DIR/redditreminder-agent.store"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+run_json() {
+  "$CLI" --json --store "$STORE" "$@"
+}
+
+run_json_dry() {
+  "$CLI" --json --dry-run --store "$STORE" "$@"
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL: $label" >&2
+    echo "Expected output to contain: $needle" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+bootstrap="$(run_json agent bootstrap)"
+assert_contains "bootstrap ok" "$bootstrap" '"ok":true'
+assert_contains "bootstrap schema" "$bootstrap" '"schemaVersion":2'
+assert_contains "bootstrap command schemas" "$bootstrap" '"commandSchemas":'
+assert_contains "bootstrap captures create" "$bootstrap" '"id":"captures.create"'
+assert_contains "bootstrap recipe schemas" "$bootstrap" '"recipeSchemas":'
+assert_contains "bootstrap agent docs" "$bootstrap" '"AGENTS.md"'
+
+context="$(run_json context show --limit 10)"
+assert_contains "context ok" "$context" '"ok":true'
+assert_contains "context counts" "$context" '"counts":'
+
+recipes="$(run_json recipes search --query dry-run)"
+assert_contains "recipes ok" "$recipes" '"ok":true'
+assert_contains "recipes dry-run project" "$recipes" '"id":"project.archive-dry-run"'
+
+preview="$(run_json_dry projects create "Agent Draft")"
+assert_contains "dry-run ok" "$preview" '"ok":true'
+assert_contains "dry-run message" "$preview" "Would create project Agent Draft."
+
+projects="$(run_json projects list)"
+assert_contains "project list ok" "$projects" '"ok":true'
+if [[ "$projects" == *"Agent Draft"* ]]; then
+  echo "FAIL: dry-run project create mutated the store" >&2
+  echo "$projects" >&2
+  exit 1
+fi
+
+echo "CLI agent smoke passed"

--- a/scripts/cli-catalog-check.py
+++ b/scripts/cli-catalog-check.py
@@ -49,14 +49,24 @@ def recipe_catalog(cli):
 
 def validate_bootstrap(cli, command_ids):
     bootstrap = cli_json(cli, ["agent", "bootstrap"])["data"]
-    if bootstrap.get("schemaVersion") != 1:
-        fail("agent bootstrap missing schemaVersion 1")
+    if bootstrap.get("schemaVersion") != 2:
+        fail("agent bootstrap missing schemaVersion 2")
     if bootstrap.get("toolName") != "redditreminder":
         fail("agent bootstrap returned wrong toolName")
     discovery = set(bootstrap.get("discoveryCommands", []))
     unknown = sorted(discovery - command_ids)
     if unknown:
         fail(f"agent bootstrap references unknown commands: {', '.join(unknown)}")
+    schema_ids = {command.get("id") for command in bootstrap.get("commandSchemas", [])}
+    if schema_ids != command_ids:
+        missing = sorted(command_ids - schema_ids)
+        extra = sorted(schema_ids - command_ids)
+        fail(f"agent bootstrap commandSchemas mismatch: missing={missing} extra={extra}")
+    recipe_schemas = bootstrap.get("recipeSchemas", [])
+    if not recipe_schemas:
+        fail("agent bootstrap missing recipeSchemas")
+    if "AGENTS.md" not in bootstrap.get("docs", []):
+        fail("agent bootstrap docs must include AGENTS.md")
 
 
 def validate_catalog(cli, catalog):

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -170,7 +170,7 @@ assert_contains "context peak presets" "$context_snapshot" '"peakPresets":['
 
 agent_bootstrap="$(run_json agent bootstrap)"
 assert_contains "agent bootstrap ok" "$agent_bootstrap" '"ok":true'
-assert_contains "agent bootstrap schema" "$agent_bootstrap" '"schemaVersion":1'
+assert_contains "agent bootstrap schema" "$agent_bootstrap" '"schemaVersion":2'
 
 commands_list="$(run_json commands list)"
 assert_contains "commands list ok" "$commands_list" '"ok":true'


### PR DESCRIPTION
## Summary
- add `AGENTS.md` as the repo-level cold-start guide for Codex, Claude Code, and other agents
- expand `agent bootstrap` to schema version 2 with install hints, binary locations, full command schemas, and recipe schemas
- add an agent smoke test that exercises bootstrap -> context -> recipe search -> dry-run mutation and wire it into `make cli-test`

## Verification
- `make cli-test`
- `./scripts/format-check.sh`
- `git diff --check`
- `build/Build/Products/Debug/redditreminder --json agent bootstrap` reports schema 2, 35 command schemas, and 6 recipe schemas