### PR TITLE
Add source agent bootstrap entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,28 @@ JSON for Codex, Claude Code, scripts, and shell pipelines.
 ## Start Here
 
 ```sh
+./scripts/agent-bootstrap.sh
+```
+
+That source-tree entry point builds the CLI if needed, then runs:
+
+```sh
+build/Build/Products/Debug/redditreminder --json agent bootstrap
+```
+
+The Makefile target is equivalent:
+
+```sh
+make agent-bootstrap
+```
+
+If `redditreminder` is already on `PATH`, this also works:
+
+```sh
 redditreminder --json agent bootstrap
 ```
 
-If `redditreminder` is not on `PATH`, install or build it:
+To install the CLI globally:
 
 ```sh
 make install-cli

--- a/CLI/Sources/CLIAgentBootstrap.swift
+++ b/CLI/Sources/CLIAgentBootstrap.swift
@@ -10,6 +10,8 @@ enum CLIAgentBootstrap {
           summary:
             "Cold-start guide for agents using the RedditReminder menu bar app through the CLI.",
           installCommands: [
+            "make agent-bootstrap",
+            "./scripts/agent-bootstrap.sh",
             "make install-cli",
             "make build-cli",
           ],

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-debug build-cli test cli-test ui-test install install-debug install-cli clean generate qa
+.PHONY: agent-bootstrap build build-debug build-cli test cli-test ui-test install install-debug install-cli clean generate qa
 
 APP_NAME := RedditReminder
 CLI_NAME := redditreminder
@@ -61,9 +61,13 @@ test: generate
 	  OTHER_CODE_SIGN_FLAGS=
 
 cli-test: build-cli
+	@./scripts/agent-bootstrap.sh >/dev/null
 	./scripts/cli-smoke.sh "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
 	./scripts/cli-agent-smoke.sh "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
 	./scripts/cli-catalog-check.py "$(BUILD_DIR)/Build/Products/Debug/$(CLI_NAME)"
+
+agent-bootstrap:
+	@./scripts/agent-bootstrap.sh
 
 ui-test: generate
 	xcodebuild test \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,16 @@ This installs:
 ~/bin/RedditReminderResources/peak-times.json
 ```
 
+From a source checkout, agents can bootstrap without installing:
+
+```sh
+./scripts/agent-bootstrap.sh
+make agent-bootstrap
+```
+
+Both commands build the debug CLI if needed and run `agent bootstrap` with JSON
+output.
+
 ## Global Flags
 
 ```sh

--- a/scripts/agent-bootstrap.sh
+++ b/scripts/agent-bootstrap.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$REPO_ROOT/build/Build/Products/Debug/redditreminder"
+
+needs_build=false
+if [[ ! -x "$CLI" ]]; then
+  needs_build=true
+elif find "$REPO_ROOT/CLI" "$REPO_ROOT/Sources" "$REPO_ROOT/Resources" \
+  "$REPO_ROOT/project.yml" "$REPO_ROOT/Makefile" -newer "$CLI" -print -quit \
+  | grep -q .
+then
+  needs_build=true
+fi
+
+if [[ "$needs_build" == true ]]; then
+  echo "Building redditreminder CLI..." >&2
+  make -C "$REPO_ROOT" build-cli >&2
+fi
+
+echo "Running: $CLI --json agent bootstrap" >&2
+exec "$CLI" --json agent bootstrap


### PR DESCRIPTION
## Summary
- add `./scripts/agent-bootstrap.sh` so agents can bootstrap from a source checkout before the CLI is installed
- add `make agent-bootstrap` with pure JSON stdout for pipe-based agent use
- advertise the source bootstrap entrypoints in `AGENTS.md`, `docs/cli.md`, and the CLI bootstrap payload
- wire the source bootstrap script into `make cli-test` so CI covers the one-command agent path

## Verification
- `make cli-test`
- `make agent-bootstrap | /usr/bin/python3 -c ...`
- `./scripts/format-check.sh`
- `git diff --check`