### PR TITLE
Add agent mutation dry-run preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ build/Build/Products/Debug/redditreminder --json agent bootstrap
   syntax.
 - Prefer recipe flows over raw mutation commands.
 - Validate proposed commands with `agent validate --` before execution.
+- Preview mutations with `agent dry-run --`, then ask for confirmation.
 - Use `--json` for machine-readable output.
 - Use `--dry-run` before mutations when supported.
 - Ask for user confirmation before executing non-dry-run mutations.
@@ -58,6 +59,7 @@ build/Build/Products/Debug/redditreminder --json agent bootstrap
 ```sh
 redditreminder --json context show --limit 10
 redditreminder --json agent validate -- projects create "Launch Ideas"
+redditreminder --json agent dry-run -- projects create "Launch Ideas"
 redditreminder --json commands list
 redditreminder --json commands show captures.create
 redditreminder --json recipes list

--- a/CLI/Sources/CLIAgentBootstrap.swift
+++ b/CLI/Sources/CLIAgentBootstrap.swift
@@ -24,6 +24,7 @@ enum CLIAgentBootstrap {
             "redditreminder --json context show --limit 10",
             "redditreminder --json commands list",
             "redditreminder --json agent validate -- projects create Draft",
+            "redditreminder --json agent dry-run -- projects create Draft",
             "redditreminder --json recipes list",
             "redditreminder --json recipes search --query dry-run",
           ],
@@ -36,6 +37,7 @@ enum CLIAgentBootstrap {
           discoveryCommands: [
             "context.show",
             "agent.validate",
+            "agent.dry-run",
             "search.all",
             "commands.list",
             "commands.show",

--- a/CLI/Sources/CLIAgentDryRunner.swift
+++ b/CLI/Sources/CLIAgentDryRunner.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+enum CLIAgentDryRunner {
+  static let mutationCommands: Set<String> = [
+    "captures.create",
+    "captures.update",
+    "captures.delete",
+    "captures.mark-posted",
+    "captures.mark-queued",
+    "events.create",
+    "events.update",
+    "events.delete",
+    "projects.create",
+    "projects.update",
+    "projects.delete",
+    "subreddits.add",
+    "subreddits.update",
+    "subreddits.delete",
+    "peaks.set",
+    "peaks.reset",
+  ]
+
+  @MainActor
+  static func dryRun(input: AgentValidateInput, options: CLIOptions) async throws -> CLIResponse {
+    let tokens = CLIAgentValidator.normalizedCommand(input.command)
+    let validation = CLIAgentValidator.validationResult(for: tokens)
+    guard validation.valid else {
+      return .success(data: .agentDryRun(failed(tokens, validation, validation.errors)))
+    }
+    guard let commandId = validation.commandId, mutationCommands.contains(commandId) else {
+      let error = "Command is read-only or does not support dry-run."
+      return .success(data: .agentDryRun(failed(tokens, validation, [error])))
+    }
+
+    var dryOptions = options
+    dryOptions.dryRun = true
+    let invocation = try CLIInvocation(arguments: tokens)
+    let runner = try CLIRunner(options: dryOptions)
+    let preview = try await runner.run(command: invocation.command)
+    return .success(
+      data: .agentDryRun(
+        AgentDryRunDTO(
+          schemaVersion: 1,
+          valid: true,
+          wouldRun: tokens,
+          requiresConfirmation: true,
+          validation: validation,
+          preview: previewDTO(from: preview),
+          errors: [])))
+  }
+
+  private static func failed(
+    _ tokens: [String],
+    _ validation: AgentValidationDTO,
+    _ errors: [String]
+  ) -> AgentDryRunDTO {
+    AgentDryRunDTO(
+      schemaVersion: 1,
+      valid: false,
+      wouldRun: tokens,
+      requiresConfirmation: false,
+      validation: validation,
+      preview: nil,
+      errors: errors)
+  }
+
+  private static func previewDTO(from response: CLIResponse) -> AgentDryRunPreviewDTO {
+    let message: String?
+    if case .dryRun(let value)? = response.data {
+      message = value
+    } else {
+      message = nil
+    }
+    return AgentDryRunPreviewDTO(
+      ok: response.ok,
+      message: message,
+      warnings: response.warnings,
+      errors: response.errors)
+  }
+}

--- a/CLI/Sources/CLIAgentValidator.swift
+++ b/CLI/Sources/CLIAgentValidator.swift
@@ -7,7 +7,7 @@ enum CLIAgentValidator {
     return .success(data: .agentValidation(result))
   }
 
-  private static func normalizedCommand(_ command: [String]) -> [String] {
+  static func normalizedCommand(_ command: [String]) -> [String] {
     var tokens = command
     if let first = tokens.first,
       first == "redditreminder" || first.hasSuffix("/redditreminder")
@@ -30,7 +30,7 @@ enum CLIAgentValidator {
     return output
   }
 
-  private static func validationResult(for tokens: [String]) -> AgentValidationDTO {
+  static func validationResult(for tokens: [String]) -> AgentValidationDTO {
     guard tokens.count >= 2 else {
       return result(tokens, nil, nil, ["Expected <domain> <command>."], [])
     }

--- a/CLI/Sources/CLICommandCatalog.swift
+++ b/CLI/Sources/CLICommandCatalog.swift
@@ -36,6 +36,13 @@ enum CLICommandCatalog {
       output: output("agentValidation", "Validation result with errors and command schema.")
     ),
     command(
+      "agent.dry-run", "agent", "dry-run",
+      "Validate and preview a mutation command with dry-run forced on.",
+      positionals: [arg("command", "Mutation command tokens after --.")],
+      examples: ["redditreminder --json agent dry-run -- projects create Draft"],
+      output: output("agentDryRun", "Validation result plus forced dry-run preview.")
+    ),
+    command(
       "context.show", "context", "show",
       "Return a compact workspace snapshot for agent planning.",
       flags: [flag("--limit", "N", "Maximum items per collection. Defaults to 20.")],

--- a/CLI/Sources/CLICommandCatalogTypes.swift
+++ b/CLI/Sources/CLICommandCatalogTypes.swift
@@ -80,3 +80,20 @@ struct AgentValidationDTO: Encodable {
   let warnings: [String]
   let command: CommandReferenceDTO?
 }
+
+struct AgentDryRunDTO: Encodable {
+  let schemaVersion: Int
+  let valid: Bool
+  let wouldRun: [String]
+  let requiresConfirmation: Bool
+  let validation: AgentValidationDTO
+  let preview: AgentDryRunPreviewDTO?
+  let errors: [String]
+}
+
+struct AgentDryRunPreviewDTO: Encodable {
+  let ok: Bool
+  let message: String?
+  let warnings: [String]
+  let errors: [String]
+}

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -22,6 +22,7 @@ enum CLIResponseData: Encodable {
   case recipeReference(RecipeReferenceDTO)
   case agentBootstrap(AgentBootstrapDTO)
   case agentValidation(AgentValidationDTO)
+  case agentDryRun(AgentDryRunDTO)
   case dryRun(String)
 
   func encode(to encoder: Encoder) throws {
@@ -48,6 +49,7 @@ enum CLIResponseData: Encodable {
     case .recipeReference(let value): try container.encode(value)
     case .agentBootstrap(let value): try container.encode(value)
     case .agentValidation(let value): try container.encode(value)
+    case .agentDryRun(let value): try container.encode(value)
     case .dryRun(let value): try container.encode(["message": value])
     }
   }

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -25,6 +25,7 @@ struct CLIOptions {
 enum CLICommand {
   case agentBootstrap
   case agentValidate(AgentValidateInput)
+  case agentDryRun(AgentValidateInput)
   case capturesList(query: String?)
   case captureCreate(CaptureCreateInput)
   case captureUpdate(CaptureUpdateInput)
@@ -62,6 +63,8 @@ enum CLICommand {
       self = .agentBootstrap
     case ("agent", "validate"):
       self = .agentValidate(try parser.consumeAgentValidateInput())
+    case ("agent", "dry-run"):
+      self = .agentDryRun(try parser.consumeAgentCommandInput(usage: "dry-run"))
     case ("captures", "list"):
       self = .capturesList(query: parser.consumeOptionalValue(for: "--query"))
     case ("captures", "search"):
@@ -236,9 +239,13 @@ struct CLIArgumentParser {
   }
 
   mutating func consumeAgentValidateInput() throws -> AgentValidateInput {
+    try consumeAgentCommandInput(usage: "validate")
+  }
+
+  mutating func consumeAgentCommandInput(usage: String) throws -> AgentValidateInput {
     _ = consumeFlag("--")
     guard !arguments.isEmpty else {
-      throw CLIError.usage("Usage: redditreminder agent validate -- <domain> <command> [args]")
+      throw CLIError.usage("Usage: redditreminder agent \(usage) -- <domain> <command> [args]")
     }
     let command = arguments
     arguments.removeAll()

--- a/CLI/Sources/CLIOutput.swift
+++ b/CLI/Sources/CLIOutput.swift
@@ -88,6 +88,10 @@ enum CLIPrinter {
       return validation.valid
         ? "Valid command: \(validation.commandId ?? validation.normalizedCommand.joined(separator: " "))"
         : "Invalid command: \(validation.errors.joined(separator: "; "))"
+    case .agentDryRun(let dryRun):
+      return dryRun.valid
+        ? "Dry-run preview ready: \(dryRun.wouldRun.joined(separator: " "))"
+        : "Dry-run rejected: \(dryRun.errors.joined(separator: "; "))"
     case .dryRun(let message): return message
     }
   }
@@ -132,7 +136,7 @@ enum CLIHelp {
 
   static func domain(_ domain: String) -> String {
     switch domain {
-    case "agent": return "Usage: redditreminder agent bootstrap|validate"
+    case "agent": return "Usage: redditreminder agent bootstrap|validate|dry-run"
     case "captures":
       return
         "Usage: redditreminder captures list|search|create|update|delete|mark-posted|mark-queued"

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -28,6 +28,8 @@ final class CLIRunner {
       return CLIAgentBootstrap.show()
     case .agentValidate(let input):
       return CLIAgentValidator.validate(input: input)
+    case .agentDryRun(let input):
+      return try await CLIAgentDryRunner.dryRun(input: input, options: options)
     case .capturesList(let query):
       return .success(data: .captures(fetchCaptures(matching: query).map(CaptureDTO.init)))
     case .captureCreate(let input):

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		CC6A10A2CEA907B520EEE2F3 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */; };
 		CCE3B3D5EE4B39D55222CA19 /* ResourcePackagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A9BB4582DA895A6C18C321 /* ResourcePackagingTests.swift */; };
 		CE614FCDDCCDE1DA0C484E58 /* CaptureMediaSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B642ED62D86AC09680939A1 /* CaptureMediaSelectionTests.swift */; };
+		CF43177BB20A1FC060A78599 /* CLIAgentDryRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861F39432972E1CC1377F282 /* CLIAgentDryRunner.swift */; };
 		CFDA6CE34A7768D4CF33D759 /* HeuristicsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1D8A8A7F250226B68B172F /* HeuristicsStore.swift */; };
 		D4C25F69F19FB5F035561B86 /* CaptureMediaAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256FB5A83C11819FC96533BA /* CaptureMediaAccessibility.swift */; };
 		D70537E281AB16807DE1E2FA /* CLICaptureCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C71FB925E32942AFE42575 /* CLICaptureCreator.swift */; };
@@ -317,6 +318,7 @@
 		843A01564D830A81EEF54CF9 /* NotificationSettingsOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsOpener.swift; sourceTree = "<group>"; };
 		84C5DAE3A8EB7A0149E897CD /* NotificationSchedulerPermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSchedulerPermissionTests.swift; sourceTree = "<group>"; };
 		85FE2A447522454CC9824DD4 /* CLIProjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIProjectManager.swift; sourceTree = "<group>"; };
+		861F39432972E1CC1377F282 /* CLIAgentDryRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAgentDryRunner.swift; sourceTree = "<group>"; };
 		8667BBC305F7B1E7A92856AC /* CaptureHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureHelpers.swift; sourceTree = "<group>"; };
 		88999911A1A3157EE5DBB4A7 /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		8A6C6B2B1A559FEFF67B391F /* RRuleOccurrenceEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleOccurrenceEdgeCaseTests.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 			isa = PBXGroup;
 			children = (
 				9BF046679692C90640222864 /* CLIAgentBootstrap.swift */,
+				861F39432972E1CC1377F282 /* CLIAgentDryRunner.swift */,
 				C6642BDB50320A87AB68443A /* CLIAgentValidator.swift */,
 				237DBF1605FF8CDD5CDD51A5 /* CLIArgumentParserCaptures.swift */,
 				C1DDFC92B31A2562246F8D58 /* CLIArgumentParserConfig.swift */,
@@ -854,6 +857,7 @@
 			files = (
 				EA9B4D6D73A9BE87850EB6B1 /* AppRefreshAction.swift in Sources */,
 				D866DE76F83DD239C8C16BE6 /* CLIAgentBootstrap.swift in Sources */,
+				CF43177BB20A1FC060A78599 /* CLIAgentDryRunner.swift in Sources */,
 				E9484CB4CA514954F2C5D1F3 /* CLIAgentValidator.swift in Sources */,
 				407571238A58E84A82F37D32 /* CLIArgumentParserCaptures.swift in Sources */,
 				7A921D8AE858EAC9BC2C9556 /* CLIArgumentParserConfig.swift in Sources */,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,7 @@ JSON responses use this envelope:
 ```sh
 redditreminder agent bootstrap --json
 redditreminder agent validate -- projects create "Launch Ideas" --json
