### PR TITLE
Support video media attachments

### DIFF
--- a/CLI/Sources/CLICommandCatalogCaptures.swift
+++ b/CLI/Sources/CLICommandCatalogCaptures.swift
@@ -28,8 +28,8 @@ extension CLICommandCatalog {
         flag("--project", "NAME_OR_ID", "Existing project."),
         flag("--subreddit", "NAME_OR_ID", "Existing subreddit.", repeatable: true),
         flag("--subreddits", "A,B", "Comma-separated subreddits."),
-        flag("--media", "PATH", "Image path to copy into media store.", repeatable: true),
-        flag("--media-paths", "A,B", "Comma-separated image paths."),
+        flag("--media", "PATH", "Image or video path to copy into media store.", repeatable: true),
+        flag("--media-paths", "A,B", "Comma-separated image or video paths."),
         flag("--due", "ISO8601", "Create one due event per selected subreddit."),
       ],
       examples: [

--- a/CLI/Sources/CLIRecipeCatalog.swift
+++ b/CLI/Sources/CLIRecipeCatalog.swift
@@ -38,12 +38,12 @@ enum CLIRecipeCatalog {
   static let coreRecipes: [RecipeReferenceDTO] = [
     recipe(
       "posting.create-with-media",
-      "Create a queued post with image media and a due posting window.",
-      goal: "Given a title, body, image path, subreddit, and due date, create the capture and its posting-window event.",
+      "Create a queued post with image or video media and a due posting window.",
+      goal: "Given a title, body, media path, subreddit, and due date, create the capture and its posting-window event.",
       inputs: [
         input("title", "Post title."),
         input("text", "Post body."),
-        input("mediaPath", "Local image path to attach."),
+        input("mediaPath", "Local image or video path to attach."),
         input("subreddit", "Existing subreddit name or id."),
         input("due", "ISO8601 posting-window date."),
         input("project", "Optional existing project name or id.", required: false),

--- a/CLI/Sources/CLIRecipeCatalogDryRun.swift
+++ b/CLI/Sources/CLIRecipeCatalogDryRun.swift
@@ -4,12 +4,12 @@ extension CLIRecipeCatalog {
   static let dryRunRecipes: [RecipeReferenceDTO] = [
     recipe(
       "posting.create-with-media-dry-run",
-      "Safely preview and then create a queued post with image media.",
+      "Safely preview and then create a queued post with image or video media.",
       goal: "Inspect state, preview capture creation with --dry-run, wait for confirmation, execute the create, and verify the result.",
       inputs: [
         input("title", "Post title."),
         input("text", "Post body."),
-        input("mediaPath", "Local image path to attach."),
+        input("mediaPath", "Local image or video path to attach."),
         input("subreddit", "Existing subreddit name or id."),
         input("due", "ISO8601 posting-window date."),
         input("project", "Optional existing project name or id.", required: false),

--- a/Sources/Services/MediaStore.swift
+++ b/Sources/Services/MediaStore.swift
@@ -44,13 +44,17 @@ final class MediaStore {
 
   func saveFile(at sourceURL: URL, captureId: UUID) throws -> String {
     let ext = sourceURL.pathExtension.lowercased()
-    guard MediaConstants.supportedImageTypes.contains(ext) else {
+    if MediaConstants.supportedImageTypes.contains(ext) {
+      guard let image = NSImage(contentsOf: sourceURL) else {
+        throw MediaError.decodingFailed
+      }
+      return try save(image: image, captureId: captureId, fileName: sourceURL.lastPathComponent)
+    }
+
+    guard MediaConstants.supportedVideoTypes.contains(ext) else {
       throw MediaError.unsupportedType
     }
-    guard let image = NSImage(contentsOf: sourceURL) else {
-      throw MediaError.decodingFailed
-    }
-    return try save(image: image, captureId: captureId, fileName: sourceURL.lastPathComponent)
+    return try copyFile(at: sourceURL, captureId: captureId)
   }
 
   func loadImage(captureId: UUID, ref: String) -> NSImage? {
@@ -79,17 +83,29 @@ final class MediaStore {
 
   func saveData(_ data: Data, captureId: UUID, ref: String) throws {
     guard isValidMediaRef(ref) else { throw MediaError.invalidReference }
-    guard let image = NSImage(data: data) else { throw MediaError.decodingFailed }
+    let ext = URL(fileURLWithPath: ref).pathExtension.lowercased()
+    guard MediaConstants.supportedTypes.contains(ext) else { throw MediaError.unsupportedType }
     let captureDir = rootDir.appendingPathComponent(captureId.uuidString)
     let thumbDir = captureDir.appendingPathComponent("thumbnails")
-    try fm.createDirectory(at: captureDir, withIntermediateDirectories: true)
-    try fm.createDirectory(at: thumbDir, withIntermediateDirectories: true)
-    try data.write(to: mediaURL(captureId: captureId, ref: ref))
-
-    let thumbnail = generateThumbnail(from: image, maxSize: MediaConstants.thumbnailMaxSize)
-    if let thumbData = pngData(from: thumbnail) {
-      try thumbData.write(to: thumbnailURL(captureId: captureId, ref: ref))
+    if MediaConstants.supportedImageTypes.contains(ext) {
+      guard let image = NSImage(data: data) else { throw MediaError.decodingFailed }
+      try fm.createDirectory(at: captureDir, withIntermediateDirectories: true)
+      try data.write(to: mediaURL(captureId: captureId, ref: ref))
+      try fm.createDirectory(at: thumbDir, withIntermediateDirectories: true)
+      let thumbnail = generateThumbnail(from: image, maxSize: MediaConstants.thumbnailMaxSize)
+      if let thumbData = pngData(from: thumbnail) {
+        try thumbData.write(to: thumbnailURL(captureId: captureId, ref: ref))
+      }
+    } else {
+      try fm.createDirectory(at: captureDir, withIntermediateDirectories: true)
+      try data.write(to: mediaURL(captureId: captureId, ref: ref))
     }
+  }
+
+  func isVideoRef(_ ref: String) -> Bool {
+    guard isValidMediaRef(ref) else { return false }
+    return MediaConstants.supportedVideoTypes.contains(
+      URL(fileURLWithPath: ref).pathExtension.lowercased())
   }
 
   private func mediaURL(captureId: UUID, ref: String) -> URL {
@@ -170,6 +186,14 @@ final class MediaStore {
       index += 1
     }
     return candidate
+  }
+
+  private func copyFile(at sourceURL: URL, captureId: UUID) throws -> String {
+    let captureDir = rootDir.appendingPathComponent(captureId.uuidString)
+    try fm.createDirectory(at: captureDir, withIntermediateDirectories: true)
+    let storedName = uniqueFileName(sourceURL.lastPathComponent, in: captureDir)
+    try fm.copyItem(at: sourceURL, to: captureDir.appendingPathComponent(storedName))
+    return storedName
   }
 
   private func isValidMediaRef(_ ref: String) -> Bool {

--- a/Sources/Utilities/CaptureMediaSelection.swift
+++ b/Sources/Utilities/CaptureMediaSelection.swift
@@ -3,17 +3,25 @@ import UniformTypeIdentifiers
 
 enum CaptureMediaSelection {
     struct Result: Equatable {
-        let imageURLs: [URL]
+        let mediaURLs: [URL]
         let rejectedCount: Int
     }
 
+    static func mediaURLs(from urls: [URL]) -> [URL] {
+        result(from: urls).mediaURLs
+    }
+
     static func imageURLs(from urls: [URL]) -> [URL] {
-        result(from: urls).imageURLs
+        mediaURLs(from: urls)
     }
 
     static func result(from urls: [URL]) -> Result {
-        let imageURLs = urls.filter(isImageURL)
-        return Result(imageURLs: imageURLs, rejectedCount: urls.count - imageURLs.count)
+        let mediaURLs = urls.filter(isMediaURL)
+        return Result(mediaURLs: mediaURLs, rejectedCount: urls.count - mediaURLs.count)
+    }
+
+    static func isMediaURL(_ url: URL) -> Bool {
+        isImageURL(url) || isVideoURL(url)
     }
 
     static func isImageURL(_ url: URL) -> Bool {
@@ -23,5 +31,14 @@ enum CaptureMediaSelection {
 
         guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
         return type.conforms(to: .image)
+    }
+
+    static func isVideoURL(_ url: URL) -> Bool {
+        if let contentType = try? url.resourceValues(forKeys: [.contentTypeKey]).contentType {
+            return contentType.conforms(to: .movie) || contentType.conforms(to: .video)
+        }
+
+        guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
+        return type.conforms(to: .movie) || type.conforms(to: .video)
     }
 }

--- a/Sources/Views/CaptureCardView.swift
+++ b/Sources/Views/CaptureCardView.swift
@@ -175,7 +175,7 @@ struct CaptureCardView: View {
       parts.append("\(capture.links.count) link\(capture.links.count == 1 ? "" : "s")")
     }
     if !capture.mediaRefs.isEmpty {
-      parts.append("\(capture.mediaRefs.count) image\(capture.mediaRefs.count == 1 ? "" : "s")")
+      parts.append("\(capture.mediaRefs.count) media file\(capture.mediaRefs.count == 1 ? "" : "s")")
     }
     if capture.notes != nil {
       parts.append("notes")

--- a/Sources/Views/CaptureMediaChips.swift
+++ b/Sources/Views/CaptureMediaChips.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CaptureMediaChip: View {
     let title: String
     let image: NSImage?
+    var isVideo: Bool = false
     let previewIdentifier: String
     let removeIdentifier: String
     let onPreview: () -> Void
@@ -40,6 +41,9 @@ struct CaptureMediaChip: View {
                 .scaledToFill()
                 .frame(width: 18, height: 18)
                 .clipShape(RoundedRectangle(cornerRadius: 3))
+        } else if isVideo {
+            Image(systemName: "film")
+                .font(.system(size: 10))
         } else {
             Image(systemName: "photo")
                 .font(.system(size: 9))
@@ -50,6 +54,7 @@ struct CaptureMediaChip: View {
 struct RemovedCaptureMediaChip: View {
     let title: String
     let image: NSImage?
+    var isVideo: Bool = false
     let restoreIdentifier: String
     let onRestore: () -> Void
 
@@ -83,6 +88,9 @@ struct RemovedCaptureMediaChip: View {
                 .scaledToFill()
                 .frame(width: 18, height: 18)
                 .clipShape(RoundedRectangle(cornerRadius: 3))
+        } else if isVideo {
+            Image(systemName: "film")
+                .font(.system(size: 10))
         } else {
             Image(systemName: "photo")
                 .font(.system(size: 9))

--- a/Sources/Views/CaptureMediaSection.swift
+++ b/Sources/Views/CaptureMediaSection.swift
@@ -22,6 +22,7 @@ struct CaptureMediaSection: View {
             CaptureMediaChip(
               title: ref,
               image: mediaStore.loadThumbnail(captureId: captureId, ref: ref),
+              isVideo: mediaStore.isVideoRef(ref),
               previewIdentifier: CaptureMediaAccessibility.previewExisting(ref: ref),
               removeIdentifier: CaptureMediaAccessibility.removeExisting(ref: ref),
               onPreview: {
@@ -47,6 +48,7 @@ struct CaptureMediaSection: View {
             RemovedCaptureMediaChip(
               title: ref,
               image: mediaStore.loadThumbnail(captureId: captureId, ref: ref),
+              isVideo: mediaStore.isVideoRef(ref),
               restoreIdentifier: CaptureMediaAccessibility.restoreExisting(ref: ref),
               onRestore: {
                 CaptureMediaEditing.restoreExisting(
@@ -67,6 +69,7 @@ struct CaptureMediaSection: View {
             CaptureMediaChip(
               title: url.lastPathComponent,
               image: NSImage(contentsOf: url),
+              isVideo: CaptureMediaSelection.isVideoURL(url),
               previewIdentifier: CaptureMediaAccessibility.previewNew(
                 fileName: url.lastPathComponent),
               removeIdentifier: CaptureMediaAccessibility.removeNew(index: index),
@@ -85,7 +88,7 @@ struct CaptureMediaSection: View {
         .stroke(Color(NSColor.separatorColor), style: StrokeStyle(lineWidth: 1, dash: [6]))
         .frame(height: 48)
         .overlay {
-          Text("Drop images here or ").font(.system(size: 11)).foregroundStyle(.secondary)
+          Text("Drop images or videos here or ").font(.system(size: 11)).foregroundStyle(.secondary)
             + Text("browse").font(.system(size: 11)).foregroundStyle(.blue)
         }
         .background(isDragOver ? Color.blue.opacity(0.05) : Color.clear)
@@ -97,12 +100,12 @@ struct CaptureMediaSection: View {
         }
         .fileImporter(
           isPresented: $isShowingImporter,
-          allowedContentTypes: [.image],
+          allowedContentTypes: [.image, .movie],
           allowsMultipleSelection: true
         ) { result in
           switch result {
           case .success(let urls):
-            appendImageFiles(urls)
+            appendMediaFiles(urls)
           case .failure(let error):
             NSLog("RedditReminder: media import failed: \(error)")
           }
@@ -146,10 +149,11 @@ struct CaptureMediaSection: View {
     let value: NSImage
   }
 
-  private func appendImageFiles(_ urls: [URL]) {
+  private func appendMediaFiles(_ urls: [URL]) {
     let result = CaptureMediaSelection.result(from: urls)
-    droppedFiles.append(contentsOf: result.imageURLs)
-    mediaSelectionError = result.rejectedCount > 0 ? "Only image files can be attached." : nil
+    droppedFiles.append(contentsOf: result.mediaURLs)
+    mediaSelectionError =
+      result.rejectedCount > 0 ? "Only image or video files can be attached." : nil
   }
 
   private func handleFileDrop(_ providers: [NSItemProvider]) -> Bool {
@@ -159,7 +163,7 @@ struct CaptureMediaSection: View {
           NSLog("RedditReminder: file drop failed: \(error)")
           return
         }
-        if let url { Task { @MainActor in appendImageFiles([url]) } }
+        if let url { Task { @MainActor in appendMediaFiles([url]) } }
       }
     }
     return true

--- a/Tests/RedditReminderTests/BackupMediaPayloadTests.swift
+++ b/Tests/RedditReminderTests/BackupMediaPayloadTests.swift
@@ -55,6 +55,37 @@ import Testing
     #expect(destinationMediaStore.loadThumbnail(captureId: sourceCapture.id, ref: ref) != nil)
 }
 
+@Test @MainActor func backupImportRestoresEmbeddedVideoMediaFiles() throws {
+    let sourceContainer = try makeBackupContainer()
+    let sourceContext = ModelContext(sourceContainer)
+    let sourceMediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+    let sourceCapture = Capture(text: "With video")
+    sourceContext.insert(sourceCapture)
+    let ref = try sourceMediaStore.saveFile(
+        at: try writeBackupVideoFixture(named: "demo.mp4"),
+        captureId: sourceCapture.id
+    )
+    sourceCapture.mediaRefs = [ref]
+    try sourceContext.save()
+    let data = try BackupService().exportBackup(from: sourceContext, mediaStore: sourceMediaStore)
+
+    let destinationContainer = try makeBackupContainer()
+    let destinationContext = ModelContext(destinationContainer)
+    let destinationMediaStore = MediaStore(rootDir: temporaryBackupMediaRoot())
+
+    try BackupService().importBackup(
+        from: data,
+        into: destinationContext,
+        mediaStore: destinationMediaStore
+    )
+
+    let captures = try destinationContext.fetch(FetchDescriptor<Capture>())
+    #expect(captures.count == 1)
+    #expect(captures[0].mediaRefs == [ref])
+    #expect(destinationMediaStore.exists(captureId: sourceCapture.id, ref: ref))
+    #expect(destinationMediaStore.loadThumbnail(captureId: sourceCapture.id, ref: ref) == nil)
+}
+
 @Test @MainActor func backupImportRejectsEmbeddedMediaWithInvalidRefsBeforeClearingData() throws {
     let container = try makeBackupContainer()
     let context = ModelContext(container)
@@ -177,4 +208,11 @@ private func backupPNGFixtureData() throws -> Data {
         throw MediaError.encodingFailed
     }
     return png
+}
+
+private func writeBackupVideoFixture(named fileName: String) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+    try Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]).write(to: url)
+    return url
 }

--- a/Tests/RedditReminderTests/CaptureMediaSelectionTests.swift
+++ b/Tests/RedditReminderTests/CaptureMediaSelectionTests.swift
@@ -2,22 +2,27 @@ import Foundation
 import Testing
 @testable import RedditReminder
 
-@Test func mediaSelectionKeepsImageURLsAndRejectsTextFiles() throws {
+@Test func mediaSelectionKeepsImageAndVideoURLsAndRejectsTextFiles() throws {
     let imageURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("\(UUID().uuidString).png")
+    let videoURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(UUID().uuidString).mp4")
     let textURL = FileManager.default.temporaryDirectory
         .appendingPathComponent("\(UUID().uuidString).txt")
     try Data([0x89, 0x50, 0x4E, 0x47]).write(to: imageURL)
+    try Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]).write(to: videoURL)
     try "not an image".write(to: textURL, atomically: true, encoding: .utf8)
     defer {
         try? FileManager.default.removeItem(at: imageURL)
+        try? FileManager.default.removeItem(at: videoURL)
         try? FileManager.default.removeItem(at: textURL)
     }
 
-    let result = CaptureMediaSelection.result(from: [imageURL, textURL])
-    #expect(result.imageURLs == [imageURL])
+    let result = CaptureMediaSelection.result(from: [imageURL, videoURL, textURL])
+    #expect(result.mediaURLs == [imageURL, videoURL])
     #expect(result.rejectedCount == 1)
-    #expect(CaptureMediaSelection.imageURLs(from: [imageURL, textURL]) == [imageURL])
+    #expect(CaptureMediaSelection.mediaURLs(from: [imageURL, videoURL, textURL]) == [imageURL, videoURL])
+    #expect(CaptureMediaSelection.imageURLs(from: [imageURL, videoURL, textURL]) == [imageURL, videoURL])
 }
 
 @Test func mediaSelectionAllowsDuplicateImageURLs() throws {

--- a/Tests/RedditReminderTests/CapturePersistenceActionsTests.swift
+++ b/Tests/RedditReminderTests/CapturePersistenceActionsTests.swift
@@ -47,6 +47,38 @@ private func makeCapturePersistenceContainer() throws -> ModelContainer {
     #expect(mediaStore.loadImage(captureId: captures[0].id, ref: captures[0].mediaRefs[0]) != nil)
 }
 
+@Test @MainActor func saveCapturePersistsVideoMediaRefs() throws {
+    let container = try makeCapturePersistenceContainer()
+    let context = ModelContext(container)
+    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+    let subreddit = Subreddit(name: "r/SwiftUI")
+    context.insert(subreddit)
+    try context.save()
+
+    let sourceURL = try writeTestVideo(named: "demo.mp4")
+    defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+    let ok = CapturePersistenceActions.saveCapture(
+        CaptureFormResult(
+            text: "Video draft",
+            notes: nil,
+            links: [],
+            project: nil,
+            subreddits: [subreddit],
+            mediaURLs: [sourceURL]
+        ),
+        modelContext: context,
+        mediaStore: mediaStore
+    )
+
+    let captures = try context.fetch(FetchDescriptor<Capture>())
+    #expect(ok)
+    #expect(captures.count == 1)
+    #expect(captures[0].mediaRefs == ["demo.mp4"])
+    #expect(mediaStore.exists(captureId: captures[0].id, ref: "demo.mp4"))
+    #expect(mediaStore.loadThumbnail(captureId: captures[0].id, ref: "demo.mp4") == nil)
+}
+
 @Test @MainActor func updateCaptureRemovesDeletedMediaAfterSave() throws {
     let container = try makeCapturePersistenceContainer()
     let context = ModelContext(container)
@@ -164,6 +196,12 @@ private func writeTestImage(named fileName: String) throws -> URL {
 private func writeTextFile(named fileName: String) throws -> URL {
     let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
     try "not media".write(to: url, atomically: true, encoding: .utf8)
+    return url
+}
+
+private func writeTestVideo(named fileName: String) throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+    try Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]).write(to: url)
     return url
 }
 

--- a/Tests/RedditReminderTests/MediaStoreTests.swift
+++ b/Tests/RedditReminderTests/MediaStoreTests.swift
@@ -66,6 +66,26 @@ import AppKit
   #expect(store.loadThumbnail(captureId: captureId, ref: ref) != nil)
 }
 
+@Test func saveFileCopiesDroppedVideoIntoMediaStore() throws {
+  let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let store = MediaStore(rootDir: rootDir)
+  let sourceURL = rootDir
+    .deletingLastPathComponent()
+    .appendingPathComponent("\(UUID().uuidString).mp4")
+  let data = Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])
+  try data.write(to: sourceURL)
+  defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+  let captureId = UUID()
+  let ref = try store.saveFile(at: sourceURL, captureId: captureId)
+
+  #expect(ref == sourceURL.lastPathComponent)
+  #expect(store.exists(captureId: captureId, ref: ref))
+  #expect(store.isVideoRef(ref))
+  #expect(store.loadThumbnail(captureId: captureId, ref: ref) == nil)
+  #expect(try store.loadData(captureId: captureId, ref: ref) == data)
+}
+
 @Test func saveFileGeneratesUniqueRefsForDuplicateNames() throws {
   let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
   let store = MediaStore(rootDir: rootDir)
@@ -168,6 +188,19 @@ import AppKit
   } catch {
     throw error
   }
+}
+
+@Test func saveDataRestoresVideoWithoutThumbnail() throws {
+  let rootDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  let store = MediaStore(rootDir: rootDir)
+  let captureId = UUID()
+  let data = Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])
+
+  try store.saveData(data, captureId: captureId, ref: "clip.mp4")
+
+  #expect(store.exists(captureId: captureId, ref: "clip.mp4"))
+  #expect(store.loadThumbnail(captureId: captureId, ref: "clip.mp4") == nil)
+  #expect(try store.loadData(captureId: captureId, ref: "clip.mp4") == data)
 }
 
 private func createTestImage(width: Int, height: Int) -> NSImage {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,7 +93,7 @@ patterns that preview changes before executing them.
 ```sh
 redditreminder captures list --json
 redditreminder captures search --query "launch" --json
-redditreminder captures create --title "Launch post" --text "Post body" --project "Launch Ideas" --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z --json
+redditreminder captures create --title "Launch post" --text "Post body" --project "Launch Ideas" --subreddit SideProject --media ~/Desktop/mock.mp4 --due 2026-05-02T18:00:00Z --json
 redditreminder captures update CAPTURE_ID --title "Updated title" --clear-notes --json
 redditreminder captures mark-posted CAPTURE_ID --url "https://reddit.com/r/SideProject/comments/abc" --json
 redditreminder captures mark-queued CAPTURE_ID --json
@@ -111,8 +111,8 @@ redditreminder captures delete CAPTURE_ID --json
 --project NAME_OR_ID  Existing project name or UUID.
 --subreddit NAME      Repeatable existing subreddit name or UUID.
 --subreddits A,B      Comma-separated subreddits.
---media PATH          Repeatable image path copied into the media store.
---media-paths A,B     Comma-separated image paths.
+--media PATH          Repeatable image/video path copied into the media store.
+--media-paths A,B     Comma-separated image/video paths.
 --due ISO8601         Creates one one-off posting-window event per chosen subreddit.
 ```
 


### PR DESCRIPTION
## Summary
- Allow MP4/MOV files through media selection, drag/drop, file import, persistence, and backup restore paths
- Store video files without image decoding or thumbnail generation while keeping image behavior unchanged
- Update media chips, capture summaries, CLI help, recipes, docs, and tests to describe image/video media

## Verification
- make cli-test
- make build-debug
- make build-cli
- isolated CLI MP4 capture create smoke
- ./scripts/cli-smoke.sh
- ./scripts/format-check.sh (passed; swift-format warnings 5063 vs baseline 5511)

Note: a full make test run was attempted serially but had to be interrupted after hanging in the existing AppDelegate scheduling/finalize-log path; no media-specific failure was observed before interruption.