### PR TITLE
Add CLI agent command validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ build/Build/Products/Debug/redditreminder --json agent bootstrap
 - Prefer `agent bootstrap`, `commands list`, and `recipes list` before guessing
   syntax.
 - Prefer recipe flows over raw mutation commands.
+- Validate proposed commands with `agent validate --` before execution.
 - Use `--json` for machine-readable output.
 - Use `--dry-run` before mutations when supported.
 - Ask for user confirmation before executing non-dry-run mutations.
@@ -56,6 +57,7 @@ build/Build/Products/Debug/redditreminder --json agent bootstrap
 
 ```sh
 redditreminder --json context show --limit 10
+redditreminder --json agent validate -- projects create "Launch Ideas"
 redditreminder --json commands list
 redditreminder --json commands show captures.create
 redditreminder --json recipes list

--- a/CLI/Sources/CLIAgentBootstrap.swift
+++ b/CLI/Sources/CLIAgentBootstrap.swift
@@ -23,6 +23,7 @@ enum CLIAgentBootstrap {
             "redditreminder --json agent bootstrap",
             "redditreminder --json context show --limit 10",
             "redditreminder --json commands list",
+            "redditreminder --json agent validate -- projects create Draft",
             "redditreminder --json recipes list",
             "redditreminder --json recipes search --query dry-run",
           ],
@@ -34,6 +35,7 @@ enum CLIAgentBootstrap {
           ],
           discoveryCommands: [
             "context.show",
+            "agent.validate",
             "search.all",
             "commands.list",
             "commands.show",

--- a/CLI/Sources/CLIAgentValidator.swift
+++ b/CLI/Sources/CLIAgentValidator.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+enum CLIAgentValidator {
+  static func validate(input: AgentValidateInput) -> CLIResponse {
+    let normalized = normalizedCommand(input.command)
+    let result = validationResult(for: normalized)
+    return .success(data: .agentValidation(result))
+  }
+
+  private static func normalizedCommand(_ command: [String]) -> [String] {
+    var tokens = command
+    if let first = tokens.first,
+      first == "redditreminder" || first.hasSuffix("/redditreminder")
+    {
+      tokens.removeFirst()
+    }
+    var output: [String] = []
+    var index = 0
+    while index < tokens.count {
+      switch tokens[index] {
+      case "--json", "--pretty", "--dry-run":
+        index += 1
+      case "--store":
+        index += tokens.indices.contains(index + 1) ? 2 : 1
+      default:
+        output.append(tokens[index])
+        index += 1
+      }
+    }
+    return output
+  }
+
+  private static func validationResult(for tokens: [String]) -> AgentValidationDTO {
+    guard tokens.count >= 2 else {
+      return result(tokens, nil, nil, ["Expected <domain> <command>."], [])
+    }
+    let commandId = "\(tokens[0]).\(tokens[1])"
+    guard let command = CLICommandCatalog.commands.first(where: { $0.id == commandId }) else {
+      return result(tokens, commandId, nil, ["Unknown command: \(commandId)."], [])
+    }
+
+    var errors: [String] = []
+    var warnings: [String] = []
+    let arguments = Array(tokens.dropFirst(2))
+    let knownFlags = Dictionary(uniqueKeysWithValues: command.flags.map { ($0.name, $0) })
+    let parsed = parse(arguments: arguments, knownFlags: knownFlags)
+    errors.append(contentsOf: parsed.errors)
+
+    let missingFlags = command.flags.filter { $0.required && !parsed.flags.contains($0.name) }
+    errors.append(contentsOf: missingFlags.map { "Missing required flag \($0.name)." })
+
+    let requiredPositionals = command.positionals.filter(\.required).count
+    if parsed.positionals.count < requiredPositionals {
+      errors.append("Missing required positional argument.")
+    } else if command.positionals.isEmpty && !parsed.positionals.isEmpty {
+      warnings.append("Command catalog does not define positional arguments for extra text.")
+    } else if command.positionals.count > 1 && parsed.positionals.count > command.positionals.count {
+      warnings.append("Command has more positional values than the catalog defines.")
+    }
+    return result(tokens, commandId, command, errors, warnings)
+  }
+
+  private static func parse(
+    arguments: [String],
+    knownFlags: [String: CommandFlagDTO]
+  ) -> (flags: Set<String>, positionals: [String], errors: [String]) {
+    var flags: Set<String> = []
+    var seenFlags: Set<String> = []
+    var positionals: [String] = []
+    var errors: [String] = []
+    var index = 0
+    while index < arguments.count {
+      let argument = arguments[index]
+      guard argument.hasPrefix("--") else {
+        positionals.append(argument)
+        index += 1
+        continue
+      }
+      guard let flag = knownFlags[argument] else {
+        errors.append("Unknown flag \(argument).")
+        index += 1
+        continue
+      }
+      if seenFlags.contains(argument), !flag.repeatable {
+        errors.append("Flag \(argument) is not repeatable.")
+      }
+      seenFlags.insert(argument)
+      flags.insert(argument)
+      if flag.value != nil {
+        guard arguments.indices.contains(index + 1), !arguments[index + 1].hasPrefix("--") else {
+          errors.append("Missing value for \(argument).")
+          index += 1
+          continue
+        }
+        index += 2
+      } else {
+        index += 1
+      }
+    }
+    return (flags, positionals, errors)
+  }
+
+  private static func result(
+    _ tokens: [String],
+    _ commandId: String?,
+    _ command: CommandReferenceDTO?,
+    _ errors: [String],
+    _ warnings: [String]
+  ) -> AgentValidationDTO {
+    AgentValidationDTO(
+      schemaVersion: 1,
+      valid: errors.isEmpty,
+      commandId: commandId,
+      normalizedCommand: tokens,
+      errors: errors,
+      warnings: warnings,
+      command: command)
+  }
+}

--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -29,6 +29,13 @@ enum CLICommandCatalog {
       output: output("agentBootstrap", "Versioned agent bootstrap guidance.")
     ),
     command(
+      "agent.validate", "agent", "validate",
+      "Validate a proposed CLI command against the command catalog without executing it.",
+      positionals: [arg("command", "Command tokens after --, for example projects create Draft.")],
+      examples: ["redditreminder --json agent validate -- projects create Draft"],
+      output: output("agentValidation", "Validation result with errors and command schema.")
+    ),
+    command(
       "context.show", "context", "show",
       "Return a compact workspace snapshot for agent planning.",
       flags: [flag("--limit", "N", "Maximum items per collection. Defaults to 20.")],

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -70,3 +70,13 @@ struct AgentBootstrapDTO: Encodable {
   let recipeSchemas: [RecipeReferenceDTO]
   let docs: [String]
 }
+
+struct AgentValidationDTO: Encodable {
+  let schemaVersion: Int
+  let valid: Bool
+  let commandId: String?
+  let normalizedCommand: [String]
+  let errors: [String]
+  let warnings: [String]
+  let command: CommandReferenceDTO?
+}

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -21,6 +21,7 @@ enum CLIResponseData: Encodable {
   case recipeReferences([RecipeReferenceDTO])
   case recipeReference(RecipeReferenceDTO)
   case agentBootstrap(AgentBootstrapDTO)
+  case agentValidation(AgentValidationDTO)
   case dryRun(String)
 
   func encode(to encoder: Encoder) throws {
@@ -46,6 +47,7 @@ enum CLIResponseData: Encodable {
     case .recipeReferences(let value): try container.encode(value)
     case .recipeReference(let value): try container.encode(value)
     case .agentBootstrap(let value): try container.encode(value)
+    case .agentValidation(let value): try container.encode(value)
     case .dryRun(let value): try container.encode(["message": value])
     }
   }
@@ -60,6 +62,10 @@ struct CaptureCreateInput {
   let subreddits: [String]
   let mediaPaths: [String]
   let due: String?
+}
+
+struct AgentValidateInput {
+  let command: [String]
 }
 
 struct CaptureUpdateInput {

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -24,6 +24,7 @@ struct CLIOptions {
 
 enum CLICommand {
   case agentBootstrap
+  case agentValidate(AgentValidateInput)
   case capturesList(query: String?)
   case captureCreate(CaptureCreateInput)
   case captureUpdate(CaptureUpdateInput)
@@ -59,6 +60,8 @@ enum CLICommand {
     switch (domain, action) {
     case ("agent", "bootstrap"):
       self = .agentBootstrap
+    case ("agent", "validate"):
+      self = .agentValidate(try parser.consumeAgentValidateInput())
     case ("captures", "list"):
       self = .capturesList(query: parser.consumeOptionalValue(for: "--query"))
     case ("captures", "search"):
@@ -154,6 +157,9 @@ struct CLIArgumentParser {
     while index < arguments.count {
       let argument = arguments[index]
       switch argument {
+      case "--":
+        index += 1
+        return options
       case "--json":
         options.json = true
         arguments.remove(at: index)
@@ -227,6 +233,16 @@ struct CLIArgumentParser {
       throw CLIError.usage("Missing \(label).")
     }
     return value
+  }
+
+  mutating func consumeAgentValidateInput() throws -> AgentValidateInput {
+    _ = consumeFlag("--")
+    guard !arguments.isEmpty else {
+      throw CLIError.usage("Usage: redditreminder agent validate -- <domain> <command> [args]")
+    }
+    let command = arguments
+    arguments.removeAll()
+    return AgentValidateInput(command: command)
   }
 
   mutating func consumeCSV(for flag: String) throws -> [String] {

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -84,6 +84,10 @@ enum CLIPrinter {
       return "\(recipe.id) - \(recipe.summary)"
     case .agentBootstrap(let bootstrap):
       return "\(bootstrap.toolName) agent bootstrap - \(bootstrap.summary)"
+    case .agentValidation(let validation):
+      return validation.valid
+        ? "Valid command: \(validation.commandId ?? validation.normalizedCommand.joined(separator: " "))"
+        : "Invalid command: \(validation.errors.joined(separator: "; "))"
     case .dryRun(let message): return message
     }
   }
@@ -128,7 +132,7 @@ enum CLIHelp {
 
   static func domain(_ domain: String) -> String {
     switch domain {
-    case "agent": return "Usage: redditreminder agent bootstrap"
+    case "agent": return "Usage: redditreminder agent bootstrap|validate"
     case "captures":
       return
         "Usage: redditreminder captures list|search|create|update|delete|mark-posted|mark-queued"

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -26,6 +26,8 @@ final class CLIRunner {
     switch command {
     case .agentBootstrap:
       return CLIAgentBootstrap.show()
+    case .agentValidate(let input):
+      return CLIAgentValidator.validate(input: input)
     case .capturesList(let query):
       return .success(data: .captures(fetchCaptures(matching: query).map(CaptureDTO.init)))
     case .captureCreate(let input):

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		E651BBE6C6C84CA44281F9B7 /* CLIArgumentParserHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2755BD3961DE8EA13B8A1E /* CLIArgumentParserHelpers.swift */; };
 		E7E5E6539BF7A2B53E5600AC /* KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D70A5A33EC82E24F9A0330 /* KeyboardShortcuts.swift */; };
 		E91A5DDE67643B2D081C9340 /* PopoverCaptureFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEA78C5D7E701E78352BF98 /* PopoverCaptureFilteringTests.swift */; };
+		E9484CB4CA514954F2C5D1F3 /* CLIAgentValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6642BDB50320A87AB68443A /* CLIAgentValidator.swift */; };
 		E9EDB8A89099DE463C304AA7 /* AppRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A6F301705FB85E1459A403 /* AppRuntimeTests.swift */; };
 		EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A63D3714291E8917CA1694 /* PopoverContentView.swift */; };
 		EA9B4D6D73A9BE87850EB6B1 /* AppRefreshAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979105135C8B3C67FC080326 /* AppRefreshAction.swift */; };
@@ -368,6 +369,7 @@
 		C15D988E0168482E463F5FE6 /* PopoverContentActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverContentActions.swift; sourceTree = "<group>"; };
 		C1DDFC92B31A2562246F8D58 /* CLIArgumentParserConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIArgumentParserConfig.swift; sourceTree = "<group>"; };
 		C4A4C24B7D668794706240A8 /* EdgeCaseTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTestSupport.swift; sourceTree = "<group>"; };
+		C6642BDB50320A87AB68443A /* CLIAgentValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAgentValidator.swift; sourceTree = "<group>"; };
 		C8C6DAB7D790FE62A62D947F /* CLICommandCatalogTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalogTypes.swift; sourceTree = "<group>"; };
 		C9AC123670C416604F87973B /* CLIEventTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIEventTypes.swift; sourceTree = "<group>"; };
 		CDFFD74D3BB094379C0212C1 /* NotificationsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTabView.swift; sourceTree = "<group>"; };
@@ -542,6 +544,7 @@
 			isa = PBXGroup;
 			children = (
 				9BF046679692C90640222864 /* CLIAgentBootstrap.swift */,
+				C6642BDB50320A87AB68443A /* CLIAgentValidator.swift */,
 				237DBF1605FF8CDD5CDD51A5 /* CLIArgumentParserCaptures.swift */,
 				C1DDFC92B31A2562246F8D58 /* CLIArgumentParserConfig.swift */,
 				5E937747CC61B8E422CE6018 /* CLIArgumentParserEvents.swift */,
@@ -851,6 +854,7 @@
 			files = (
 				EA9B4D6D73A9BE87850EB6B1 /* AppRefreshAction.swift in Sources */,
 				D866DE76F83DD239C8C16BE6 /* CLIAgentBootstrap.swift in Sources */,
+				E9484CB4CA514954F2C5D1F3 /* CLIAgentValidator.swift in Sources */,
 				407571238A58E84A82F37D32 /* CLIArgumentParserCaptures.swift in Sources */,
 				7A921D8AE858EAC9BC2C9556 /* CLIArgumentParserConfig.swift in Sources */,
 				B9A0FFC6B8D690F11AC676EA /* CLIArgumentParserEvents.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,7 @@ JSON responses use this envelope:
 
 ```sh
 redditreminder agent bootstrap --json