+redditreminder agent dry-run -- projects create "Launch Ideas" --json
 redditreminder context show --json
 redditreminder context show --limit 5 --json
 redditreminder search all --query "launch" --json
@@ -72,6 +73,9 @@ mutations safely, and includes command and recipe schemas in the same response.
 `agent validate -- <domain> <command> [args]` checks a proposed CLI command
 against the command catalog without executing it. The validation response reports
 unknown commands, unknown flags, missing required flags, and missing positionals.
+`agent dry-run -- <domain> <command> [args]` validates a proposed mutation,
+rejects read-only commands, forces `--dry-run`, and returns the preview response
+that should be shown to the user before confirmation.
 `AGENTS.md` is the repo-level bootstrap guide for agents starting from source.
 `context show` returns a compact snapshot of the workspace: counts, projects,
 subreddits with peak summaries, queued captures, active events, and peak presets.

--- a/scripts/cli-agent-smoke.sh
+++ b/scripts/cli-agent-smoke.sh
@@ -48,6 +48,17 @@ assert_contains "validate invalid ok" "$invalid_command" '"ok":true'
 assert_contains "validate invalid" "$invalid_command" '"valid":false'
 assert_contains "validate missing flag" "$invalid_command" "Missing required flag --hours."
 
+dry_run_preview="$(run_json agent dry-run -- projects create "Agent Draft")"
+assert_contains "agent dry-run ok" "$dry_run_preview" '"ok":true'
+assert_contains "agent dry-run valid" "$dry_run_preview" '"valid":true'
+assert_contains "agent dry-run confirmation" "$dry_run_preview" '"requiresConfirmation":true'
+assert_contains "agent dry-run preview" "$dry_run_preview" "Would create project Agent Draft."
+
+read_only_preview="$(run_json agent dry-run -- context show --limit 1)"
+assert_contains "agent dry-run read-only ok" "$read_only_preview" '"ok":true'
+assert_contains "agent dry-run read-only invalid" "$read_only_preview" '"valid":false'
+assert_contains "agent dry-run read-only rejected" "$read_only_preview" "read-only"
+
 context="$(run_json context show --limit 10)"
 assert_contains "context ok" "$context" '"ok":true'
 assert_contains "context counts" "$context" '"counts":'


### PR DESCRIPTION
## Summary
- add agent dry-run command that validates proposed mutations and forces CLI dry-run mode
- return structured dry-run previews with confirmation metadata for coding agents
- document and smoke-test the new bootstrap workflow

## Verification
- make cli-test
- git diff --check
- ./scripts/format-check.sh
- build/Build/Products/Debug/redditreminder --json agent dry-run -- projects create "Agent Draft"
- build/Build/Products/Debug/redditreminder --json agent dry-run -- context show --limit 1
- build/Build/Products/Debug/redditreminder --json agent dry-run -- totally unknown