### PR TITLE
Add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RedditReminder
 
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-7289da?style=flat&logo=discord&logoColor=white)](https://discord.gg/7xsxU4ZG6A)
+
 macOS menu bar app for preparing Reddit posts, tracking subreddit posting windows, and getting nudged when it is time to post.
 
 ## Workflow


### PR DESCRIPTION
## Summary
- Add Discord badge linking to the neonwatty projects community server
- Points to #general channel with a permanent invite link