+redditreminder agent validate -- projects create "Launch Ideas" --json
 redditreminder context show --json
 redditreminder context show --limit 5 --json
 redditreminder search all --query "launch" --json
@@ -68,6 +69,9 @@ redditreminder recipes show posting.create-with-media-dry-run --json
 agents. Once an agent knows the `redditreminder` binary name, bootstrap tells it
 which discovery commands to run next, where to find recipes, how to handle
 mutations safely, and includes command and recipe schemas in the same response.
+`agent validate -- <domain> <command> [args]` checks a proposed CLI command
+against the command catalog without executing it. The validation response reports
+unknown commands, unknown flags, missing required flags, and missing positionals.
 `AGENTS.md` is the repo-level bootstrap guide for agents starting from source.
 `context show` returns a compact snapshot of the workspace: counts, projects,
 subreddits with peak summaries, queued captures, active events, and peak presets.

--- a/scripts/cli-agent-smoke.sh
+++ b/scripts/cli-agent-smoke.sh
@@ -38,6 +38,16 @@ assert_contains "bootstrap captures create" "$bootstrap" '"id":"captures.create"
 assert_contains "bootstrap recipe schemas" "$bootstrap" '"recipeSchemas":'
 assert_contains "bootstrap agent docs" "$bootstrap" '"AGENTS.md"'
 
+valid_command="$(run_json agent validate -- projects create "Agent Draft")"
+assert_contains "validate ok" "$valid_command" '"ok":true'
+assert_contains "validate valid" "$valid_command" '"valid":true'
+assert_contains "validate command id" "$valid_command" '"commandId":"projects.create"'
+
+invalid_command="$(run_json agent validate -- peaks set SideProject --days mon)"
+assert_contains "validate invalid ok" "$invalid_command" '"ok":true'
+assert_contains "validate invalid" "$invalid_command" '"valid":false'
+assert_contains "validate missing flag" "$invalid_command" "Missing required flag --hours."
+
 context="$(run_json context show --limit 10)"
 assert_contains "context ok" "$context" '"ok":true'
 assert_contains "context counts" "$context" '"counts":'


### PR DESCRIPTION
## Summary
- add `redditreminder --json agent validate -- <domain> <command> [args]` as a read-only guardrail for agents
- validate proposed commands against the command catalog for unknown commands, unknown flags, missing required flags, duplicate non-repeatable flags, and missing positionals
- return structured `agentValidation` data with `valid`, `errors`, `warnings`, normalized command tokens, and the matching command schema
- advertise validation in bootstrap/docs and cover valid/invalid examples in agent smoke tests

## Verification
- `make cli-test`
- `./scripts/format-check.sh`
- `git diff --check`
- manual JSON checks for valid `projects.create` and invalid `peaks.set` missing `--hours`