### PR TITLE
[codex] Harden RedditReminder critique findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     if: github.event_name == 'pull_request'
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      package_metadata: ${{ steps.filter.outputs.package_metadata }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,6 +43,11 @@ jobs:
               - 'scripts/**'
               - '.github/**'
               - '.gitignore'
+            package_metadata:
+              - 'package.json'
+              - 'package-lock.json'
+              - '.releaserc.json'
+              - 'commitlint.config.cjs'
 
   lint:
     name: Lint
@@ -181,6 +187,67 @@ jobs:
       - name: Run CLI tests
         run: make cli-test
 
+  ui-tests:
+    name: UI Tests
+    runs-on: macos-15
+    timeout-minutes: 25
+    needs: [detect-changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' ||
+       needs.detect-changes.outputs.code == 'true')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -version
+      - name: Install xcodegen
+        run: brew install xcodegen
+      - name: Generate Xcode project
+        run: xcodegen generate
+      - name: Run UI tests
+        run: >
+          xcodebuild test
+          -project RedditReminder.xcodeproj
+          -scheme RedditReminderUITests
+          -configuration Debug
+          -destination 'platform=macOS'
+          -derivedDataPath build
+          CODE_SIGN_IDENTITY="-"
+          CODE_SIGN_STYLE=Manual
+          DEVELOPMENT_TEAM=
+          ENABLE_DEBUG_DYLIB=NO
+          ENABLE_HARDENED_RUNTIME=NO
+          OTHER_CODE_SIGN_FLAGS=
+          -resultBundlePath UITestResults.xcresult
+      - name: Upload UI test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results
+          path: UITestResults.xcresult
+          retention-days: 14
+
+  package-metadata:
+    name: Package Metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [detect-changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' ||
+       needs.detect-changes.outputs.package_metadata == 'true')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Validate package metadata
+        run: |
+          npm ci
+          node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8')); JSON.parse(require('fs').readFileSync('package-lock.json', 'utf8')); JSON.parse(require('fs').readFileSync('.releaserc.json', 'utf8')); require('./commitlint.config.cjs');"
+
   file-size-check:
     name: File Size Check
     runs-on: macos-latest
@@ -211,6 +278,8 @@ jobs:
       - build
       - unit-tests
       - cli-tests
+      - ui-tests
+      - package-metadata
       - file-size-check
     steps:
       - name: Check required jobs
@@ -219,10 +288,12 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_RESULT: ${{ needs.unit-tests.result }}
           CLI_TEST_RESULT: ${{ needs.cli-tests.result }}
+          UI_TEST_RESULT: ${{ needs.ui-tests.result }}
+          PACKAGE_METADATA_RESULT: ${{ needs.package-metadata.result }}
           SIZE_RESULT: ${{ needs.file-size-check.result }}
         run: |
-          echo "Lint: $LINT_RESULT, Build: $BUILD_RESULT, Tests: $TEST_RESULT, CLI: $CLI_TEST_RESULT, Size: $SIZE_RESULT"
-          for result in "$LINT_RESULT" "$BUILD_RESULT" "$TEST_RESULT" "$CLI_TEST_RESULT" "$SIZE_RESULT"; do
+          echo "Lint: $LINT_RESULT, Build: $BUILD_RESULT, Tests: $TEST_RESULT, CLI: $CLI_TEST_RESULT, UI: $UI_TEST_RESULT, Package: $PACKAGE_METADATA_RESULT, Size: $SIZE_RESULT"
+          for result in "$LINT_RESULT" "$BUILD_RESULT" "$TEST_RESULT" "$CLI_TEST_RESULT" "$UI_TEST_RESULT" "$PACKAGE_METADATA_RESULT" "$SIZE_RESULT"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "A required job reported: $result"
               exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ with than the full bootstrap payload.
 
 - Search workspace state: `redditreminder --json search all --query "launch"`
 - Create a project: `redditreminder --json projects create "Launch Ideas"`
+- Create captures only with at least one destination: `redditreminder --json captures create --title "Launch" --subreddit SideProject`
 - Add a subreddit safely: `redditreminder --json subreddits add --verify SideProject`
 - Configure peaks: `redditreminder --json peaks set SideProject --days mon,wed --hours 9,10`
 - Preview a mutation: `redditreminder --json --dry-run projects create "Draft"`

--- a/CLI/Sources/CLIAgentValidator.swift
+++ b/CLI/Sources/CLIAgentValidator.swift
@@ -48,13 +48,19 @@ enum CLIAgentValidator {
 
     let missingFlags = command.flags.filter { $0.required && !parsed.flags.contains($0.name) }
     errors.append(contentsOf: missingFlags.map { "Missing required flag \($0.name)." })
+    if commandId == "captures.create",
+      !parsed.flags.contains("--subreddit") && !parsed.flags.contains("--subreddits")
+    {
+      errors.append("Missing required destination: provide --subreddit or --subreddits.")
+    }
 
     let requiredPositionals = command.positionals.filter(\.required).count
     if parsed.positionals.count < requiredPositionals {
       errors.append("Missing required positional argument.")
     } else if command.positionals.isEmpty && !parsed.positionals.isEmpty {
       warnings.append("Command catalog does not define positional arguments for extra text.")
-    } else if command.positionals.count > 1 && parsed.positionals.count > command.positionals.count {
+    } else if command.positionals.count > 1 && parsed.positionals.count > command.positionals.count
+    {
       warnings.append("Command has more positional values than the catalog defines.")
     }
     return result(tokens, commandId, command, errors, warnings)

--- a/CLI/Sources/CLIArgumentParserCaptures.swift
+++ b/CLI/Sources/CLIArgumentParserCaptures.swift
@@ -32,6 +32,9 @@ extension CLIArgumentParser {
     guard input.title != nil || !input.text.isEmpty else {
       throw CLIError.usage("Capture create requires --text, --title, or trailing text.")
     }
+    guard !input.subreddits.isEmpty else {
+      throw CLIError.usage("Capture create requires --subreddit or --subreddits.")
+    }
     return input
   }
 
@@ -74,5 +77,21 @@ extension CLIArgumentParser {
       throw CLIError.usage("Capture update requires at least one field flag.")
     }
     return input
+  }
+
+  mutating func consumeCapturePostStatusInput() throws -> CapturePostStatusInput {
+    let id = try consumeRequiredArgument(label: "capture id")
+    return CapturePostStatusInput(
+      id: id,
+      subreddit: normalizedOptional(consumeOptionalValue(for: "--subreddit")),
+      url: normalizedOptional(consumeOptionalValue(for: "--url"))
+    )
+  }
+
+  mutating func consumeCaptureQueueStatusInput() throws -> CaptureQueueStatusInput {
+    CaptureQueueStatusInput(
+      id: try consumeRequiredArgument(label: "capture id"),
+      subreddit: normalizedOptional(consumeOptionalValue(for: "--subreddit"))
+    )
   }
 }

--- a/CLI/Sources/CLICaptureLifecycle.swift
+++ b/CLI/Sources/CLICaptureLifecycle.swift
@@ -69,22 +69,46 @@ struct CLICaptureLifecycle {
     return .success(data: .deleted(DeletedDTO(id: deletedId)))
   }
 
-  func markPosted(id: String, url: String?) throws -> CLIResponse {
-    let capture = try findCapture(id)
-    if options.dryRun {
-      return .success(data: .dryRun("Would mark capture \(capture.id.uuidString) posted."))
+  func markPosted(input: CapturePostStatusInput) throws -> CLIResponse {
+    let capture = try findCapture(input.id)
+    let subreddit = try input.subreddit.map(findSubreddit)
+    if let subreddit, !capture.subreddits.contains(where: { $0.id == subreddit.id }) {
+      throw CLIError.validation("\(subreddit.name) is not a target subreddit for this capture.")
     }
-    capture.markAsPosted(postedURL: url)
+    if options.dryRun {
+      let target = subreddit.map { " for \($0.name)" } ?? ""
+      return .success(data: .dryRun("Would mark capture \(capture.id.uuidString) posted\(target)."))
+    }
+    if let subreddit {
+      capture.markSubredditAsPosted(subreddit.id)
+      if capture.status == .posted {
+        capture.postedURL = input.url
+      }
+    } else {
+      capture.markAsPosted(postedURL: input.url)
+    }
     try context.save()
     return .success(data: .capture(CaptureDTO(capture)))
   }
 
-  func markQueued(id: String) throws -> CLIResponse {
-    let capture = try findCapture(id)
-    if options.dryRun {
-      return .success(data: .dryRun("Would mark capture \(capture.id.uuidString) queued."))
+  func markQueued(input: CaptureQueueStatusInput) throws -> CLIResponse {
+    let capture = try findCapture(input.id)
+    let subreddit = try input.subreddit.map(findSubreddit)
+    if let subreddit, !capture.subreddits.contains(where: { $0.id == subreddit.id }) {
+      throw CLIError.validation("\(subreddit.name) is not a target subreddit for this capture.")
     }
-    capture.markAsQueued()
+    if options.dryRun {
+      let target = subreddit.map { " for \($0.name)" } ?? ""
+      return .success(data: .dryRun("Would mark capture \(capture.id.uuidString) queued\(target)."))
+    }
+    if let subreddit {
+      capture.markSubredditAsUnposted(subreddit.id)
+      if capture.status == .queued {
+        capture.postedURL = nil
+      }
+    } else {
+      capture.markAsQueued()
+    }
     try context.save()
     return .success(data: .capture(CaptureDTO(capture)))
   }

--- a/CLI/Sources/CLICommandCatalogCaptures.swift
+++ b/CLI/Sources/CLICommandCatalogCaptures.swift
@@ -18,7 +18,7 @@ extension CLICommandCatalog {
     ),
     command(
       "captures.create", "captures", "create",
-      "Create a queued capture, optionally with media and due events.",
+      "Create a queued capture for one or more existing subreddits, optionally with media and due events.",
       flags: [
         flag("--title", "TEXT", "Optional post title."),
         flag("--text", "TEXT", "Post body. Trailing text is used when omitted."),
@@ -26,8 +26,11 @@ extension CLICommandCatalog {
         flag("--link", "URL", "Add one link.", repeatable: true),
         flag("--links", "A,B", "Comma-separated links."),
         flag("--project", "NAME_OR_ID", "Existing project."),
-        flag("--subreddit", "NAME_OR_ID", "Existing subreddit.", repeatable: true),
-        flag("--subreddits", "A,B", "Comma-separated subreddits."),
+        flag(
+          "--subreddit", "NAME_OR_ID", "Existing subreddit. Required unless --subreddits is used.",
+          repeatable: true),
+        flag(
+          "--subreddits", "A,B", "Comma-separated subreddits. Required unless --subreddit is used."),
         flag("--media", "PATH", "Image or video path to copy into media store.", repeatable: true),
         flag("--media-paths", "A,B", "Comma-separated image or video paths."),
         flag("--due", "ISO8601", "Create one due event per selected subreddit."),
@@ -71,17 +74,27 @@ extension CLICommandCatalog {
     ),
     command(
       "captures.mark-posted", "captures", "mark-posted",
-      "Mark a capture as posted.",
+      "Mark a capture, or one target subreddit on a capture, as posted.",
       positionals: [arg("id", "Capture UUID.")],
-      flags: [flag("--url", "URL", "Posted Reddit URL.")],
-      examples: ["redditreminder --json captures mark-posted CAPTURE_ID --url https://reddit.com/..."],
+      flags: [
+        flag("--subreddit", "NAME_OR_ID", "Mark only this target subreddit as posted."),
+        flag("--url", "URL", "Posted Reddit URL."),
+      ],
+      examples: [
+        "redditreminder --json captures mark-posted CAPTURE_ID --subreddit SideProject",
+        "redditreminder --json captures mark-posted CAPTURE_ID --url https://reddit.com/...",
+      ],
       output: output("capture", "Updated capture object.")
     ),
     command(
       "captures.mark-queued", "captures", "mark-queued",
-      "Move a posted capture back to queued.",
+      "Move a posted capture, or one target subreddit on a capture, back to queued.",
       positionals: [arg("id", "Capture UUID.")],
-      examples: ["redditreminder --json captures mark-queued CAPTURE_ID"],
+      flags: [flag("--subreddit", "NAME_OR_ID", "Move only this target subreddit back to queued.")],
+      examples: [
+        "redditreminder --json captures mark-queued CAPTURE_ID --subreddit SideProject",
+        "redditreminder --json captures mark-queued CAPTURE_ID",
+      ],
       output: output("capture", "Updated capture object.")
     ),
   ]

--- a/CLI/Sources/CLIDTOs.swift
+++ b/CLI/Sources/CLIDTOs.swift
@@ -66,6 +66,17 @@ struct CaptureCreateInput {
   let due: String?
 }
 
+struct CapturePostStatusInput {
+  let id: String
+  let subreddit: String?
+  let url: String?
+}
+
+struct CaptureQueueStatusInput {
+  let id: String
+  let subreddit: String?
+}
+
 struct AgentValidateInput {
   let command: [String]
 }
@@ -154,6 +165,7 @@ struct CaptureDTO: Encodable {
   let postedURL: String?
   let project: ProjectRefDTO?
   let subreddits: [SubredditRefDTO]
+  let subredditProgress: [CaptureSubredditProgressDTO]
 
   init(_ capture: Capture) {
     id = capture.id.uuidString
@@ -167,7 +179,25 @@ struct CaptureDTO: Encodable {
     postedAt = capture.postedAt.map(CLIFormat.date)
     postedURL = capture.postedURL
     project = capture.project.map(ProjectRefDTO.init)
-    subreddits = capture.subreddits.sorted { $0.sortOrder < $1.sortOrder }.map(SubredditRefDTO.init)
+    let sortedSubreddits = capture.subreddits.sorted { $0.sortOrder < $1.sortOrder }
+    subreddits = sortedSubreddits.map(SubredditRefDTO.init)
+    let postedSubredditIDs = Set(capture.postedSubredditIDs)
+    subredditProgress = sortedSubreddits.map { subreddit in
+      CaptureSubredditProgressDTO(
+        subreddit: subreddit, posted: postedSubredditIDs.contains(subreddit.id))
+    }
+  }
+}
+
+struct CaptureSubredditProgressDTO: Encodable {
+  let id: String
+  let name: String
+  let posted: Bool
+
+  init(subreddit: Subreddit, posted: Bool) {
+    id = subreddit.id.uuidString
+    name = subreddit.name
+    self.posted = posted
   }
 }
 

--- a/CLI/Sources/CLIInvocation.swift
+++ b/CLI/Sources/CLIInvocation.swift
@@ -30,8 +30,8 @@ enum CLICommand {
   case captureCreate(CaptureCreateInput)
   case captureUpdate(CaptureUpdateInput)
   case captureDelete(id: String)
-  case captureMarkPosted(id: String, url: String?)
-  case captureMarkQueued(id: String)
+  case captureMarkPosted(CapturePostStatusInput)
+  case captureMarkQueued(CaptureQueueStatusInput)
   case eventsList(EventListInput)
   case eventCreate(EventCreateInput)
   case eventUpdate(EventUpdateInput)
@@ -76,10 +76,9 @@ enum CLICommand {
     case ("captures", "delete"):
       self = .captureDelete(id: try parser.consumeRequiredArgument(label: "capture id"))
     case ("captures", "mark-posted"):
-      let id = try parser.consumeRequiredArgument(label: "capture id")
-      self = .captureMarkPosted(id: id, url: parser.consumeOptionalValue(for: "--url"))
+      self = .captureMarkPosted(try parser.consumeCapturePostStatusInput())
     case ("captures", "mark-queued"):
-      self = .captureMarkQueued(id: try parser.consumeRequiredArgument(label: "capture id"))
+      self = .captureMarkQueued(try parser.consumeCaptureQueueStatusInput())
     case ("events", "list"):
       self = .eventsList(try parser.consumeEventListInput(queryRequired: false))
     case ("events", "search"):

--- a/CLI/Sources/CLIRecipeCatalog.swift
+++ b/CLI/Sources/CLIRecipeCatalog.swift
@@ -20,17 +20,15 @@ enum CLIRecipeCatalog {
   }
 
   private static func searchableText(for recipe: RecipeReferenceDTO) -> String {
-    (
-      [
-        recipe.id,
-        recipe.summary,
-        recipe.goal,
-        recipe.examples.joined(separator: " "),
-        recipe.relatedCommands.joined(separator: " "),
-      ]
+    ([
+      recipe.id,
+      recipe.summary,
+      recipe.goal,
+      recipe.examples.joined(separator: " "),
+      recipe.relatedCommands.joined(separator: " "),
+    ]
       + recipe.inputs.map { "\($0.name) \($0.summary)" }
-      + recipe.steps.map { "\($0.commandId) \($0.purpose) \($0.example)" }
-    ).joined(separator: " ")
+      + recipe.steps.map { "\($0.commandId) \($0.purpose) \($0.example)" }).joined(separator: " ")
   }
 
   static let recipes: [RecipeReferenceDTO] = coreRecipes + dryRunRecipes
@@ -39,7 +37,8 @@ enum CLIRecipeCatalog {
     recipe(
       "posting.create-with-media",
       "Create a queued post with image or video media and a due posting window.",
-      goal: "Given a title, body, media path, subreddit, and due date, create the capture and its posting-window event.",
+      goal:
+        "Given a title, body, media path, subreddit, and due date, create the capture and its posting-window event.",
       inputs: [
         input("title", "Post title."),
         input("text", "Post body."),
@@ -56,7 +55,8 @@ enum CLIRecipeCatalog {
         step(
           2, "captures.create",
           "Create the queued capture, copy media, and add a due event.",
-          "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"),
+          "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"
+        ),
         step(
           3, "context.show",
           "Verify the queued capture and upcoming event are visible.",
@@ -68,7 +68,8 @@ enum CLIRecipeCatalog {
     recipe(
       "workspace.recommend-targets",
       "Inspect the workspace before recommending subreddits and times.",
-      goal: "Gather enough state to recommend where and when a draft should be posted without mutating data.",
+      goal:
+        "Gather enough state to recommend where and when a draft should be posted without mutating data.",
       inputs: [
         input("topic", "Topic or launch text to search for."),
         input("limit", "Maximum rows per context collection.", required: false),
@@ -92,8 +93,9 @@ enum CLIRecipeCatalog {
     ),
     recipe(
       "subreddit.configure-peak-times",
-      "Add or verify a subreddit and configure its peak posting windows.",
-      goal: "Create a subreddit safely, then apply local peak days and hours used to generate posting events.",
+      "Add subreddit, verify it, and configure its peak posting windows.",
+      goal:
+        "Create a subreddit safely, then apply local peak days and hours used to generate posting events.",
       inputs: [
         input("subreddit", "Subreddit name or Reddit URL."),
         input("days", "Comma-separated day keys such as mon,wed,fri."),
@@ -112,7 +114,8 @@ enum CLIRecipeCatalog {
         step(
           3, "peaks.set",
           "Apply local peak days and hours; generated events resync automatically.",
-          "redditreminder --json peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"),
+          "redditreminder --json peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"
+        ),
         step(
           4, "peaks.get",
           "Confirm the effective peak configuration.",

--- a/CLI/Sources/CLIRecipeCatalogDryRun.swift
+++ b/CLI/Sources/CLIRecipeCatalogDryRun.swift
@@ -5,7 +5,8 @@ extension CLIRecipeCatalog {
     recipe(
       "posting.create-with-media-dry-run",
       "Safely preview and then create a queued post with image or video media.",
-      goal: "Inspect state, preview capture creation with --dry-run, wait for confirmation, execute the create, and verify the result.",
+      goal:
+        "Inspect state, preview capture creation with --dry-run, wait for confirmation, execute the create, and verify the result.",
       inputs: [
         input("title", "Post title."),
         input("text", "Post body."),
@@ -26,11 +27,13 @@ extension CLIRecipeCatalog {
         step(
           3, "captures.create",
           "Preview the capture creation without saving app data.",
-          "redditreminder --json --dry-run captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"),
+          "redditreminder --json --dry-run captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"
+        ),
         step(
           4, "captures.create",
           "After user confirmation, create the capture and due posting-window event.",
-          "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"),
+          "redditreminder --json captures create --title 'Launch' --text 'Body' --subreddit SideProject --media ~/Desktop/mock.png --due 2026-05-02T18:00:00Z"
+        ),
         step(
           5, "context.show",
           "Verify the queued capture and event are visible.",
@@ -41,8 +44,9 @@ extension CLIRecipeCatalog {
     ),
     recipe(
       "subreddit.configure-peak-times-dry-run",
-      "Safely preview and then configure subreddit peak times.",
-      goal: "Verify the subreddit, inspect current peak settings, preview the peak override, wait for confirmation, apply it, and verify generated events.",
+      "Add subreddit safely by verifying it, previewing changes, and configuring peak times.",
+      goal:
+        "Verify the subreddit, inspect current peak settings, preview the peak override, wait for confirmation, apply it, and verify generated events.",
       inputs: [
         input("subreddit", "Existing subreddit name or id."),
         input("days", "Comma-separated day keys such as mon,wed,fri."),
@@ -61,11 +65,13 @@ extension CLIRecipeCatalog {
         step(
           3, "peaks.set",
           "Preview the peak override without saving app data.",
-          "redditreminder --json --dry-run peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"),
+          "redditreminder --json --dry-run peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"
+        ),
         step(
           4, "peaks.set",
           "After user confirmation, save the peak override and resync generated events.",
-          "redditreminder --json peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"),
+          "redditreminder --json peaks set SideProject --days mon,wed --hours 9,10 --timezone America/Phoenix"
+        ),
         step(
           5, "peaks.get",
           "Verify the updated effective peak configuration.",
@@ -77,9 +83,10 @@ extension CLIRecipeCatalog {
     recipe(
       "project.archive-dry-run",
       "Safely preview and then archive a project.",
-      goal: "Find the project, preview archival with --dry-run, wait for confirmation, archive it, and verify project state.",
+      goal:
+        "Find the project, preview archival with --dry-run, wait for confirmation, archive it, and verify project state.",
       inputs: [
-        input("project", "Existing project name or id."),
+        input("project", "Existing project name or id.")
       ],
       steps: [
         step(

--- a/CLI/Sources/CLIRunner.swift
+++ b/CLI/Sources/CLIRunner.swift
@@ -38,11 +38,10 @@ final class CLIRunner {
       return try CLICaptureLifecycle(options: options, context: context).update(input: input)
     case .captureDelete(let id):
       return try CLICaptureLifecycle(options: options, context: context).delete(id: id)
-    case .captureMarkPosted(let id, let url):
-      return try CLICaptureLifecycle(options: options, context: context).markPosted(
-        id: id, url: url)
-    case .captureMarkQueued(let id):
-      return try CLICaptureLifecycle(options: options, context: context).markQueued(id: id)
+    case .captureMarkPosted(let input):
+      return try CLICaptureLifecycle(options: options, context: context).markPosted(input: input)
+    case .captureMarkQueued(let input):
+      return try CLICaptureLifecycle(options: options, context: context).markQueued(input: input)
     case .eventsList(let input):
       return try CLIEventManager(options: options, context: context).list(input: input)
     case .eventCreate(let input):

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ make qa
 
 The QA script uses System Events and CGWindowList, so the terminal needs Accessibility and Screen Recording permissions.
 The UI test target exercises native menu/window smoke coverage. It requires macOS UI automation permission for Xcode or the invoking terminal, and a signing setup that can run XCTest UI bundles.
+UI tests launch RedditReminder with a per-test `--ui-test-store` path so `--seed-qa` and `--clear-qa` operate on isolated SwiftData storage instead of the normal app store.
+CI runs unit, CLI, and UI test jobs for code changes. Package and release metadata
+changes run a lightweight npm metadata validation job. Coverage is reported and
+uploaded by CI, but it is not enforced as a numeric gate yet.
 
 ## Notes
 

--- a/RedditReminder.xcodeproj/project.pbxproj
+++ b/RedditReminder.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		326E8AD5FB53C2321638FA11 /* RRuleInvalidInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA9529C3BB40299A84C6FB8 /* RRuleInvalidInputTests.swift */; };
 		347F4FD54749869424F5CD6C /* SubredditPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B43770F07184CA5B9115AD /* SubredditPersistenceActionsTests.swift */; };
 		34A742D186F38DF2BCA6AB97 /* BackupImportValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9B6699AB8158EF4CE8C9DF /* BackupImportValidationTests.swift */; };
+		34F77E36D2BA03E16EA09248 /* PostHandoffView+Destinations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236898BE0FC838682277A1D7 /* PostHandoffView+Destinations.swift */; };
 		35019FA152D3938D32F1CD28 /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		3686DE3CF630B2A2461E80ED /* CaptureEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331A38F1DC4F9E18A7D4A332 /* CaptureEdgeCaseTests.swift */; };
 		39599A62DE082B83B172E166 /* EventSourceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA0E39705C2A66347A1E21C /* EventSourceSummary.swift */; };
@@ -102,6 +103,7 @@
 		5C0D0E781F591772712EFB08 /* SubredditRowHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF61A85A98656AA6B6499C /* SubredditRowHelpers.swift */; };
 		5C7C1DE86B921C9BEC82DED5 /* CLICommandCatalogConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0562480A128BF2812DB8536B /* CLICommandCatalogConfig.swift */; };
 		5CA152F3AF2710572F6500B9 /* AppDelegateSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF8CF5E2ADCE8C17BC17231 /* AppDelegateSchedulingTests.swift */; };
+		5D06CE718204FE768D5C9CB3 /* ProjectActionsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADDA8904A434AB3D8A490CBB /* ProjectActionsMenu.swift */; };
 		5E9E214B7FD7706B64F703BA /* PlannerTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3788B79517572C51854172CC /* PlannerTabView.swift */; };
 		5EC386BDC953ADC9C0C7FC1A /* Subreddit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA306067C4690F4D1CDAC2D /* Subreddit.swift */; };
 		5F1D46DD680783625B42F553 /* ProjectPersistenceActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654481D1BBF7AF8DA529EA7E /* ProjectPersistenceActionsTests.swift */; };
@@ -253,6 +255,7 @@
 		1F6975993534B39BF8DEB32E /* BackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupService.swift; sourceTree = "<group>"; };
 		20605F46A9FD49C870EBC32D /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
 		23399264919E264763449E07 /* PostingChecklistItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingChecklistItems.swift; sourceTree = "<group>"; };
+		236898BE0FC838682277A1D7 /* PostHandoffView+Destinations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHandoffView+Destinations.swift"; sourceTree = "<group>"; };
 		237DBF1605FF8CDD5CDD51A5 /* CLIArgumentParserCaptures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIArgumentParserCaptures.swift; sourceTree = "<group>"; };
 		2462E2B8BF95342CCBB4FC70 /* ProjectCRUDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCRUDTests.swift; sourceTree = "<group>"; };
 		256FB5A83C11819FC96533BA /* CaptureMediaAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaAccessibility.swift; sourceTree = "<group>"; };
@@ -367,6 +370,7 @@
 		ABAFC3BF96ACD4F01D08367F /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		AD3C4FF9EDB23763DEF6DCBD /* CaptureMediaChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureMediaChips.swift; sourceTree = "<group>"; };
 		AD7532CAA943BDB70D1E3541 /* CLICommandCatalogCaptures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICommandCatalogCaptures.swift; sourceTree = "<group>"; };
+		ADDA8904A434AB3D8A490CBB /* ProjectActionsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectActionsMenu.swift; sourceTree = "<group>"; };
 		AE1122ADEB6045619C303C31 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		AEE4E14F7A70E1A66FA994A3 /* Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capture.swift; sourceTree = "<group>"; };
 		B14A6B7A047D5672F9159659 /* CLIOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIOutput.swift; sourceTree = "<group>"; };
@@ -702,8 +706,10 @@
 				07A63D3714291E8917CA1694 /* PopoverContentView.swift */,
 				1C701C57FBE1AFC895E8CF40 /* PostedListView.swift */,
 				303FB325A99764563E4FB2AC /* PostHandoffView.swift */,
+				236898BE0FC838682277A1D7 /* PostHandoffView+Destinations.swift */,
 				DCB15AEFC17C70DC66CA4A05 /* PostHandoffViewHelpers.swift */,
 				28906380DECDA56AD0DDE325 /* PreferencesView.swift */,
+				ADDA8904A434AB3D8A490CBB /* ProjectActionsMenu.swift */,
 				1F66F6C53D3F37EBF882C677 /* ProjectsTabView.swift */,
 				BB9D18BDF63A57734A4A6C7A /* ShortcutRecorderInput.swift */,
 				90876C6D9E2430D963222BFB /* ShortcutRecorderView.swift */,
@@ -1074,12 +1080,14 @@
 				4571169CFBCD9757344904F2 /* PopoverContentRoutes.swift in Sources */,
 				EA437C7902BEFE4C1F701586 /* PopoverContentView.swift in Sources */,
 				2D2A3ADE0E9F1C8BE10A948A /* PopoverTimingPresentation.swift in Sources */,
+				34F77E36D2BA03E16EA09248 /* PostHandoffView+Destinations.swift in Sources */,
 				0FED0DF0846890CB2DEE1F53 /* PostHandoffView.swift in Sources */,
 				0D450A66EF492AF4779AD92B /* PostHandoffViewHelpers.swift in Sources */,
 				3B26AC6E0CA725948AA2CA74 /* PostedListView.swift in Sources */,
 				62761A56A55BD30D9D7FC87E /* PostingChecklistItems.swift in Sources */,
 				B64C0B3A5EF8D5A8827074C1 /* PreferencesView.swift in Sources */,
 				4ED4F0F35E3D250D13E85CF6 /* Project.swift in Sources */,
+				5D06CE718204FE768D5C9CB3 /* ProjectActionsMenu.swift in Sources */,
 				12B7E4C8F9AB781325FFC21F /* ProjectPersistenceActions.swift in Sources */,
 				73DA1B8D3DA7E2410FAD189D /* ProjectsTabView.swift in Sources */,
 				C898B37A4DBF7694EA095857 /* QAFixtureMedia.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -133,7 +133,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   private func bootstrapApplication() {
     let container: ModelContainer
     do {
-      container = try AppModelContainerFactory.makeContainer()
+      container = try AppModelContainerFactory.makeContainer(storeURL: AppRuntime.uiTestStoreURL())
     } catch {
       presentStoreUnavailableAlert(error: error)
       return
@@ -292,7 +292,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     )
   }
 
-  func scheduleNotifications(activeEvents: [SubredditEvent], windows: [TimingEngine.UpcomingWindow]) async {
+  func scheduleNotifications(activeEvents: [SubredditEvent], windows: [TimingEngine.UpcomingWindow])
+    async
+  {
     _ = await notificationScheduler.schedule(activeEvents: activeEvents, windows: windows)
   }
 }

--- a/Sources/App/AppDelegateNotifications.swift
+++ b/Sources/App/AppDelegateNotifications.swift
@@ -2,63 +2,64 @@ import SwiftData
 @preconcurrency import UserNotifications
 
 extension AppDelegate {
-    nonisolated func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping @Sendable () -> Void
-    ) {
-        let userInfo = response.notification.request.content.userInfo
-        let subredditName = userInfo[AppNotificationIdentifiers.subredditNameUserInfoKey] as? String
-        let actionId = response.actionIdentifier
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+  ) {
+    let userInfo = response.notification.request.content.userInfo
+    let subredditName = userInfo[AppNotificationIdentifiers.subredditNameUserInfoKey] as? String
+    let actionId = response.actionIdentifier
 
-        Task { @MainActor in
-            self.handleNotificationAction(actionId, subredditName: subredditName)
-            completionHandler()
-        }
+    Task { @MainActor in
+      self.handleNotificationAction(actionId, subredditName: subredditName)
+      completionHandler()
     }
+  }
 
-    nonisolated func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping @Sendable (UNNotificationPresentationOptions) -> Void
-    ) {
-        completionHandler([.banner, .sound])
-    }
+  nonisolated func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler:
+      @escaping @Sendable (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner, .sound])
+  }
 
-    func handleNotificationAction(_ actionId: String, subredditName: String?) {
-        switch actionId {
-        case AppNotificationIdentifiers.markPostedAction:
-            if let subredditName {
-                markCapturesAsPosted(forSubreddit: subredditName)
-            }
-            openPopoverForNotificationAction()
-        case UNNotificationDefaultActionIdentifier, AppNotificationIdentifiers.openAction:
-            openPopoverForNotificationAction()
-        default:
-            break
-        }
+  func handleNotificationAction(_ actionId: String, subredditName: String?) {
+    switch actionId {
+    case AppNotificationIdentifiers.markPostedAction:
+      if let subredditName {
+        markCapturesAsPosted(forSubreddit: subredditName)
+      }
+      openPopoverForNotificationAction()
+    case UNNotificationDefaultActionIdentifier, AppNotificationIdentifiers.openAction:
+      openPopoverForNotificationAction()
+    default:
+      break
     }
+  }
 
-    func markCapturesAsPosted(forSubreddit name: String) {
-        guard let container = modelContainer else {
-            NSLog("RedditReminder: markCapturesAsPosted skipped - no ModelContainer")
-            return
-        }
-        let context = container.mainContext
-        do {
-            let captures = try context.fetch(FetchDescriptor<Capture>())
-            let matching = captures.filter { capture in
-                capture.status == .queued &&
-                capture.subreddits.contains { $0.name == name }
-            }
-            for capture in matching {
-                capture.markAsPosted()
-            }
-            try context.save()
-            NSLog("RedditReminder: marked \(matching.count) captures as posted for \(name)")
-            runRefreshCycle()
-        } catch {
-            NSLog("RedditReminder: failed to mark captures as posted: \(error)")
-        }
+  func markCapturesAsPosted(forSubreddit name: String) {
+    guard let container = modelContainer else {
+      NSLog("RedditReminder: markCapturesAsPosted skipped - no ModelContainer")
+      return
     }
+    let context = container.mainContext
+    do {
+      let captures = try context.fetch(FetchDescriptor<Capture>())
+      let matching = captures.filter { capture in
+        capture.status == .queued && capture.subreddits.contains { $0.name == name }
+      }
+      for capture in matching {
+        guard let subreddit = capture.subreddits.first(where: { $0.name == name }) else { continue }
+        capture.markSubredditAsPosted(subreddit.id)
+      }
+      try context.save()
+      NSLog("RedditReminder: marked \(matching.count) captures as posted for \(name)")
+      runRefreshCycle()
+    } catch {
+      NSLog("RedditReminder: failed to mark captures as posted: \(error)")
+    }
+  }
 }

--- a/Sources/App/AppModelContainerFactory.swift
+++ b/Sources/App/AppModelContainerFactory.swift
@@ -2,38 +2,49 @@ import Foundation
 import SwiftData
 
 enum AppModelContainerFactory {
-    static var schemaTypes: [any PersistentModel.Type] {
-        [Project.self, Capture.self, Subreddit.self, SubredditEvent.self]
+  static var schemaTypes: [any PersistentModel.Type] {
+    [Project.self, Capture.self, Subreddit.self, SubredditEvent.self]
+  }
+
+  static var schema: Schema {
+    Schema(schemaTypes)
+  }
+
+  static var appSupportDirectory: URL {
+    FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("RedditReminder", isDirectory: true)
+  }
+
+  static func makePersistentContainer(storeURL: URL? = nil) throws -> ModelContainer {
+    if let storeURL {
+      let directory = storeURL.deletingLastPathComponent()
+      try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+      let configuration = ModelConfiguration("RedditReminderUITests", schema: schema, url: storeURL)
+      return try ModelContainer(for: schema, configurations: configuration)
     }
 
-    static var schema: Schema {
-        Schema(schemaTypes)
-    }
+    return try ModelContainer(for: schema)
+  }
 
-    static var appSupportDirectory: URL {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("RedditReminder", isDirectory: true)
-    }
+  static func makeInMemoryContainer() throws -> ModelContainer {
+    let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(for: schema, configurations: configuration)
+  }
 
-    static func makePersistentContainer() throws -> ModelContainer {
-        try ModelContainer(for: schema)
+  static func makeContainer(storeURL: URL? = nil) throws -> ModelContainer {
+    try makeContainer {
+      try makePersistentContainer(storeURL: storeURL)
     }
+  }
 
-    static func makeInMemoryContainer() throws -> ModelContainer {
-        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        return try ModelContainer(for: schema, configurations: configuration)
+  static func makeContainer(makePersistentContainer: () throws -> ModelContainer) throws
+    -> ModelContainer
+  {
+    do {
+      return try makePersistentContainer()
+    } catch {
+      NSLog("RedditReminder: failed to create persistent ModelContainer: \(error)")
+      throw error
     }
-
-    static func makeContainer() throws -> ModelContainer {
-        try makeContainer(makePersistentContainer: makePersistentContainer)
-    }
-
-    static func makeContainer(makePersistentContainer: () throws -> ModelContainer) throws -> ModelContainer {
-        do {
-            return try makePersistentContainer()
-        } catch {
-            NSLog("RedditReminder: failed to create persistent ModelContainer: \(error)")
-            throw error
-        }
-    }
+  }
 }

--- a/Sources/Models/Capture.swift
+++ b/Sources/Models/Capture.swift
@@ -62,17 +62,32 @@ final class Capture {
   }
 
   func markSubredditAsPosted(_ subredditId: UUID) {
-    guard !postedSubredditIDs.contains(subredditId) else { return }
-    postedSubredditIDs.append(subredditId)
-    if Set(postedSubredditIDs) == Set(subreddits.map(\.id)) {
-      status = .posted
-      postedAt = Date()
+    guard subreddits.contains(where: { $0.id == subredditId }) else { return }
+    if !postedSubredditIDs.contains(subredditId) {
+      postedSubredditIDs.append(subredditId)
     }
+    reconcilePostingStateForCurrentSubreddits()
   }
 
   func markSubredditAsUnposted(_ subredditId: UUID) {
     postedSubredditIDs.removeAll { $0 == subredditId }
-    if status == .posted {
+    reconcilePostingStateForCurrentSubreddits()
+  }
+
+  func reconcilePostingStateForCurrentSubreddits() {
+    let currentSubredditIDs = subreddits.map(\.id)
+    let currentSubredditIDSet = Set(currentSubredditIDs)
+    var seenSubredditIDs = Set<UUID>()
+    postedSubredditIDs = postedSubredditIDs.filter { subredditId in
+      currentSubredditIDSet.contains(subredditId) && seenSubredditIDs.insert(subredditId).inserted
+    }
+
+    if !currentSubredditIDs.isEmpty && Set(postedSubredditIDs) == currentSubredditIDSet {
+      status = .posted
+      if postedAt == nil {
+        postedAt = Date()
+      }
+    } else {
       status = .queued
       postedAt = nil
     }

--- a/Sources/Utilities/AppRuntime.swift
+++ b/Sources/Utilities/AppRuntime.swift
@@ -1,16 +1,36 @@
 import Foundation
 
 enum AppRuntime {
-    static func isRunningUnitTests(
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> Bool {
-        environment["XCTestConfigurationFilePath"] != nil ||
-            environment["XCTestBundlePath"] != nil
+  static let uiTestStoreLaunchArgument = "--ui-test-store"
+
+  static func isRunningUnitTests(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> Bool {
+    environment["XCTestConfigurationFilePath"] != nil || environment["XCTestBundlePath"] != nil
+  }
+
+  static func shouldRegisterGlobalShortcut(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> Bool {
+    !isRunningUnitTests(environment: environment)
+  }
+
+  static func uiTestStoreURL(arguments: [String] = ProcessInfo.processInfo.arguments) -> URL? {
+    for (index, argument) in arguments.enumerated() {
+      if argument == uiTestStoreLaunchArgument {
+        let valueIndex = arguments.index(after: index)
+        guard arguments.indices.contains(valueIndex) else { return nil }
+        return URL(fileURLWithPath: arguments[valueIndex])
+      }
+
+      let prefix = "\(uiTestStoreLaunchArgument)="
+      if argument.hasPrefix(prefix) {
+        let path = String(argument.dropFirst(prefix.count))
+        guard !path.isEmpty else { return nil }
+        return URL(fileURLWithPath: path)
+      }
     }
 
-    static func shouldRegisterGlobalShortcut(
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> Bool {
-        !isRunningUnitTests(environment: environment)
-    }
+    return nil
+  }
 }

--- a/Sources/Utilities/CapturePersistenceActions.swift
+++ b/Sources/Utilities/CapturePersistenceActions.swift
@@ -67,6 +67,7 @@ enum CapturePersistenceActions {
     capture.mediaRefs.append(contentsOf: newlySavedRefs)
     capture.project = result.project
     capture.subreddits = result.subreddits
+    capture.reconcilePostingStateForCurrentSubreddits()
 
     do {
       try modelContext.save()

--- a/Sources/Utilities/RedditPostingActions.swift
+++ b/Sources/Utilities/RedditPostingActions.swift
@@ -35,6 +35,14 @@ enum RedditPostingActions {
   }
 
   @MainActor
+  static func submitURL(for capture: Capture, subredditId: UUID) -> URL? {
+    guard let subreddit = capture.subreddits.first(where: { $0.id == subredditId }) else {
+      return nil
+    }
+    return submitURL(forSubredditName: subreddit.name)
+  }
+
+  @MainActor
   static func titleText(for capture: Capture) -> String {
     capture.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
   }

--- a/Sources/Views/CaptureWindowView+FormState.swift
+++ b/Sources/Views/CaptureWindowView+FormState.swift
@@ -91,6 +91,28 @@ extension CaptureWindowView {
     )
   }
 
+  var hasUnsavedEditChanges: Bool {
+    guard case .edit(let capture) = mode else { return false }
+    return currentDraft
+      != CaptureFormDraft(
+        title: capture.title ?? "",
+        text: capture.text,
+        notes: capture.notes ?? "",
+        selectedProjectId: capture.project?.id,
+        selectedSubredditIds: Set(capture.subreddits.map(\.id)),
+        links: capture.links
+      )
+  }
+
+  func addSubredditFromPicker() {
+    if hasUnsavedEditChanges {
+      saveError = "Save or cancel this edit before adding a channel."
+      return
+    }
+
+    onAddSubreddit(currentDraft)
+  }
+
   func save() {
     guard canSave else { return }
     let selectedSubs = subreddits.filter { selectedSubreddits.contains($0.id) }

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -8,6 +8,7 @@ struct CaptureWindowView: View {
   }
 
   static let saveRequirementsAccessibilityIdentifier = "captureWindow.saveRequirements"
+  static let contentRequirementText = "Add a title or capture text to save."
 
   let mode: Mode
   var initialDraft: CaptureFormDraft?
@@ -38,7 +39,7 @@ struct CaptureWindowView: View {
       Divider()
       ScrollView {
         VStack(alignment: .leading, spacing: 12) {
-          fieldSection("TITLE", optional: true) {
+          fieldSection("TITLE") {
             TextField("Add a Reddit post title...", text: $title)
               .font(.system(size: 12))
               .textFieldStyle(.plain)
@@ -48,7 +49,7 @@ struct CaptureWindowView: View {
               .accessibilityIdentifier("captureWindow.title")
           }
 
-          fieldSection("CAPTURE TEXT", optional: true) {
+          fieldSection("CAPTURE TEXT") {
             VStack(spacing: 6) {
               HStack {
                 Spacer()
@@ -90,13 +91,18 @@ struct CaptureWindowView: View {
                   .accessibilityLabel("Capture text")
                   .accessibilityIdentifier("captureWindow.text")
               }
+              Text(Self.contentRequirementText)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityIdentifier("captureWindow.contentRequirement")
             }
           }
           fieldSection("SUBREDDIT", required: true) {
             CaptureSubredditPicker(
               subreddits: subreddits,
               selectedSubreddits: $selectedSubreddits,
-              onAddSubreddit: { onAddSubreddit(currentDraft) }
+              onAddSubreddit: addSubredditFromPicker
             )
 
             if let saveRequirementsMessage, selectedSubreddits.isEmpty {

--- a/Sources/Views/ChannelsView.swift
+++ b/Sources/Views/ChannelsView.swift
@@ -15,6 +15,8 @@ struct ChannelsTabView: View {
   static let createFirstCaptureButtonText = "Create first capture"
   static let addSubredditPlaceholder = "Subreddit name"
   static let addSubredditButtonText = "Add channel"
+  static let localOnlyChannelText =
+    "App additions are local-only; verify with redditreminder subreddits verify when needed."
   static let emptyListText = "Added channels will appear here."
   static let expandsNewSubredditAfterAdd = false
 
@@ -52,6 +54,12 @@ struct ChannelsTabView: View {
             .font(.system(size: 10))
             .foregroundStyle(feedbackMessage.isError ? .red : .secondary)
         }
+
+        Text(Self.localOnlyChannelText)
+          .font(.system(size: 10))
+          .foregroundStyle(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+          .accessibilityIdentifier("channels.localOnlyVerification")
 
         if didAddFirstChannel {
           firstChannelNextStep

--- a/Sources/Views/PopoverContentActions.swift
+++ b/Sources/Views/PopoverContentActions.swift
@@ -140,6 +140,24 @@ extension PopoverContentView {
     }
   }
 
+  func openRedditSubmitPage(for capture: Capture, subredditId: UUID) {
+    guard let url = RedditPostingActions.submitURL(for: capture, subredditId: subredditId) else {
+      showToast("Subreddit is not on this capture", style: .error)
+      return
+    }
+
+    let text = RedditPostingActions.clipboardText(for: capture)
+    if !text.isEmpty {
+      _ = RedditPostingActions.copyText(text)
+    }
+
+    if NSWorkspace.shared.open(url) {
+      showToast("Copied text and opened Reddit")
+    } else {
+      showToast("Could not open Reddit", style: .error)
+    }
+  }
+
   func openPostedURL(for capture: Capture) {
     guard
       let postedURL = capture.postedURL,

--- a/Sources/Views/PopoverContentRoutes.swift
+++ b/Sources/Views/PopoverContentRoutes.swift
@@ -13,7 +13,7 @@ extension PopoverContentView {
             saveCapture(result)
           case .edit(let capture):
             updateCapture(capture, with: result)
-        }
+          }
         guard didSave else { return false }
         if mode.isCreate {
           pendingCreateDraft = nil
@@ -48,6 +48,9 @@ extension PopoverContentView {
       onCopyLinks: { copyPostLinks(for: capture) },
       onCopyAll: { copyPostHandoffText(for: capture) },
       onOpenSubmit: { openRedditSubmitPage(for: capture) },
+      onOpenSubmitForSubreddit: { subredditId in
+        openRedditSubmitPage(for: capture, subredditId: subredditId)
+      },
       onMarkPosted: { markCaptureAsPosted(capture) },
       onClose: { route = .root },
       onMarkSubredditPosted: { subredditId in

--- a/Sources/Views/PostHandoffView+Destinations.swift
+++ b/Sources/Views/PostHandoffView+Destinations.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+extension PostHandoffView {
+  var destinationSection: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      sectionHeader("Destination")
+
+      if capture.subreddits.isEmpty {
+        Text("No subreddit selected")
+          .font(.system(size: 12))
+          .foregroundStyle(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 6) {
+          ForEach(sortedSubreddits, id: \.id) { subreddit in
+            destinationRow(subreddit)
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  var openSubmitControl: some View {
+    if sortedSubreddits.count > 1 {
+      Menu {
+        ForEach(sortedSubreddits, id: \.id) { subreddit in
+          Button(subreddit.name) {
+            openSubmit(for: subreddit)
+          }
+        }
+      } label: {
+        Label("Choose Subreddit", systemImage: "arrow.up.right.square")
+      }
+      .help(Self.chooseSubmitDestinationAccessibilityLabel)
+      .accessibilityLabel(Self.chooseSubmitDestinationAccessibilityLabel)
+      .accessibilityIdentifier("postHandoff.chooseSubmitDestination")
+    } else {
+      Button(action: onOpenSubmit) {
+        Label("Open Reddit", systemImage: "arrow.up.right.square")
+      }
+      .keyboardShortcut(.defaultAction)
+      .help(Self.openSubmitAccessibilityLabel)
+      .accessibilityLabel(Self.openSubmitAccessibilityLabel)
+      .accessibilityIdentifier("postHandoff.openSubmit")
+    }
+  }
+
+  private func destinationRow(_ subreddit: Subreddit) -> some View {
+    let isPosted = capture.postedSubredditIDs.contains(subreddit.id)
+    return HStack(spacing: 8) {
+      Text(subreddit.name)
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(isPosted ? .secondary : AppColors.redditOrange)
+        .strikethrough(isPosted)
+
+      Spacer()
+
+      openSubredditButton(subreddit)
+      postedStateButton(subreddit, isPosted: isPosted)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 6)
+    .background(
+      isPosted
+        ? Color(red: 0.13, green: 0.77, blue: 0.37).opacity(0.06)
+        : AppColors.redditOrange.opacity(0.06)
+    )
+    .clipShape(RoundedRectangle(cornerRadius: 6))
+  }
+
+  private func openSubredditButton(_ subreddit: Subreddit) -> some View {
+    Button(action: { openSubmit(for: subreddit) }) {
+      Image(systemName: "arrow.up.right.square")
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(.secondary)
+        .frame(width: Self.iconButtonMinimumHitSize, height: Self.iconButtonMinimumHitSize)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .help("Open Reddit for \(subreddit.name)")
+    .accessibilityLabel("Open Reddit for \(subreddit.name)")
+    .accessibilityIdentifier("postHandoff.openSubmit.\(subreddit.name.postHandoffIdentifierSuffix)")
+  }
+
+  private func postedStateButton(_ subreddit: Subreddit, isPosted: Bool) -> some View {
+    Button(action: {
+      if isPosted {
+        onMarkSubredditUnposted?(subreddit.id)
+      } else {
+        onMarkSubredditPosted?(subreddit.id)
+      }
+    }) {
+      HStack(spacing: 4) {
+        Image(systemName: isPosted ? "checkmark.circle.fill" : "circle")
+          .font(.system(size: 12))
+        Text(isPosted ? "Posted" : "Not posted")
+          .font(.system(size: 10, weight: .medium))
+      }
+      .foregroundStyle(isPosted ? Color(red: 0.13, green: 0.77, blue: 0.37) : .secondary)
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(
+      isPosted ? "Unmark \(subreddit.name) as posted" : "Mark \(subreddit.name) as posted"
+    )
+    .accessibilityIdentifier("postHandoff.subreddit.\(subreddit.name)")
+  }
+
+  private func openSubmit(for subreddit: Subreddit) {
+    if let onOpenSubmitForSubreddit {
+      onOpenSubmitForSubreddit(subreddit.id)
+    } else {
+      onOpenSubmit()
+    }
+  }
+}

--- a/Sources/Views/PostHandoffView.swift
+++ b/Sources/Views/PostHandoffView.swift
@@ -6,6 +6,8 @@ struct PostHandoffView: View {
   nonisolated static let copyLinksAccessibilityLabel = "Copy post links"
   nonisolated static let copyAllAccessibilityLabel = "Copy full post text"
   nonisolated static let openSubmitAccessibilityLabel = "Open Reddit submit page"
+  nonisolated static let chooseSubmitDestinationAccessibilityLabel =
+    "Choose Reddit submit destination"
 
   let capture: Capture
   var checklistItems: [String] = []
@@ -14,6 +16,7 @@ struct PostHandoffView: View {
   let onCopyLinks: () -> Bool
   let onCopyAll: () -> Bool
   let onOpenSubmit: () -> Void
+  var onOpenSubmitForSubreddit: ((UUID) -> Void)? = nil
   let onMarkPosted: () -> Void
   let onClose: () -> Void
   var onMarkSubredditPosted: ((UUID) -> Void)? = nil
@@ -101,55 +104,6 @@ struct PostHandoffView: View {
     }
   }
 
-  private var destinationSection: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      sectionHeader("Destination")
-
-      if capture.subreddits.isEmpty {
-        Text("No subreddit selected")
-          .font(.system(size: 12))
-          .foregroundStyle(.secondary)
-      } else {
-        VStack(alignment: .leading, spacing: 6) {
-          ForEach(sortedSubreddits, id: \.id) { subreddit in
-            let isPosted = capture.postedSubredditIDs.contains(subreddit.id)
-            HStack(spacing: 8) {
-              Text(subreddit.name)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(isPosted ? .secondary : AppColors.redditOrange)
-                .strikethrough(isPosted)
-
-              Spacer()
-
-              Button(action: {
-                if isPosted {
-                  onMarkSubredditUnposted?(subreddit.id)
-                } else {
-                  onMarkSubredditPosted?(subreddit.id)
-                }
-              }) {
-                HStack(spacing: 4) {
-                  Image(systemName: isPosted ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 12))
-                  Text(isPosted ? "Posted" : "Not posted")
-                    .font(.system(size: 10, weight: .medium))
-                }
-                .foregroundStyle(isPosted ? Color(red: 0.13, green: 0.77, blue: 0.37) : .secondary)
-              }
-              .buttonStyle(.plain)
-              .accessibilityLabel(isPosted ? "Unmark \(subreddit.name) as posted" : "Mark \(subreddit.name) as posted")
-              .accessibilityIdentifier("postHandoff.subreddit.\(subreddit.name)")
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(isPosted ? Color(red: 0.13, green: 0.77, blue: 0.37).opacity(0.06) : AppColors.redditOrange.opacity(0.06))
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-          }
-        }
-      }
-    }
-  }
-
   private var materialsSection: some View {
     VStack(alignment: .leading, spacing: 10) {
       HStack {
@@ -221,13 +175,7 @@ struct PostHandoffView: View {
       .accessibilityLabel("Mark posted")
       .accessibilityIdentifier("postHandoff.markPosted")
 
-      Button(action: onOpenSubmit) {
-        Label("Open Reddit", systemImage: "arrow.up.right.square")
-      }
-      .keyboardShortcut(.defaultAction)
-      .help(Self.openSubmitAccessibilityLabel)
-      .accessibilityLabel(Self.openSubmitAccessibilityLabel)
-      .accessibilityIdentifier("postHandoff.openSubmit")
+      openSubmitControl
     }
     .font(.system(size: 12, weight: .medium))
     .padding(.horizontal, 20)
@@ -251,4 +199,5 @@ struct PostHandoffView: View {
   private func runCopy(_ action: () -> Bool, successMessage: String) {
     statusMessage = action() ? successMessage : "Copy failed"
   }
+
 }

--- a/Sources/Views/PostHandoffViewHelpers.swift
+++ b/Sources/Views/PostHandoffViewHelpers.swift
@@ -140,7 +140,7 @@ extension PostHandoffView {
 }
 
 extension String {
-  fileprivate var postHandoffIdentifierSuffix: String {
+  var postHandoffIdentifierSuffix: String {
     lowercased()
       .split { !$0.isLetter && !$0.isNumber }
       .joined(separator: ".")

--- a/Sources/Views/ProjectActionsMenu.swift
+++ b/Sources/Views/ProjectActionsMenu.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ProjectActionsMenu: View {
+  let project: Project
+  let onRename: () -> Void
+  let onToggleArchive: () -> Void
+  let onDelete: () -> Void
+
+  var body: some View {
+    Menu {
+      Button(ProjectsTabView.renameAccessibilityLabel, action: onRename)
+      Button(
+        project.archived
+          ? ProjectsTabView.unarchiveAccessibilityLabel : ProjectsTabView.archiveAccessibilityLabel,
+        action: onToggleArchive
+      )
+      Divider()
+      Button(ProjectsTabView.deleteAccessibilityLabel, role: .destructive, action: onDelete)
+    } label: {
+      Image(systemName: "ellipsis.circle")
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(.secondary)
+        .frame(width: 32, height: 32)
+        .background(.quaternary.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+    .menuStyle(.borderlessButton)
+    .menuIndicator(.hidden)
+    .help(ProjectsTabView.moreActionsAccessibilityLabel)
+    .accessibilityLabel(ProjectsTabView.moreActionsAccessibilityLabel)
+    .accessibilityIdentifier("projects.row.\(project.id.uuidString).actions")
+  }
+}

--- a/Sources/Views/ProjectsTabView.swift
+++ b/Sources/Views/ProjectsTabView.swift
@@ -1,234 +1,299 @@
-import SwiftUI
 import SwiftData
+import SwiftUI
 
 struct ProjectsTabView: View {
-    nonisolated static let moreActionsAccessibilityLabel = "More project actions"
-    nonisolated static let renameAccessibilityLabel = "Rename project"
-    nonisolated static let archiveAccessibilityLabel = "Archive project"
-    nonisolated static let unarchiveAccessibilityLabel = "Unarchive project"
-    nonisolated static let deleteAccessibilityLabel = "Delete project"
+  nonisolated static let moreActionsAccessibilityLabel = "More project actions"
+  nonisolated static let renameAccessibilityLabel = "Rename project"
+  nonisolated static let archiveAccessibilityLabel = "Archive project"
+  nonisolated static let unarchiveAccessibilityLabel = "Unarchive project"
+  nonisolated static let deleteAccessibilityLabel = "Delete project"
 
-    @Query(sort: \Project.name) private var projects: [Project]
-    @Environment(\.modelContext) private var modelContext
+  @Query(sort: \Project.name) private var projects: [Project]
+  @Environment(\.modelContext) private var modelContext
 
-    @State private var newProjectName = ""
-    @State private var editingProject: Project?
-    @State private var editName = ""
+  @State private var newProjectName = ""
+  @State private var editingProject: Project?
+  @State private var editName = ""
+  @State private var projectFeedbackMessage: String?
+  @State private var editFeedbackMessage: String?
+  @State private var projectPendingDeletion: Project?
 
-    var body: some View {
-        VStack(spacing: 0) {
-            addProjectBar
-            Divider()
-            projectList
-        }
+  var body: some View {
+    VStack(spacing: 0) {
+      addProjectBar
+      Divider()
+      projectList
     }
+    .alert(
+      "Delete Project?", isPresented: deleteConfirmationIsPresented,
+      presenting: projectPendingDeletion
+    ) {
+      project in
+      Button("Delete", role: .destructive) {
+        deleteProject(project)
+        projectPendingDeletion = nil
+      }
+      Button("Cancel", role: .cancel) {
+        projectPendingDeletion = nil
+      }
+    } message: { project in
+      Text(deleteConfirmationMessage(for: project))
+    }
+  }
 
-    private var addProjectBar: some View {
-        HStack(spacing: 8) {
-            TextField("New project name...", text: $newProjectName)
-                .font(.system(size: 11))
-                .textFieldStyle(.plain)
-                .padding(7)
-                .inputFieldStyle(cornerRadius: 6)
-                .onSubmit { addProject() }
+  private var addProjectBar: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 8) {
+        TextField("New project name...", text: $newProjectName)
+          .font(.system(size: 11))
+          .textFieldStyle(.plain)
+          .padding(7)
+          .inputFieldStyle(cornerRadius: 6)
+          .onChange(of: newProjectName) {
+            projectFeedbackMessage = projectValidationMessage(for: newProjectName)
+          }
+          .onSubmit { addProject() }
 
-            Button(action: addProject) {
-                Image(systemName: "plus")
-                    .font(.system(size: 14, weight: .light))
-                    .foregroundStyle(canAdd ? AppColors.redditOrange : .secondary)
-                    .frame(width: 32, height: 32)
-                    .background(
-                        canAdd
-                            ? AppColors.redditOrange.opacity(0.15)
-                            : Color.clear
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
+        Button(action: addProject) {
+          Image(systemName: "plus")
+            .font(.system(size: 14, weight: .light))
+            .foregroundStyle(canAdd ? AppColors.redditOrange : .secondary)
+            .frame(width: 32, height: 32)
+            .background(
+              canAdd
+                ? AppColors.redditOrange.opacity(0.15)
+                : Color.clear
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!canAdd)
+      }
+
+      if let projectFeedbackMessage {
+        Text(projectFeedbackMessage)
+          .font(.system(size: 10))
+          .foregroundStyle(.red)
+          .accessibilityIdentifier("projects.add.feedback")
+      }
+    }
+    .padding(12)
+  }
+
+  private var projectList: some View {
+    ScrollView {
+      VStack(spacing: 0) {
+        let activeProjects = projects.filter { !$0.archived }
+        let archivedProjects = projects.filter { $0.archived }
+
+        if activeProjects.isEmpty && archivedProjects.isEmpty {
+          emptyState
+        }
+
+        ForEach(activeProjects, id: \.id) { project in
+          projectRow(project)
+          if project.id != activeProjects.last?.id || !archivedProjects.isEmpty {
+            Divider().padding(.horizontal, 12)
+          }
+        }
+
+        if !archivedProjects.isEmpty {
+          archivedHeader
+          ForEach(archivedProjects, id: \.id) { project in
+            projectRow(project)
+            if project.id != archivedProjects.last?.id {
+              Divider().padding(.horizontal, 12)
             }
-            .buttonStyle(.plain)
-            .disabled(!canAdd)
+          }
         }
-        .padding(12)
+      }
+      .padding(.vertical, 8)
     }
+  }
 
-    private var projectList: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                let activeProjects = projects.filter { !$0.archived }
-                let archivedProjects = projects.filter { $0.archived }
-
-                if activeProjects.isEmpty && archivedProjects.isEmpty {
-                    emptyState
-                }
-
-                ForEach(activeProjects, id: \.id) { project in
-                    projectRow(project)
-                    if project.id != activeProjects.last?.id || !archivedProjects.isEmpty {
-                        Divider().padding(.horizontal, 12)
-                    }
-                }
-
-                if !archivedProjects.isEmpty {
-                    archivedHeader
-                    ForEach(archivedProjects, id: \.id) { project in
-                        projectRow(project)
-                        if project.id != archivedProjects.last?.id {
-                            Divider().padding(.horizontal, 12)
-                        }
-                    }
-                }
-            }
-            .padding(.vertical, 8)
-        }
+  private var emptyState: some View {
+    VStack(spacing: 8) {
+      Text("No projects yet")
+        .font(.system(size: 12))
+        .foregroundStyle(.secondary)
+      Text("Projects help organize your captures")
+        .font(.system(size: 11))
+        .foregroundStyle(.tertiary)
     }
+    .frame(maxWidth: .infinity)
+    .padding(.top, 40)
+  }
 
-    private var emptyState: some View {
-        VStack(spacing: 8) {
-            Text("No projects yet")
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-            Text("Projects help organize your captures")
-                .font(.system(size: 11))
-                .foregroundStyle(.tertiary)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.top, 40)
+  private var archivedHeader: some View {
+    HStack {
+      Text("ARCHIVED")
+        .font(.system(size: 10, weight: .medium))
+        .foregroundStyle(.tertiary)
+        .tracking(0.3)
+      Spacer()
     }
+    .padding(.horizontal, 12)
+    .padding(.top, 12)
+    .padding(.bottom, 4)
+  }
 
-    private var archivedHeader: some View {
-        HStack {
-            Text("ARCHIVED")
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(.tertiary)
-                .tracking(0.3)
-            Spacer()
-        }
-        .padding(.horizontal, 12)
-        .padding(.top, 12)
-        .padding(.bottom, 4)
+  private func projectRow(_ project: Project) -> some View {
+    HStack(spacing: 10) {
+      if editingProject?.id == project.id {
+        editingRow(project)
+      } else {
+        displayRow(project)
+      }
     }
-
-    private func projectRow(_ project: Project) -> some View {
-        HStack(spacing: 10) {
-            if editingProject?.id == project.id {
-                editingRow(project)
-            } else {
-                displayRow(project)
-            }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .contentShape(Rectangle())
-        .contextMenu {
-            Button("Rename") { startEditing(project) }
-            Button(project.archived ? "Unarchive" : "Archive") {
-                ProjectPersistenceActions.setArchived(
-                    project,
-                    archived: !project.archived,
-                    modelContext: modelContext
-                )
-            }
-            Divider()
-            Button("Delete", role: .destructive) { deleteProject(project) }
-        }
-    }
-
-    private func editingRow(_ project: Project) -> some View {
-        Group {
-            TextField("Project name", text: $editName)
-                .font(.system(size: 12))
-                .textFieldStyle(.plain)
-                .onSubmit { finishEditing(project) }
-
-            Button("Done") { finishEditing(project) }
-                .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(AppColors.redditOrange)
-                .buttonStyle(.plain)
-        }
-    }
-
-    private func displayRow(_ project: Project) -> some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(project.name)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(project.archived ? .secondary : .primary)
-                if let desc = project.projectDescription, !desc.isEmpty {
-                    Text(desc)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                Text("\(project.captures.count) capture\(project.captures.count == 1 ? "" : "s")")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.tertiary)
-            }
-            Spacer()
-            projectActionsMenu(project)
-        }
-    }
-
-    private func projectActionsMenu(_ project: Project) -> some View {
-        Menu {
-            Button(Self.renameAccessibilityLabel) { startEditing(project) }
-            Button(project.archived ? Self.unarchiveAccessibilityLabel : Self.archiveAccessibilityLabel) {
-                ProjectPersistenceActions.setArchived(
-                    project,
-                    archived: !project.archived,
-                    modelContext: modelContext
-                )
-            }
-            Divider()
-            Button(Self.deleteAccessibilityLabel, role: .destructive) { deleteProject(project) }
-        } label: {
-            Image(systemName: "ellipsis.circle")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.secondary)
-                .frame(width: 32, height: 32)
-                .background(.quaternary.opacity(0.3))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-        }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .help(Self.moreActionsAccessibilityLabel)
-        .accessibilityLabel(Self.moreActionsAccessibilityLabel)
-        .accessibilityIdentifier("projects.row.\(project.id.uuidString).actions")
-    }
-
-    private var canAdd: Bool {
-        ProjectPersistenceActions.isNameAvailable(newProjectName, projects: projects)
-    }
-
-    private func isNameAvailable(_ name: String, excluding: Project? = nil) -> Bool {
-        ProjectPersistenceActions.isNameAvailable(name, projects: projects, excluding: excluding)
-    }
-
-    private func addProject() {
-        if ProjectPersistenceActions.addProject(
-            named: newProjectName,
-            projects: projects,
-            modelContext: modelContext
-        ) != nil {
-            newProjectName = ""
-        }
-    }
-
-    private func startEditing(_ project: Project) {
-        editingProject = project
-        editName = project.name
-    }
-
-    private func finishEditing(_ project: Project) {
-        ProjectPersistenceActions.renameProject(
-            project,
-            to: editName,
-            projects: projects,
-            modelContext: modelContext
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .contentShape(Rectangle())
+    .contextMenu {
+      Button("Rename") { startEditing(project) }
+      Button(project.archived ? "Unarchive" : "Archive") {
+        ProjectPersistenceActions.setArchived(
+          project,
+          archived: !project.archived,
+          modelContext: modelContext
         )
-        editingProject = nil
-        editName = ""
+      }
+      Divider()
+      Button("Delete", role: .destructive) { requestDeleteProject(project) }
     }
+  }
 
-    private func deleteProject(_ project: Project) {
-        ProjectPersistenceActions.deleteProject(project, modelContext: modelContext)
+  private func editingRow(_ project: Project) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 8) {
+        TextField("Project name", text: $editName)
+          .font(.system(size: 12))
+          .textFieldStyle(.plain)
+          .onChange(of: editName) {
+            editFeedbackMessage = projectValidationMessage(for: editName, excluding: project)
+          }
+          .onSubmit { finishEditing(project) }
+
+        Button("Done") { finishEditing(project) }
+          .font(.system(size: 10, weight: .medium))
+          .foregroundStyle(AppColors.redditOrange)
+          .buttonStyle(.plain)
+      }
+
+      if let editFeedbackMessage {
+        Text(editFeedbackMessage)
+          .font(.system(size: 10))
+          .foregroundStyle(.red)
+          .accessibilityIdentifier("projects.edit.feedback")
+      }
     }
+  }
+
+  private func displayRow(_ project: Project) -> some View {
+    HStack(spacing: 10) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(project.name)
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(project.archived ? .secondary : .primary)
+        if let desc = project.projectDescription, !desc.isEmpty {
+          Text(desc)
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        Text("\(project.captures.count) capture\(project.captures.count == 1 ? "" : "s")")
+          .font(.system(size: 10))
+          .foregroundStyle(.tertiary)
+      }
+      Spacer()
+      ProjectActionsMenu(
+        project: project,
+        onRename: { startEditing(project) },
+        onToggleArchive: {
+          ProjectPersistenceActions.setArchived(
+            project,
+            archived: !project.archived,
+            modelContext: modelContext
+          )
+        },
+        onDelete: { requestDeleteProject(project) }
+      )
+    }
+  }
+
+  private var canAdd: Bool {
+    ProjectPersistenceActions.isNameAvailable(newProjectName, projects: projects)
+  }
+
+  private func isNameAvailable(_ name: String, excluding: Project? = nil) -> Bool {
+    ProjectPersistenceActions.isNameAvailable(name, projects: projects, excluding: excluding)
+  }
+
+  private func projectValidationMessage(for name: String, excluding: Project? = nil) -> String? {
+    guard let normalized = ProjectPersistenceActions.normalizedName(name) else { return nil }
+    return isNameAvailable(normalized, excluding: excluding)
+      ? nil : "A project with this name already exists."
+  }
+
+  private func addProject() {
+    if ProjectPersistenceActions.addProject(
+      named: newProjectName,
+      projects: projects,
+      modelContext: modelContext
+    ) != nil {
+      newProjectName = ""
+      projectFeedbackMessage = nil
+    } else {
+      projectFeedbackMessage =
+        projectValidationMessage(for: newProjectName) ?? "Enter a project name."
+    }
+  }
+
+  private func startEditing(_ project: Project) {
+    editingProject = project
+    editName = project.name
+    editFeedbackMessage = nil
+  }
+
+  private func finishEditing(_ project: Project) {
+    guard
+      ProjectPersistenceActions.renameProject(
+        project,
+        to: editName,
+        projects: projects,
+        modelContext: modelContext
+      )
+    else {
+      editFeedbackMessage =
+        projectValidationMessage(for: editName, excluding: project) ?? "Enter a project name."
+      return
+    }
+    editingProject = nil
+    editName = ""
+    editFeedbackMessage = nil
+  }
+
+  private var deleteConfirmationIsPresented: Binding<Bool> {
+    Binding(
+      get: { projectPendingDeletion != nil },
+      set: { isPresented in
+        if !isPresented {
+          projectPendingDeletion = nil
+        }
+      }
+    )
+  }
+
+  private func requestDeleteProject(_ project: Project) {
+    projectPendingDeletion = project
+  }
+
+  private func deleteConfirmationMessage(for project: Project) -> String {
+    let captureCount = project.captures.count
+    let captureText = "\(captureCount) capture\(captureCount == 1 ? "" : "s")"
+    return "Deleting \(project.name) will also delete \(captureText). This cannot be undone."
+  }
+
+  private func deleteProject(_ project: Project) {
+    ProjectPersistenceActions.deleteProject(project, modelContext: modelContext)
+  }
 }

--- a/Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift
@@ -19,6 +19,22 @@ import UserNotifications
   #expect(fixture.unrelated.status == .queued)
 }
 
+@Test @MainActor func appDelegateMarkPostedActionMarksOnlyNotificationSubreddit() throws {
+  let fixture = try makeCaptureFixture()
+  let delegate = makeNotificationActionDelegate()
+  delegate.modelContainer = fixture.container
+  let multiTarget = Capture(text: "Cross-post", subreddits: [fixture.target, fixture.other])
+  fixture.container.mainContext.insert(multiTarget)
+  try fixture.container.mainContext.save()
+
+  delegate.markCapturesAsPosted(forSubreddit: "r/Test")
+
+  #expect(multiTarget.status == .queued)
+  #expect(multiTarget.postedAt == nil)
+  #expect(multiTarget.postedSubredditIDs == [fixture.target.id])
+  #expect(!multiTarget.postedSubredditIDs.contains(fixture.other.id))
+}
+
 @Test @MainActor func appDelegateMarkPostedActionIsNoopWithoutContainer() {
   let delegate = makeNotificationActionDelegate()
 
@@ -193,6 +209,8 @@ private func makeCaptureFixture() throws -> CaptureFixture {
   try context.save()
   return CaptureFixture(
     container: container,
+    target: target,
+    other: other,
     matching: matching,
     alreadyPosted: alreadyPosted,
     unrelated: unrelated
@@ -201,6 +219,8 @@ private func makeCaptureFixture() throws -> CaptureFixture {
 
 private struct CaptureFixture {
   let container: ModelContainer
+  let target: Subreddit
+  let other: Subreddit
   let matching: Capture
   let alreadyPosted: Capture
   let unrelated: Capture

--- a/Tests/RedditReminderTests/AppModelContainerFactoryTests.swift
+++ b/Tests/RedditReminderTests/AppModelContainerFactoryTests.swift
@@ -1,38 +1,55 @@
+import Foundation
 import SwiftData
 import Testing
+
 @testable import RedditReminder
 
 @Test func appModelContainerFactoryDefinesExpectedSchemaTypes() {
-    let names = AppModelContainerFactory.schemaTypes.map { String(describing: $0) }
+  let names = AppModelContainerFactory.schemaTypes.map { String(describing: $0) }
 
-    #expect(names == ["Project", "Capture", "Subreddit", "SubredditEvent"])
+  #expect(names == ["Project", "Capture", "Subreddit", "SubredditEvent"])
 }
 
 @Test @MainActor func appModelContainerFactoryCreatesInMemoryContainer() throws {
-    let container = try AppModelContainerFactory.makeInMemoryContainer()
-    let context = ModelContext(container)
-    context.insert(Project(name: "Smoke"))
-    try context.save()
+  let container = try AppModelContainerFactory.makeInMemoryContainer()
+  let context = ModelContext(container)
+  context.insert(Project(name: "Smoke"))
+  try context.save()
 
-    let projects = try context.fetch(FetchDescriptor<Project>())
-    #expect(projects.map(\.name) == ["Smoke"])
+  let projects = try context.fetch(FetchDescriptor<Project>())
+  #expect(projects.map(\.name) == ["Smoke"])
+}
+
+@Test @MainActor func appModelContainerFactoryCreatesContainerAtExplicitStoreURL() throws {
+  let storeURL = FileManager.default.temporaryDirectory
+    .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    .appendingPathComponent("RedditReminderUITests.store")
+  defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+  let container = try AppModelContainerFactory.makePersistentContainer(storeURL: storeURL)
+  let context = ModelContext(container)
+  context.insert(Project(name: "Isolated"))
+  try context.save()
+
+  #expect(FileManager.default.fileExists(atPath: storeURL.path))
+  #expect(!storeURL.path.contains(AppModelContainerFactory.appSupportDirectory.path))
 }
 
 @Test @MainActor func appModelContainerFactoryPropagatesPersistentStoreFailure() throws {
-    enum StoreFailure: Error, Equatable {
-        case unavailable
-    }
+  enum StoreFailure: Error, Equatable {
+    case unavailable
+  }
 
-    #expect(throws: StoreFailure.unavailable) {
-        _ = try AppModelContainerFactory.makeContainer {
-            throw StoreFailure.unavailable
-        }
+  #expect(throws: StoreFailure.unavailable) {
+    _ = try AppModelContainerFactory.makeContainer {
+      throw StoreFailure.unavailable
     }
+  }
 }
 
 @Test func appModelContainerFactoryExposesAppSupportDirectory() {
-    let directory = AppModelContainerFactory.appSupportDirectory
+  let directory = AppModelContainerFactory.appSupportDirectory
 
-    #expect(directory.lastPathComponent == "RedditReminder")
-    #expect(directory.path.contains("Application Support"))
+  #expect(directory.lastPathComponent == "RedditReminder")
+  #expect(directory.path.contains("Application Support"))
 }

--- a/Tests/RedditReminderTests/AppRuntimeTests.swift
+++ b/Tests/RedditReminderTests/AppRuntimeTests.swift
@@ -1,24 +1,53 @@
+import Foundation
 import Testing
+
 @testable import RedditReminder
 
 @Test func appRuntimeDetectsXCTestConfigurationEnvironment() {
-    #expect(AppRuntime.isRunningUnitTests(environment: [
-        "XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"
+  #expect(
+    AppRuntime.isRunningUnitTests(environment: [
+      "XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"
     ]))
 }
 
 @Test func appRuntimeDetectsXCTestBundleEnvironment() {
-    #expect(AppRuntime.isRunningUnitTests(environment: [
-        "XCTestBundlePath": "/tmp/RedditReminderTests.xctest"
+  #expect(
+    AppRuntime.isRunningUnitTests(environment: [
+      "XCTestBundlePath": "/tmp/RedditReminderTests.xctest"
     ]))
 }
 
 @Test func appRuntimeAllowsShortcutRegistrationOutsideTests() {
-    #expect(AppRuntime.shouldRegisterGlobalShortcut(environment: [:]))
+  #expect(AppRuntime.shouldRegisterGlobalShortcut(environment: [:]))
 }
 
 @Test func appRuntimeSkipsShortcutRegistrationDuringTests() {
-    #expect(!AppRuntime.shouldRegisterGlobalShortcut(environment: [
-        "XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"
+  #expect(
+    !AppRuntime.shouldRegisterGlobalShortcut(environment: [
+      "XCTestConfigurationFilePath": "/tmp/test.xctestconfiguration"
     ]))
+}
+
+@Test func appRuntimeParsesUITestStoreArgumentPair() {
+  let url = AppRuntime.uiTestStoreURL(arguments: [
+    "RedditReminder",
+    "--ui-test-store",
+    "/tmp/redditreminder-ui-tests.store",
+  ])
+
+  #expect(url == URL(fileURLWithPath: "/tmp/redditreminder-ui-tests.store"))
+}
+
+@Test func appRuntimeParsesUITestStoreArgumentAssignment() {
+  let url = AppRuntime.uiTestStoreURL(arguments: [
+    "RedditReminder",
+    "--ui-test-store=/tmp/redditreminder-ui-tests.store",
+  ])
+
+  #expect(url == URL(fileURLWithPath: "/tmp/redditreminder-ui-tests.store"))
+}
+
+@Test func appRuntimeIgnoresMissingUITestStoreValue() {
+  #expect(AppRuntime.uiTestStoreURL(arguments: ["RedditReminder", "--ui-test-store"]) == nil)
+  #expect(AppRuntime.uiTestStoreURL(arguments: ["RedditReminder"]) == nil)
 }

--- a/Tests/RedditReminderTests/CapturePersistenceActionsTests.swift
+++ b/Tests/RedditReminderTests/CapturePersistenceActionsTests.swift
@@ -2,214 +2,320 @@ import AppKit
 import Foundation
 import SwiftData
 import Testing
+
 @testable import RedditReminder
 
 private func makeCapturePersistenceContainer() throws -> ModelContainer {
-    let config = ModelConfiguration(isStoredInMemoryOnly: true)
-    return try ModelContainer(
-        for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
-        configurations: config
-    )
+  let config = ModelConfiguration(isStoredInMemoryOnly: true)
+  return try ModelContainer(
+    for: Project.self, Capture.self, Subreddit.self, SubredditEvent.self,
+    configurations: config
+  )
 }
 
 @Test @MainActor func saveCapturePersistsMediaRefsAndSignalsChange() throws {
-    let container = try makeCapturePersistenceContainer()
-    let context = ModelContext(container)
-    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
-    let subreddit = Subreddit(name: "r/SwiftUI")
-    context.insert(subreddit)
-    try context.save()
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let subreddit = Subreddit(name: "r/SwiftUI")
+  context.insert(subreddit)
+  try context.save()
 
-    let sourceURL = try writeTestImage(named: "draft.png")
-    defer { try? FileManager.default.removeItem(at: sourceURL) }
-    var changeCount = 0
+  let sourceURL = try writeTestImage(named: "draft.png")
+  defer { try? FileManager.default.removeItem(at: sourceURL) }
+  var changeCount = 0
 
-    let ok = CapturePersistenceActions.saveCapture(
-        CaptureFormResult(
-            text: "Draft",
-            notes: "Notes",
-            links: ["https://example.com"],
-            project: nil,
-            subreddits: [subreddit],
-            mediaURLs: [sourceURL]
-        ),
-        modelContext: context,
-        mediaStore: mediaStore,
-        onAppStateChanged: { changeCount += 1 }
-    )
+  let ok = CapturePersistenceActions.saveCapture(
+    CaptureFormResult(
+      text: "Draft",
+      notes: "Notes",
+      links: ["https://example.com"],
+      project: nil,
+      subreddits: [subreddit],
+      mediaURLs: [sourceURL]
+    ),
+    modelContext: context,
+    mediaStore: mediaStore,
+    onAppStateChanged: { changeCount += 1 }
+  )
 
-    let captures = try context.fetch(FetchDescriptor<Capture>())
-    #expect(ok)
-    #expect(changeCount == 1)
-    #expect(captures.count == 1)
-    #expect(captures[0].mediaRefs.count == 1)
-    #expect(captures[0].mediaRefs[0].hasSuffix("draft.png"))
-    #expect(mediaStore.loadImage(captureId: captures[0].id, ref: captures[0].mediaRefs[0]) != nil)
+  let captures = try context.fetch(FetchDescriptor<Capture>())
+  #expect(ok)
+  #expect(changeCount == 1)
+  #expect(captures.count == 1)
+  #expect(captures[0].mediaRefs.count == 1)
+  #expect(captures[0].mediaRefs[0].hasSuffix("draft.png"))
+  #expect(mediaStore.loadImage(captureId: captures[0].id, ref: captures[0].mediaRefs[0]) != nil)
 }
 
 @Test @MainActor func saveCapturePersistsVideoMediaRefs() throws {
-    let container = try makeCapturePersistenceContainer()
-    let context = ModelContext(container)
-    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
-    let subreddit = Subreddit(name: "r/SwiftUI")
-    context.insert(subreddit)
-    try context.save()
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let subreddit = Subreddit(name: "r/SwiftUI")
+  context.insert(subreddit)
+  try context.save()
 
-    let sourceURL = try writeTestVideo(named: "demo.mp4")
-    defer { try? FileManager.default.removeItem(at: sourceURL) }
+  let sourceURL = try writeTestVideo(named: "demo.mp4")
+  defer { try? FileManager.default.removeItem(at: sourceURL) }
 
-    let ok = CapturePersistenceActions.saveCapture(
-        CaptureFormResult(
-            text: "Video draft",
-            notes: nil,
-            links: [],
-            project: nil,
-            subreddits: [subreddit],
-            mediaURLs: [sourceURL]
-        ),
-        modelContext: context,
-        mediaStore: mediaStore
-    )
+  let ok = CapturePersistenceActions.saveCapture(
+    CaptureFormResult(
+      text: "Video draft",
+      notes: nil,
+      links: [],
+      project: nil,
+      subreddits: [subreddit],
+      mediaURLs: [sourceURL]
+    ),
+    modelContext: context,
+    mediaStore: mediaStore
+  )
 
-    let captures = try context.fetch(FetchDescriptor<Capture>())
-    #expect(ok)
-    #expect(captures.count == 1)
-    #expect(captures[0].mediaRefs == ["demo.mp4"])
-    #expect(mediaStore.exists(captureId: captures[0].id, ref: "demo.mp4"))
-    #expect(mediaStore.loadThumbnail(captureId: captures[0].id, ref: "demo.mp4") == nil)
+  let captures = try context.fetch(FetchDescriptor<Capture>())
+  #expect(ok)
+  #expect(captures.count == 1)
+  #expect(captures[0].mediaRefs == ["demo.mp4"])
+  #expect(mediaStore.exists(captureId: captures[0].id, ref: "demo.mp4"))
+  #expect(mediaStore.loadThumbnail(captureId: captures[0].id, ref: "demo.mp4") == nil)
 }
 
 @Test @MainActor func updateCaptureRemovesDeletedMediaAfterSave() throws {
-    let container = try makeCapturePersistenceContainer()
-    let context = ModelContext(container)
-    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
-    let subreddit = Subreddit(name: "r/macOS")
-    let capture = Capture(text: "Old", subreddits: [subreddit])
-    context.insert(subreddit)
-    context.insert(capture)
-    let first = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "first.png")
-    let second = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "second.png")
-    capture.mediaRefs = [first, second]
-    try context.save()
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let subreddit = Subreddit(name: "r/macOS")
+  let capture = Capture(text: "Old", subreddits: [subreddit])
+  context.insert(subreddit)
+  context.insert(capture)
+  let first = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "first.png")
+  let second = try mediaStore.save(
+    image: testImage(), captureId: capture.id, fileName: "second.png")
+  capture.mediaRefs = [first, second]
+  try context.save()
 
-    let ok = CapturePersistenceActions.updateCapture(
-        capture,
-        with: CaptureFormResult(
-            text: "Updated",
-            notes: nil,
-            links: [],
-            project: nil,
-            subreddits: [subreddit],
-            mediaURLs: [],
-            removedMediaRefs: [first]
-        ),
-        modelContext: context,
-        mediaStore: mediaStore
-    )
+  let ok = CapturePersistenceActions.updateCapture(
+    capture,
+    with: CaptureFormResult(
+      text: "Updated",
+      notes: nil,
+      links: [],
+      project: nil,
+      subreddits: [subreddit],
+      mediaURLs: [],
+      removedMediaRefs: [first]
+    ),
+    modelContext: context,
+    mediaStore: mediaStore
+  )
 
-    #expect(ok)
-    #expect(capture.text == "Updated")
-    #expect(capture.mediaRefs == [second])
-    #expect(mediaStore.loadImage(captureId: capture.id, ref: first) == nil)
-    #expect(mediaStore.loadThumbnail(captureId: capture.id, ref: first) == nil)
-    #expect(mediaStore.loadImage(captureId: capture.id, ref: second) != nil)
+  #expect(ok)
+  #expect(capture.text == "Updated")
+  #expect(capture.mediaRefs == [second])
+  #expect(mediaStore.loadImage(captureId: capture.id, ref: first) == nil)
+  #expect(mediaStore.loadThumbnail(captureId: capture.id, ref: first) == nil)
+  #expect(mediaStore.loadImage(captureId: capture.id, ref: second) != nil)
+}
+
+@Test @MainActor func updateCaptureRemovesStalePostedSubredditIDs() throws {
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let first = Subreddit(name: "r/Swift")
+  let second = Subreddit(name: "r/macOS")
+  let replacement = Subreddit(name: "r/SideProject")
+  let capture = Capture(text: "Cross-post", subreddits: [first, second])
+  capture.markSubredditAsPosted(first.id)
+  context.insert(first)
+  context.insert(second)
+  context.insert(replacement)
+  context.insert(capture)
+  try context.save()
+
+  let ok = CapturePersistenceActions.updateCapture(
+    capture,
+    with: CaptureFormResult(
+      text: "Cross-post",
+      notes: nil,
+      links: [],
+      project: nil,
+      subreddits: [second, replacement],
+      mediaURLs: []
+    ),
+    modelContext: context,
+    mediaStore: mediaStore
+  )
+
+  #expect(ok)
+  #expect(capture.status == .queued)
+  #expect(capture.postedAt == nil)
+  #expect(capture.postedSubredditIDs.isEmpty)
+}
+
+@Test @MainActor func updateCaptureReopensPostedCaptureWhenNewSubredditIsAdded() throws {
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let first = Subreddit(name: "r/Swift")
+  let second = Subreddit(name: "r/macOS")
+  let capture = Capture(text: "Cross-post", subreddits: [first])
+  capture.markAsPosted()
+  context.insert(first)
+  context.insert(second)
+  context.insert(capture)
+  try context.save()
+
+  let ok = CapturePersistenceActions.updateCapture(
+    capture,
+    with: CaptureFormResult(
+      text: "Cross-post",
+      notes: nil,
+      links: [],
+      project: nil,
+      subreddits: [first, second],
+      mediaURLs: []
+    ),
+    modelContext: context,
+    mediaStore: mediaStore
+  )
+
+  #expect(ok)
+  #expect(capture.status == .queued)
+  #expect(capture.postedAt == nil)
+  #expect(capture.postedSubredditIDs == [first.id])
+}
+
+@Test @MainActor func updateCaptureMarksPostedWhenRemainingSubredditsArePosted() throws {
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let first = Subreddit(name: "r/Swift")
+  let second = Subreddit(name: "r/macOS")
+  let capture = Capture(text: "Cross-post", subreddits: [first, second])
+  capture.markSubredditAsPosted(first.id)
+  context.insert(first)
+  context.insert(second)
+  context.insert(capture)
+  try context.save()
+
+  let ok = CapturePersistenceActions.updateCapture(
+    capture,
+    with: CaptureFormResult(
+      text: "Cross-post",
+      notes: nil,
+      links: [],
+      project: nil,
+      subreddits: [first],
+      mediaURLs: []
+    ),
+    modelContext: context,
+    mediaStore: mediaStore
+  )
+
+  #expect(ok)
+  #expect(capture.status == .posted)
+  #expect(capture.postedAt != nil)
+  #expect(capture.postedSubredditIDs == [first.id])
 }
 
 @Test @MainActor func updateCaptureRollsBackNewMediaWhenLaterFileFails() throws {
-    let container = try makeCapturePersistenceContainer()
-    let context = ModelContext(container)
-    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
-    let subreddit = Subreddit(name: "r/Swift")
-    let capture = Capture(text: "Original", mediaRefs: [], subreddits: [subreddit])
-    context.insert(subreddit)
-    context.insert(capture)
-    try context.save()
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let subreddit = Subreddit(name: "r/Swift")
+  let capture = Capture(text: "Original", mediaRefs: [], subreddits: [subreddit])
+  context.insert(subreddit)
+  context.insert(capture)
+  try context.save()
 
-    let validURL = try writeTestImage(named: "valid.png")
-    let invalidURL = try writeTextFile(named: "bad.txt")
-    defer {
-        try? FileManager.default.removeItem(at: validURL)
-        try? FileManager.default.removeItem(at: invalidURL)
-    }
+  let validURL = try writeTestImage(named: "valid.png")
+  let invalidURL = try writeTextFile(named: "bad.txt")
+  defer {
+    try? FileManager.default.removeItem(at: validURL)
+    try? FileManager.default.removeItem(at: invalidURL)
+  }
 
-    let ok = CapturePersistenceActions.updateCapture(
-        capture,
-        with: CaptureFormResult(
-            text: "Changed",
-            notes: nil,
-            links: [],
-            project: nil,
-            subreddits: [subreddit],
-            mediaURLs: [validURL, invalidURL]
-        ),
-        modelContext: context,
-        mediaStore: mediaStore
-    )
+  let ok = CapturePersistenceActions.updateCapture(
+    capture,
+    with: CaptureFormResult(
+      text: "Changed",
+      notes: nil,
+      links: [],
+      project: nil,
+      subreddits: [subreddit],
+      mediaURLs: [validURL, invalidURL]
+    ),
+    modelContext: context,
+    mediaStore: mediaStore
+  )
 
-    #expect(!ok)
-    #expect(capture.text == "Original")
-    #expect(capture.mediaRefs.isEmpty)
-    #expect(mediaStore.loadImage(captureId: capture.id, ref: validURL.lastPathComponent) == nil)
-    #expect(mediaStore.loadThumbnail(captureId: capture.id, ref: validURL.lastPathComponent) == nil)
+  #expect(!ok)
+  #expect(capture.text == "Original")
+  #expect(capture.mediaRefs.isEmpty)
+  #expect(mediaStore.loadImage(captureId: capture.id, ref: validURL.lastPathComponent) == nil)
+  #expect(mediaStore.loadThumbnail(captureId: capture.id, ref: validURL.lastPathComponent) == nil)
 }
 
 @Test @MainActor func deleteCaptureRemovesPersistedMedia() throws {
-    let container = try makeCapturePersistenceContainer()
-    let context = ModelContext(container)
-    let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
-    let capture = Capture(text: "Delete me")
-    context.insert(capture)
-    let ref = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "delete.png")
-    capture.mediaRefs = [ref]
-    try context.save()
-    let captureId = capture.id
-    var changeCount = 0
+  let container = try makeCapturePersistenceContainer()
+  let context = ModelContext(container)
+  let mediaStore = MediaStore(rootDir: temporaryMediaRoot())
+  let capture = Capture(text: "Delete me")
+  context.insert(capture)
+  let ref = try mediaStore.save(image: testImage(), captureId: capture.id, fileName: "delete.png")
+  capture.mediaRefs = [ref]
+  try context.save()
+  let captureId = capture.id
+  var changeCount = 0
 
-    try CapturePersistenceActions.deleteCapture(
-        capture,
-        modelContext: context,
-        mediaStore: mediaStore,
-        onAppStateChanged: { changeCount += 1 }
-    )
+  try CapturePersistenceActions.deleteCapture(
+    capture,
+    modelContext: context,
+    mediaStore: mediaStore,
+    onAppStateChanged: { changeCount += 1 }
+  )
 
-    #expect(changeCount == 1)
-    #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 0)
-    #expect(mediaStore.loadImage(captureId: captureId, ref: ref) == nil)
-    #expect(mediaStore.loadThumbnail(captureId: captureId, ref: ref) == nil)
+  #expect(changeCount == 1)
+  #expect(try context.fetchCount(FetchDescriptor<Capture>()) == 0)
+  #expect(mediaStore.loadImage(captureId: captureId, ref: ref) == nil)
+  #expect(mediaStore.loadThumbnail(captureId: captureId, ref: ref) == nil)
 }
 
 private func temporaryMediaRoot() -> URL {
-    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+  FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 }
 
 private func writeTestImage(named fileName: String) throws -> URL {
-    let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
-    guard let tiff = testImage().tiffRepresentation,
-          let bitmap = NSBitmapImageRep(data: tiff),
-          let png = bitmap.representation(using: .png, properties: [:]) else {
-        throw MediaError.encodingFailed
-    }
-    try png.write(to: url)
-    return url
+  let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+    "\(UUID().uuidString)-\(fileName)")
+  guard let tiff = testImage().tiffRepresentation,
+    let bitmap = NSBitmapImageRep(data: tiff),
+    let png = bitmap.representation(using: .png, properties: [:])
+  else {
+    throw MediaError.encodingFailed
+  }
+  try png.write(to: url)
+  return url
 }
 
 private func writeTextFile(named fileName: String) throws -> URL {
-    let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString)-\(fileName)")
-    try "not media".write(to: url, atomically: true, encoding: .utf8)
-    return url
+  let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+    "\(UUID().uuidString)-\(fileName)")
+  try "not media".write(to: url, atomically: true, encoding: .utf8)
+  return url
 }
 
 private func writeTestVideo(named fileName: String) throws -> URL {
-    let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
-    try Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]).write(to: url)
-    return url
+  let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+  try Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]).write(to: url)
+  return url
 }
 
 private func testImage() -> NSImage {
-    let image = NSImage(size: NSSize(width: 64, height: 64))
-    image.lockFocus()
-    NSColor.systemOrange.setFill()
-    NSRect(x: 0, y: 0, width: 64, height: 64).fill()
-    image.unlockFocus()
-    return image
+  let image = NSImage(size: NSSize(width: 64, height: 64))
+  image.lockFocus()
+  NSColor.systemOrange.setFill()
+  NSRect(x: 0, y: 0, width: 64, height: 64).fill()
+  image.unlockFocus()
+  return image
 }

--- a/Tests/RedditReminderTests/PostHandoffViewTests.swift
+++ b/Tests/RedditReminderTests/PostHandoffViewTests.swift
@@ -8,4 +8,8 @@ import Testing
   #expect(PostHandoffView.copyBodyAccessibilityLabel == "Copy post body")
   #expect(PostHandoffView.copyLinksAccessibilityLabel == "Copy post links")
   #expect(PostHandoffView.copyAllAccessibilityLabel == "Copy full post text")
+  #expect(PostHandoffView.openSubmitAccessibilityLabel == "Open Reddit submit page")
+  #expect(
+    PostHandoffView.chooseSubmitDestinationAccessibilityLabel == "Choose Reddit submit destination"
+  )
 }

--- a/Tests/RedditReminderTests/RedditPostingActionsTests.swift
+++ b/Tests/RedditReminderTests/RedditPostingActionsTests.swift
@@ -66,6 +66,30 @@ private final class MockPasteboard: PasteboardWriting {
   )
 }
 
+@Test @MainActor func redditSubmitURLUsesSelectedCaptureSubreddit() {
+  let macOS = Subreddit(name: "r/macOS", sortOrder: 2)
+  let sideProject = Subreddit(name: "r/SideProject", sortOrder: 0)
+  let capture = Capture(
+    text: "Launch post",
+    subreddits: [macOS, sideProject]
+  )
+
+  #expect(
+    RedditPostingActions.submitURL(for: capture, subredditId: macOS.id)?
+      .absoluteString == "https://www.reddit.com/r/macOS/submit"
+  )
+  #expect(
+    RedditPostingActions.submitURL(for: capture, subredditId: sideProject.id)?
+      .absoluteString == "https://www.reddit.com/r/SideProject/submit"
+  )
+}
+
+@Test @MainActor func redditSubmitURLRejectsSubredditOutsideCapture() {
+  let capture = Capture(text: "Launch post", subreddits: [Subreddit(name: "r/macOS")])
+
+  #expect(RedditPostingActions.submitURL(for: capture, subredditId: UUID()) == nil)
+}
+
 @Test @MainActor func clipboardTextIncludesCaptureTextOnly() {
   let capture = Capture(text: "  Ship notes  ")
 

--- a/Tests/RedditReminderUITests/RedditReminderUITestSupport.swift
+++ b/Tests/RedditReminderUITests/RedditReminderUITestSupport.swift
@@ -2,65 +2,83 @@ import XCTest
 
 @MainActor
 extension XCTestCase {
-    func makeSeededRedditReminderApp() -> XCUIApplication {
-        let app = XCUIApplication()
-        app.launchArguments = ["--seed-qa"]
-        return app
-    }
+  func makeSeededRedditReminderApp() -> XCUIApplication {
+    let app = XCUIApplication()
+    app.launchArguments = qaLaunchArguments(action: "--seed-qa")
+    return app
+  }
 
-    func makeClearedRedditReminderApp() -> XCUIApplication {
-        let app = XCUIApplication()
-        app.launchArguments = ["--clear-qa"]
-        return app
-    }
+  func makeClearedRedditReminderApp() -> XCUIApplication {
+    let app = XCUIApplication()
+    app.launchArguments = qaLaunchArguments(action: "--clear-qa")
+    return app
+  }
 
-    func launchAndWaitForRedditReminder(_ app: XCUIApplication) {
-        app.launch()
-        XCTAssertTrue(
-            app.wait(for: .runningForeground, timeout: 5)
-                || app.wait(for: .runningBackground, timeout: 5),
-            "RedditReminder should launch for UI testing"
-        )
-        app.activate()
-    }
+  func qaLaunchArguments(action: String) -> [String] {
+    [
+      action,
+      "--ui-test-store",
+      uiTestStoreURL().path,
+    ]
+  }
 
-    func openNewCaptureRoute(in app: XCUIApplication) {
-        app.typeKey("n", modifierFlags: .command)
-        XCTAssertTrue(
-            app.textFields["captureWindow.title"].waitForExistence(timeout: 3),
-            "New Capture route should expose the title field"
-        )
-    }
+  func uiTestStoreURL(function: String = #function) -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("RedditReminderUITests", isDirectory: true)
+      .appendingPathComponent(
+        "\(String(describing: type(of: self)))-\(function)-\(UUID().uuidString)"
+      )
+      .appendingPathExtension("store")
+  }
 
-    func cancelCaptureRoute(in app: XCUIApplication) {
-        let cancel = app.buttons["captureWindow.cancel"]
-        XCTAssertTrue(cancel.waitForExistence(timeout: 3), "Cancel button should exist")
-        cancel.click()
-    }
+  func launchAndWaitForRedditReminder(_ app: XCUIApplication) {
+    app.launch()
+    XCTAssertTrue(
+      app.wait(for: .runningForeground, timeout: 5)
+        || app.wait(for: .runningBackground, timeout: 5),
+      "RedditReminder should launch for UI testing"
+    )
+    app.activate()
+  }
 
-    func openPreferencesRoute(in app: XCUIApplication) {
-        openHomePopover(in: app)
-        let settingsButton = app.buttons["popover.header.settings"]
-        XCTAssertTrue(settingsButton.waitForExistence(timeout: 3), "Settings button should exist")
-        settingsButton.click()
-        XCTAssertTrue(
-            app.buttons["preferences.tab.General"].waitForExistence(timeout: 3),
-            "Preferences route should expose the General tab"
-        )
-    }
+  func openNewCaptureRoute(in app: XCUIApplication) {
+    app.typeKey("n", modifierFlags: .command)
+    XCTAssertTrue(
+      app.textFields["captureWindow.title"].waitForExistence(timeout: 3),
+      "New Capture route should expose the title field"
+    )
+  }
 
-    func openHomePopover(in app: XCUIApplication) {
-        openNewCaptureRoute(in: app)
-        cancelCaptureRoute(in: app)
-    }
+  func cancelCaptureRoute(in app: XCUIApplication) {
+    let cancel = app.buttons["captureWindow.cancel"]
+    XCTAssertTrue(cancel.waitForExistence(timeout: 3), "Cancel button should exist")
+    cancel.click()
+  }
 
-    func openWorkspace(_ identifier: String, in app: XCUIApplication) {
-        let button = app.buttons[identifier]
-        XCTAssertTrue(button.waitForExistence(timeout: 3), "Workspace button \(identifier) should exist")
-        button.click()
-    }
+  func openPreferencesRoute(in app: XCUIApplication) {
+    openHomePopover(in: app)
+    let settingsButton = app.buttons["popover.header.settings"]
+    XCTAssertTrue(settingsButton.waitForExistence(timeout: 3), "Settings button should exist")
+    settingsButton.click()
+    XCTAssertTrue(
+      app.buttons["preferences.tab.General"].waitForExistence(timeout: 3),
+      "Preferences route should expose the General tab"
+    )
+  }
 
-    func firstButton(withIdentifierPrefix prefix: String, in app: XCUIApplication) -> XCUIElement {
-        app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", prefix)).firstMatch
-    }
+  func openHomePopover(in app: XCUIApplication) {
+    openNewCaptureRoute(in: app)
+    cancelCaptureRoute(in: app)
+  }
+
+  func openWorkspace(_ identifier: String, in app: XCUIApplication) {
+    let button = app.buttons[identifier]
+    XCTAssertTrue(
+      button.waitForExistence(timeout: 3), "Workspace button \(identifier) should exist")
+    button.click()
+  }
+
+  func firstButton(withIdentifierPrefix prefix: String, in app: XCUIApplication) -> XCUIElement {
+    app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", prefix)).firstMatch
+  }
 }

--- a/Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift
@@ -2,42 +2,63 @@ import XCTest
 
 @MainActor
 final class RedditReminderWorkflowUITests: XCTestCase {
-    func testCreateCapturePopoverAppears() throws {
-        continueAfterFailure = false
-        let app = makeSeededRedditReminderApp()
-        defer { app.terminate() }
+  func testCreateCapturePopoverAppears() throws {
+    continueAfterFailure = false
+    let app = makeSeededRedditReminderApp()
+    defer { app.terminate() }
 
-        launchAndWaitForRedditReminder(app)
-        openNewCaptureRoute(in: app)
+    launchAndWaitForRedditReminder(app)
+    openNewCaptureRoute(in: app)
 
-        let saveButton = app.buttons["captureWindow.save"]
-        XCTAssertTrue(saveButton.exists)
+    let saveButton = app.buttons["captureWindow.save"]
+    XCTAssertTrue(saveButton.exists)
 
-        let cancelButton = app.buttons["captureWindow.cancel"]
-        XCTAssertTrue(cancelButton.exists)
+    let cancelButton = app.buttons["captureWindow.cancel"]
+    XCTAssertTrue(cancelButton.exists)
+  }
+
+  func testPreferencesTabNavigation() throws {
+    continueAfterFailure = false
+    let app = makeSeededRedditReminderApp()
+    defer { app.terminate() }
+
+    launchAndWaitForRedditReminder(app)
+    openPreferencesRoute(in: app)
+
+    let tabs = ["General", "Notifications", "Backup"]
+    for tab in tabs {
+      let tabButton = app.buttons["preferences.tab.\(tab)"]
+      XCTAssertTrue(tabButton.waitForExistence(timeout: 3), "Tab '\(tab)' should exist")
+      tabButton.click()
+      XCTAssertTrue(
+        app.descendants(matching: .any)["preferences.content.\(tab)"].waitForExistence(timeout: 3),
+        "Tab '\(tab)' should expose its content"
+      )
     }
+  }
 
-    func testPreferencesTabNavigation() throws {
-        continueAfterFailure = false
-        let app = makeSeededRedditReminderApp()
-        defer { app.terminate() }
+  func testDeleteConfirmationAppears() throws {
+    continueAfterFailure = false
+    let app = makeSeededRedditReminderApp()
+    defer { app.terminate() }
 
-        launchAndWaitForRedditReminder(app)
-        openPreferencesRoute(in: app)
+    launchAndWaitForRedditReminder(app)
+    openHomePopover(in: app)
+    openWorkspace("popover.header.posted", in: app)
 
-        let tabs = ["General", "Notifications", "Backup"]
-        for tab in tabs {
-            let tabButton = app.buttons["preferences.tab.\(tab)"]
-            XCTAssertTrue(tabButton.waitForExistence(timeout: 3), "Tab '\(tab)' should exist")
-            tabButton.click()
-            XCTAssertTrue(
-                app.descendants(matching: .any)["preferences.content.\(tab)"].waitForExistence(timeout: 3),
-                "Tab '\(tab)' should expose its content"
-            )
-        }
-    }
+    let deleteButton = app.buttons.matching(identifier: "postedList.delete").firstMatch
+    XCTAssertTrue(deleteButton.waitForExistence(timeout: 3), "Posted delete button should exist")
+    deleteButton.click()
 
-    func testDeleteConfirmationAppears() throws {
-        throw XCTSkip("Deferred until destructive capture rows expose a reliable XCUITest hit target")
-    }
+    let confirmationDelete = app.buttons["Delete"].firstMatch
+    XCTAssertTrue(
+      confirmationDelete.waitForExistence(timeout: 3),
+      "Delete confirmation should expose a destructive confirmation button"
+    )
+
+    let cancelButton = app.buttons["Cancel"].firstMatch
+    XCTAssertTrue(
+      cancelButton.waitForExistence(timeout: 3), "Delete confirmation should be cancellable")
+    cancelButton.click()
+  }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,8 +95,8 @@ redditreminder captures list --json
 redditreminder captures search --query "launch" --json
 redditreminder captures create --title "Launch post" --text "Post body" --project "Launch Ideas" --subreddit SideProject --media ~/Desktop/mock.mp4 --due 2026-05-02T18:00:00Z --json
 redditreminder captures update CAPTURE_ID --title "Updated title" --clear-notes --json
-redditreminder captures mark-posted CAPTURE_ID --url "https://reddit.com/r/SideProject/comments/abc" --json
-redditreminder captures mark-queued CAPTURE_ID --json
+redditreminder captures mark-posted CAPTURE_ID --subreddit SideProject --json
+redditreminder captures mark-queued CAPTURE_ID --subreddit SideProject --json
 redditreminder captures delete CAPTURE_ID --json
 ```
 
@@ -109,8 +109,8 @@ redditreminder captures delete CAPTURE_ID --json
 --link URL            Repeatable link value.
 --links A,B           Comma-separated links.
 --project NAME_OR_ID  Existing project name or UUID.
---subreddit NAME      Repeatable existing subreddit name or UUID.
---subreddits A,B      Comma-separated subreddits.
+--subreddit NAME      Repeatable existing subreddit name or UUID. Required unless --subreddits is used.
+--subreddits A,B      Comma-separated subreddits. Required unless --subreddit is used.
 --media PATH          Repeatable image/video path copied into the media store.
 --media-paths A,B     Comma-separated image/video paths.
 --due ISO8601         Creates one one-off posting-window event per chosen subreddit.
@@ -131,6 +131,12 @@ redditreminder captures delete CAPTURE_ID --json
 
 There is no separate due-date field on captures today. `--due` maps to the app's
 posting-window model by creating `SubredditEvent` rows for the selected subreddit(s).
+
+Capture JSON includes `subredditProgress`, an array of each target subreddit and
+whether that target has been posted. `captures mark-posted CAPTURE_ID --subreddit
+NAME` and `captures mark-queued CAPTURE_ID --subreddit NAME` update one target on
+a multi-subreddit capture. Omitting `--subreddit` keeps the existing whole-capture
+behavior.
 
 ## Events
 

--- a/docs/goals/redditreminder-critique-hardening/goal.md
+++ b/docs/goals/redditreminder-critique-hardening/goal.md
@@ -1,0 +1,88 @@
+# RedditReminder Critique Hardening
+
+## Objective
+
+Turn the three-agent critique into a sequenced, verified development effort that fixes the highest-risk RedditReminder UX, functionality, and CI/test-coverage gaps.
+
+## Original Request
+
+Create a detailed plan with clear acceptance criteria for each finding so development can be driven with GoalBuddy.
+
+## Intake Summary
+
+- Input shape: `existing_plan`
+- Audience: RedditReminder maintainer and future GoalBuddy PM/Scout/Judge/Worker agents
+- Authority: `requested`
+- Proof type: `test`
+- Completion proof: The board's implementation tasks are completed or explicitly blocked with receipts, each accepted issue has passing targeted verification, CI coverage is updated for the relevant behavior, and a final audit maps fixes back to the critique findings.
+- Likely misfire: GoalBuddy could produce a polished plan but stop before implementing and verifying the product fixes.
+- Blind spots considered: UI-test data isolation before CI enablement, destructive data-loss risks, multi-subreddit state consistency, CLI/app parity, and avoiding broad unrelated refactors.
+- Existing plan facts: Three independent reviews identified priority findings across UX/workflow, features/functionality, and tests/CI. The most important findings are notification over-posting, UI tests absent from CI and unsafe against real data, unsaved edit loss when adding channels, unconfirmed cascading project deletion, stale per-subreddit posting state after edits, destination-less CLI captures, missing CLI partial-post parity, first-subreddit-only Reddit submit flow, unenforced coverage, misleading optional labels, missing in-app subreddit verification, weak project failure feedback, and brittle recipe search.
+
+## Goal Kind
+
+`existing_plan`
+
+## Current Tranche
+
+Complete successive safe verified slices until the accepted critique findings are either fixed with tests or intentionally deferred with a recorded rationale. Start by validating and operationalizing the critique into bounded work packages, then implement the highest-risk correctness and data-safety fixes before CI/test hardening and lower-priority UX parity work.
+
+## Non-Negotiable Constraints
+
+- Work only from board tasks; do not implement without an active Worker task.
+- Preserve user data and avoid destructive commands.
+- UI tests must use isolated storage before they can be added to CI.
+- Prefer existing app and CLI patterns over broad rewrites.
+- Keep fixes scoped to the critique findings unless a blocker requires a small adjacent change.
+- Every Worker task must include targeted verification and update or add tests appropriate to the risk.
+- Do not mark the goal complete while required Worker tasks remain queued, active, or unverified.
+
+## Acceptance Criteria Summary
+
+Each accepted finding has task-level acceptance criteria in `state.yaml`. In general, a finding is accepted only when:
+
+- The user-visible behavior is corrected or the risk is explicitly deferred.
+- Relevant unit, CLI, UI, or workflow tests cover the corrected behavior.
+- Existing smoke checks still pass.
+- Final audit confirms the behavior against concrete file/test evidence.
+
+## Stop Rule
+
+Stop only when a final audit proves the full original outcome is complete.
+
+Do not stop after planning, discovery, or Judge selection if safe Worker tasks can be activated.
+
+Do not stop after one verified Worker package when the broader critique hardening outcome still has safe local follow-up work. Advance the board to the next highest-leverage safe Worker package and continue unless a phase, risk, rejected-verification, ambiguity, or final-completion review is due.
+
+## Slice Sizing
+
+Safe means bounded, explicit, verified, and reversible. It does not mean tiny.
+
+A good Worker task should complete a coherent product slice, such as cross-post state correctness, UI-test isolation plus CI enablement, destructive-action safety, or CLI parity.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/redditreminder-critique-hardening/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/redditreminder-critique-hardening/goal.md.
+```
+
+## PM Loop
+
+On every `/goal` continuation:
+
+1. Read this charter.
+2. Read `state.yaml`.
+3. Run the bundled GoalBuddy update checker when available and mention a newer version without blocking.
+4. Work only on the active board task.
+5. Assign Scout, Judge, Worker, or PM according to the task.
+6. Write a compact task receipt.
+7. Update the board.
+8. Continue to the next safe local task unless a final audit proves completion.

--- a/docs/goals/redditreminder-critique-hardening/state.yaml
+++ b/docs/goals/redditreminder-critique-hardening/state.yaml
@@ -1,0 +1,654 @@
+version: 2
+
+goal:
+  title: "RedditReminder Critique Hardening"
+  slug: "redditreminder-critique-hardening"
+  kind: existing_plan
+  tranche: "Implement and verify the highest-value fixes from the UX, functionality, and CI/test critique."
+  status: done
+  intake:
+    original_request: "Create a detailed plan with clear acceptance criteria for each finding so development can be driven with GoalBuddy."
+    interpreted_outcome: "A GoalBuddy board sequences the critique findings into implementable, verified development slices with clear acceptance criteria."
+    input_shape: existing_plan
+    audience: "RedditReminder maintainer and GoalBuddy execution agents"
+    authority: requested
+    proof_type: test
+    completion_proof: "All required critique-hardening tasks are done or explicitly blocked/deferred with receipts; targeted tests and CI checks pass; final audit maps evidence back to every accepted finding."
+    likely_misfire: "Stopping at a plan or completing easy low-risk UX wording while leaving cross-post correctness and CI protection gaps unresolved."
+    blind_spots_considered:
+      - "UI tests must not seed or clear the real app store before they are run locally or in CI."
+      - "Project deletion can cascade captures and needs stronger confirmation/dry-run messaging."
+      - "Multi-subreddit posting progress must stay consistent across notifications, edits, app UI, and CLI."
+      - "CI coverage reporting without enforcement may look protective while allowing regressions."
+      - "App/CLI parity matters because agents are expected to use the CLI as a primary interface."
+    existing_plan_facts:
+      - "UX finding: adding a subreddit while editing a capture can discard unsaved edits."
+      - "UX finding: project deletion is destructive and lacks confirmation/cascade warning."
+      - "UX finding: capture title/body labels both say optional although one is required."
+      - "UX finding: app channel creation lacks CLI-style subreddit verification."
+      - "UX finding: project add/rename failures are mostly silent."
+      - "UX finding: recipe search is brittle for terms like add subreddit."
+      - "Functionality finding: notification Mark as Posted over-posts multi-subreddit captures."
+      - "Functionality finding: editing capture subreddits does not reconcile postedSubredditIDs/status."
+      - "Functionality finding: CLI can create destination-less captures unlike the app UI."
+      - "Functionality finding: CLI lacks per-subreddit posting-progress parity."
+      - "Functionality finding: multi-subreddit Open Reddit chooses only the first subreddit."
+      - "CI finding: CI does not run the UI test target."
+      - "CI finding: UI test harness is not isolated from real app data."
+      - "CI finding: coverage is reported but not enforced; measured app coverage was 23.80%."
+      - "CI finding: destructive UI behavior is explicitly skipped."
+      - "CI finding: PR path filtering can mark some non-code changes green with skipped main checks."
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+  preserve_and_validate_existing_plan: true
+  intake_misfire_must_be_audited: true
+  slice_policy:
+    max_consecutive_tiny_tasks: 2
+    prefer_vertical_slices: true
+    judge_picks_largest_safe_slice: true
+    worker_completes_whole_slice: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+visual_board:
+  selected: local
+  local:
+    status: live
+    url: "http://goalbuddy.localhost:41737/redditreminder-critique-hardening/"
+    command: "npx goalbuddy board docs/goals/redditreminder-critique-hardening"
+  github_projects:
+    status: not_requested
+    url: null
+    command: "npx goalbuddy extend github-projects"
+    missing: []
+
+active_task: null
+
+tasks:
+  - id: T001
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Validate the critique findings, confirm the safest implementation sequence, and refine task scope before any product edits."
+    inputs:
+      - "Three-agent critique summarized in goal.intake.existing_plan_facts"
+      - "RedditReminder repository"
+      - "Current CI/test commands"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Preserve the user-provided critique as plan facts, but challenge priority, scope, and verification where needed."
+    expected_output:
+      - "Confirmed or revised priority order."
+      - "Any findings that should be deferred, merged, or split."
+      - "First Worker task objective, allowed_files, verify commands, and stop_if conditions."
+      - "Risk notes for UI-test isolation and destructive data behavior."
+    acceptance_criteria:
+      - "Every high-priority critique finding is mapped to a queued Worker task or a justified deferral."
+      - "The first Worker task is the largest safe useful slice and has exact allowed_files, verify commands, and stop_if rules."
+      - "No code or product files are edited during validation."
+    receipt:
+      result: done
+      decision: "approved"
+      full_outcome_complete: false
+      summary: "Confirmed the highest-risk first slice should be multi-subreddit posting-state correctness. AppDelegateNotifications currently calls markAsPosted for all matching queued captures, and CapturePersistenceActions updates subreddits without reconciling postedSubredditIDs or status."
+      priority_order:
+        - "T002 first: correctness bug can silently remove cross-post targets from future planner/reminder flows."
+        - "T003/T004 next: UI-test isolation must precede CI UI-test enablement."
+        - "T005 after correctness/test foundation: destructive/data-loss UX has product semantics to preserve."
+        - "T006-T008 after foundations: CLI parity, handoff, and polish are important but less urgent than state correctness."
+      evidence:
+        - "Sources/App/AppDelegateNotifications.swift:42"
+        - "Sources/App/AppDelegateNotifications.swift:55"
+        - "Sources/Models/Capture.swift:50"
+        - "Sources/Models/Capture.swift:64"
+        - "Sources/Utilities/CapturePersistenceActions.swift:67"
+        - "Tests/RedditReminderTests/CapturePerSubredditPostingTests.swift:71"
+      first_worker:
+        task: T002
+        objective: "Fix multi-subreddit posting-state correctness across notification actions and capture subreddit edits."
+        allowed_files:
+          - "Sources/App/AppDelegateNotifications.swift"
+          - "Sources/Models/Capture.swift"
+          - "Sources/Utilities/CapturePersistenceActions.swift"
+          - "Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift"
+          - "Tests/RedditReminderTests/CapturePersistenceActionsTests.swift"
+          - "Tests/RedditReminderTests/CapturePerSubredditPostingTests.swift"
+        verify:
+          - "make test"
+        stop_if:
+          - "Fix requires changing SwiftData model schema beyond postedSubredditIDs/status semantics."
+          - "Expected behavior for editing a fully posted capture to add a new subreddit is ambiguous after reading existing tests."
+          - "Verification fails twice for unrelated reasons."
+
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Fix multi-subreddit posting-state correctness across notification actions and capture subreddit edits."
+    allowed_files:
+      - "Sources/App/AppDelegateNotifications.swift"
+      - "Sources/Models/Capture.swift"
+      - "Sources/Utilities/CapturePersistenceActions.swift"
+      - "Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift"
+      - "Tests/RedditReminderTests/CapturePersistenceActionsTests.swift"
+      - "Tests/RedditReminderTests/CapturePerSubredditPostingTests.swift"
+    verify:
+      - "make test"
+    stop_if:
+      - "Fix requires changing SwiftData model schema beyond postedSubredditIDs/status semantics."
+      - "Expected behavior for editing a fully posted capture to add a new subreddit is ambiguous after reading existing tests."
+      - "Verification fails twice for unrelated reasons."
+    acceptance_criteria:
+      - "Notification Mark as Posted marks only the notification subreddit for matching multi-subreddit captures."
+      - "A multi-subreddit capture remains queued until all target subreddits are posted."
+      - "Editing a capture's subreddit list removes stale postedSubredditIDs for removed subreddits."
+      - "Adding a new target subreddit to a posted or partially posted capture reopens/keeps status consistently queued unless all current target subreddits are posted."
+      - "Unit tests cover notification partial posting, stale posted ID cleanup, and status reconciliation."
+      - "`make test` passes."
+    receipt:
+      result: done
+      changed_files:
+        - "Sources/App/AppDelegateNotifications.swift"
+        - "Sources/Models/Capture.swift"
+        - "Sources/Utilities/CapturePersistenceActions.swift"
+        - "Tests/RedditReminderTests/AppDelegateNotificationActionTests.swift"
+        - "Tests/RedditReminderTests/CapturePersistenceActionsTests.swift"
+      commands:
+        - cmd: "make test"
+          status: pass
+          summary: "440 tests passed."
+      summary: "Notification actions now mark only the matching notification subreddit. Capture posting state now reconciles current subreddit targets by filtering stale postedSubredditIDs, deduplicating posted IDs, reopening captures when added targets are unposted, and marking captures posted only when all current targets are posted."
+      acceptance:
+        - "Notification Mark as Posted marks only the notification subreddit for matching multi-subreddit captures."
+        - "A multi-subreddit capture remains queued until all target subreddits are posted."
+        - "Editing a capture's subreddit list removes stale postedSubredditIDs for removed subreddits."
+        - "Adding a new target subreddit to a posted or partially posted capture reopens/keeps status consistently queued unless all current target subreddits are posted."
+        - "Unit tests cover notification partial posting, stale posted ID cleanup, and status reconciliation."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Make UI tests safe to run by isolating QA seed/clear storage from real app data."
+    allowed_files:
+      - "Sources/App/AppDelegate.swift"
+      - "Sources/App/AppDelegateQA.swift"
+      - "Sources/App/AppModelContainerFactory.swift"
+      - "Sources/Utilities/AppRuntime.swift"
+      - "Tests/RedditReminderUITests/RedditReminderUITestSupport.swift"
+      - "Tests/RedditReminderTests/AppModelContainerFactoryTests.swift"
+      - "Tests/RedditReminderTests/AppRuntimeTests.swift"
+      - "Makefile"
+      - "README.md"
+    verify:
+      - "make test"
+      - "make ui-test"
+    stop_if:
+      - "macOS automation permissions prevent local UI-test verification."
+      - "Isolated store support requires changing production storage location semantics."
+      - "Verification fails twice for unrelated CI/permission reasons."
+    acceptance_criteria:
+      - "UI tests launch the app with an explicit isolated store path or in-memory/test container."
+      - "`--seed-qa` and `--clear-qa` cannot mutate the normal production SwiftData store during UI tests."
+      - "README or Makefile documents the UI-test isolation behavior."
+      - "A unit test or UI-test support assertion proves the test store path is distinct from the default app store."
+      - "`make test` passes."
+      - "`make ui-test` is run successfully or a permission-related blocker is recorded with enough detail for CI/local setup."
+    receipt:
+      result: done
+      changed_files:
+        - "Sources/App/AppDelegate.swift"
+        - "Sources/App/AppModelContainerFactory.swift"
+        - "Sources/Utilities/AppRuntime.swift"
+        - "Tests/RedditReminderUITests/RedditReminderUITestSupport.swift"
+        - "Tests/RedditReminderTests/AppModelContainerFactoryTests.swift"
+        - "Tests/RedditReminderTests/AppRuntimeTests.swift"
+        - "README.md"
+      commands:
+        - cmd: "make test"
+          status: pass
+          summary: "444 tests passed."
+        - cmd: "make ui-test"
+          status: pass
+          summary: "8 UI tests passed with 1 existing destructive-flow test skipped."
+      summary: "Added an explicit --ui-test-store launch argument, wired app startup to create a SwiftData container at that path, and updated UI tests to launch with per-test temporary store files. Documented that QA seed/clear runs against isolated UI-test storage."
+      acceptance:
+        - "UI tests launch the app with an explicit isolated store path."
+        - "--seed-qa and --clear-qa operate on the passed UI-test SwiftData store during UI tests."
+        - "README documents UI-test isolation behavior."
+        - "Unit tests cover UI-test store argument parsing and explicit store creation outside the default app support directory."
+        - "make test passes."
+        - "make ui-test passes."
+
+  - id: T004
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Add UI tests to CI once the UI-test harness is isolated, and make CI gate the result appropriately."
+    allowed_files:
+      - ".github/workflows/ci.yml"
+      - "Makefile"
+      - "README.md"
+    verify:
+      - "make ui-test"
+      - "make test"
+      - "make cli-test"
+    stop_if:
+      - "T003 is not done or UI tests are still unsafe against real data."
+      - "GitHub-hosted macOS UI automation cannot run the target reliably without credentials or permission setup."
+      - "Workflow change would make normal PR CI impractically slow without an agreed gating strategy."
+    acceptance_criteria:
+      - "CI includes a UI test job or an explicitly documented/manual-gated alternative with rationale."
+      - "The final CI gate fails if the required UI test job fails or is cancelled."
+      - "Artifacts are uploaded for UI-test failures when available."
+      - "Docs state how UI tests are run locally and in CI."
+      - "`make ui-test`, `make test`, and `make cli-test` pass locally or any UI-automation permission blocker is recorded."
+    receipt:
+      result: done
+      changed_files:
+        - ".github/workflows/ci.yml"
+        - "README.md"
+      commands:
+        - cmd: "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\"); puts \"ci yaml ok\"'"
+          status: pass
+        - cmd: "make cli-test"
+          status: pass
+        - cmd: "make test"
+          status: pass
+          summary: "444 tests passed after the product/UI-test isolation changes."
+        - cmd: "make ui-test"
+          status: pass
+          summary: "8 UI tests passed with 1 existing skipped destructive-flow test after UI-test isolation."
+      summary: "Added a required macOS UI Tests CI job that generates the Xcode project, runs the RedditReminderUITests scheme with a result bundle, uploads failure artifacts, and participates in the final CI gate. README now states that code-change CI runs unit, CLI, and UI test jobs."
+      acceptance:
+        - "CI includes a UI test job."
+        - "The final CI gate fails if the UI test job fails or is cancelled."
+        - "UI test failure artifacts are uploaded when available."
+        - "Docs state that CI runs UI tests and how UI tests isolate storage locally."
+        - "make ui-test, make test, and make cli-test pass locally."
+
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Protect destructive and data-loss-prone UX flows: project deletion, add-channel while editing, and skipped destructive UI coverage."
+    allowed_files:
+      - "Sources/Views/ProjectsTabView.swift"
+      - "Sources/Views/PopoverContentRoutes.swift"
+      - "Sources/Views/CaptureWindowView.swift"
+      - "Sources/Views/CaptureWindowView+FormState.swift"
+      - "Sources/Utilities/ProjectPersistenceActions.swift"
+      - "Tests/RedditReminderTests/ProjectPersistenceActionsTests.swift"
+      - "Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift"
+      - "Tests/RedditReminderUITests/RedditReminderUXFlowUITests.swift"
+    verify:
+      - "make test"
+      - "make ui-test"
+    stop_if:
+      - "Existing UI architecture cannot preserve edit draft state without broader navigation refactor."
+      - "Project deletion semantics are ambiguous: cascade delete versus detach captures."
+      - "UI-test hit targets remain unreliable after adding accessibility identifiers."
+    acceptance_criteria:
+      - "Project deletion requires explicit confirmation in the app UI."
+      - "Confirmation copy communicates capture impact when deletion can cascade or otherwise affect captures."
+      - "Deleting a project through persistence is covered by tests for the chosen capture behavior."
+      - "Adding a channel from capture edit mode preserves unsaved edits, prompts before discarding, or blocks navigation with a clear message."
+      - "Destructive capture/project UI flow has reliable accessibility identifiers and is no longer skipped solely because XCUITest cannot hit the controls."
+      - "`make test` passes."
+      - "`make ui-test` passes or records only an environment permission blocker."
+    receipt:
+      result: done
+      changed_files:
+        - "Sources/Views/ProjectsTabView.swift"
+        - "Sources/Views/CaptureWindowView.swift"
+        - "Sources/Views/CaptureWindowView+FormState.swift"
+        - "Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift"
+      commands:
+        - cmd: "make test"
+          status: pass
+          summary: "444 tests passed."
+        - cmd: "make ui-test"
+          status: pass
+          summary: "8 UI tests passed with 0 failures; the destructive confirmation test is no longer skipped."
+      notes:
+        - "Initial UI-test run exposed an ambiguous seeded query for postedList.delete; the test now uses firstMatch for the seeded posted delete action."
+        - "A strict app.alerts title lookup did not match the AppKit NSAlert accessibility shape; the test now verifies the blocking Delete and Cancel confirmation buttons."
+      summary: "Project deletion now opens an explicit SwiftUI confirmation before calling deleteProject, with copy that includes the affected capture count and warns that the action cannot be undone. Capture edit mode now blocks add-channel navigation when unsaved changes would be discarded and shows an inline save/cancel message. The skipped destructive UI coverage was replaced with a real posted-capture delete confirmation test."
+      acceptance:
+        - "Project deletion requires explicit confirmation in the app UI."
+        - "Confirmation copy communicates affected capture count and permanence."
+        - "Existing persistence tests cover project deletion cascade behavior for captures."
+        - "Adding a channel while editing with unsaved changes is blocked with a clear save/cancel message instead of discarding draft edits."
+        - "Destructive posted-capture UI coverage is no longer skipped and verifies a cancellable confirmation."
+        - "make test passes."
+        - "make ui-test passes."
+
+  - id: T006
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Bring CLI behavior into parity with app posting constraints and per-subreddit progress."
+    allowed_files:
+      - "CLI/Sources/CLIInvocation.swift"
+      - "CLI/Sources/CLIRunner.swift"
+      - "CLI/Sources/CLIArgumentParserCaptures.swift"
+      - "CLI/Sources/CLICaptureLifecycle.swift"
+      - "CLI/Sources/CLICommandCatalogCaptures.swift"
+      - "CLI/Sources/CLIDTOs.swift"
+      - "CLI/Sources/CLIAgentDryRunner.swift"
+      - "CLI/Sources/CLIAgentValidator.swift"
+      - "scripts/cli-smoke.sh"
+      - "scripts/cli-agent-smoke.sh"
+      - "scripts/cli-catalog-check.py"
+      - "docs/cli.md"
+      - "AGENTS.md"
+    verify:
+      - "make cli-test"
+      - "make test"
+    stop_if:
+      - "Existing agent recipes intentionally allow destination-less captures as a supported inbox workflow."
+      - "Adding per-subreddit CLI commands requires a command shape that is ambiguous without user approval."
+      - "CLI schema/catalog compatibility would break existing documented recipes without migration notes."
+    acceptance_criteria:
+      - "CLI validation and dry-run reject destination-less capture creation unless an explicit documented inbox/no-destination mode is approved and added."
+      - "Capture JSON output exposes per-subreddit posted state or equivalent machine-readable progress."
+      - "CLI supports marking/unmarking one subreddit posted for a multi-subreddit capture."
+      - "Command catalog, agent bootstrap, and docs describe the new/changed behavior."
+      - "CLI smoke and agent smoke tests cover destination validation and per-subreddit progress."
+      - "`make cli-test` and `make test` pass."
+    receipt:
+      result: done
+      changed_files:
+        - "AGENTS.md"
+        - "CLI/Sources/CLIArgumentParserCaptures.swift"
+        - "CLI/Sources/CLICaptureLifecycle.swift"
+        - "CLI/Sources/CLICommandCatalogCaptures.swift"
+        - "CLI/Sources/CLIDTOs.swift"
+        - "CLI/Sources/CLIAgentValidator.swift"
+        - "CLI/Sources/CLIInvocation.swift"
+        - "CLI/Sources/CLIRunner.swift"
+        - "docs/cli.md"
+        - "scripts/cli-agent-smoke.sh"
+        - "scripts/cli-smoke.sh"
+      commands:
+        - cmd: "make cli-test"
+          status: pass
+          summary: "CLI build, smoke, agent smoke, and catalog check passed."
+        - cmd: "make test"
+          status: pass
+          summary: "444 tests passed."
+      summary: "CLI capture creation now rejects destination-less captures through normal parsing and agent validate/dry-run. Capture JSON exposes subredditProgress for machine-readable per-target posted state. Existing mark-posted and mark-queued commands now accept --subreddit to update a single target while preserving whole-capture behavior when omitted."
+      acceptance:
+        - "CLI validation and dry-run reject destination-less capture creation unless --subreddit or --subreddits is provided."
+        - "Capture JSON output exposes per-subreddit posted state as subredditProgress."
+        - "CLI supports marking and unmarking one subreddit posted for a multi-subreddit capture through --subreddit."
+        - "Command catalog, agent bootstrap inputs, AGENTS.md, and docs describe the changed behavior."
+        - "CLI smoke and agent smoke cover destination validation and per-subreddit progress."
+        - "make cli-test and make test pass."
+
+  - id: T007
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Improve multi-subreddit handoff so opening Reddit is destination-specific instead of always using the first subreddit."
+    allowed_files:
+      - "Sources/Views/PostHandoffView.swift"
+      - "Sources/Views/PostHandoffViewHelpers.swift"
+      - "Sources/Views/PopoverContentActions.swift"
+      - "Sources/Views/PopoverContentRoutes.swift"
+      - "Sources/Utilities/RedditPostingActions.swift"
+      - "Tests/RedditReminderTests/RedditPostingActionsTests.swift"
+      - "Tests/RedditReminderTests/PostHandoffViewTests.swift"
+      - "Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift"
+    verify:
+      - "make test"
+      - "make ui-test"
+    stop_if:
+      - "Existing product decision requires a single default destination for Open Reddit."
+      - "Destination-specific UI would need a larger handoff redesign than the current tranche permits."
+      - "UI tests cannot verify the control because browser launching is not testable in the current harness."
+    acceptance_criteria:
+      - "Users can open Reddit submit flow for a selected target subreddit from a multi-subreddit capture."
+      - "The default action is clear and does not silently imply all destinations."
+      - "Single-subreddit captures keep a simple one-click path."
+      - "Tests cover URL generation for selected subreddit and stable behavior for single-subreddit captures."
+      - "`make test` passes."
+      - "`make ui-test` passes or records only an environment permission blocker."
+    receipt:
+      result: done
+      changed_files:
+        - "Sources/Utilities/RedditPostingActions.swift"
+        - "Sources/Views/PostHandoffView.swift"
+        - "Sources/Views/PostHandoffViewHelpers.swift"
+        - "Sources/Views/PopoverContentActions.swift"
+        - "Sources/Views/PopoverContentRoutes.swift"
+        - "Tests/RedditReminderTests/PostHandoffViewTests.swift"
+        - "Tests/RedditReminderTests/RedditPostingActionsTests.swift"
+      commands:
+        - cmd: "make test"
+          status: pass
+          summary: "446 tests passed."
+      notes:
+        - "make ui-test was retried twice and blocked before app test execution by XCTest automation initialization: 'Timed out while enabling automation mode.' Result bundles: build/Logs/Test/Test-RedditReminderUITests-2026.05.16_13-20-58--0700.xcresult and Test-RedditReminderUITests-2026.05.16_13-22-12--0700.xcresult."
+      summary: "Multi-subreddit post handoff now exposes destination-specific Open Reddit controls. Single-subreddit captures retain the one-click Open Reddit footer button, while multi-subreddit captures show a Choose Subreddit footer menu and per-row open controls. Reddit submit URL generation now supports a selected capture subreddit and rejects subreddit IDs outside the capture."
+      acceptance:
+        - "Users can open Reddit submit flow for a selected target subreddit from a multi-subreddit capture."
+        - "The multi-subreddit default action is explicit: the footer prompts to choose a subreddit instead of silently using the first target."
+        - "Single-subreddit captures keep a simple one-click Open Reddit path."
+        - "Tests cover URL generation for selected subreddit and rejection of non-target subreddit IDs."
+        - "make test passes."
+        - "make ui-test is blocked by local XCTest automation initialization, not by an app test failure."
+
+  - id: T008
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Address medium/low UX and agent-discoverability polish findings after correctness and CI foundations are stable."
+    allowed_files:
+      - "Sources/Views/CaptureWindowView.swift"
+      - "Sources/Views/ChannelsView.swift"
+      - "Sources/Views/ProjectsTabView.swift"
+      - "Sources/Utilities/SubredditPersistenceActions.swift"
+      - "CLI/Sources/CLIRecipeCatalog.swift"
+      - "CLI/Sources/CLIRecipeCatalogDryRun.swift"
+      - "Tests/RedditReminderTests/SubredditPersistenceActionsTests.swift"
+      - "Tests/RedditReminderTests/ProjectPersistenceActionsTests.swift"
+      - "Tests/RedditReminderUITests/RedditReminderUXFlowUITests.swift"
+      - "scripts/cli-agent-smoke.sh"
+      - "docs/cli.md"
+    verify:
+      - "make test"
+      - "make cli-test"
+      - "make ui-test"
+    stop_if:
+      - "Subreddit verification requires live network behavior that cannot be tested deterministically."
+      - "Recipe search needs a ranking/search design beyond simple synonym support."
+      - "UI polish conflicts with established copy or design decisions."
+    acceptance_criteria:
+      - "Capture title/body labels or nearby requirement copy clearly communicate that at least one is required."
+      - "In-app channel creation offers verification or clearly labels unverified local-only additions."
+      - "Project add/rename validation failures surface clear feedback and do not silently close failed edits."
+      - "Recipe search finds relevant subreddit setup recipes for natural queries such as add subreddit."
+      - "Targeted unit, UI, or CLI smoke tests cover the changed validation/discovery behavior."
+      - "`make test`, `make cli-test`, and `make ui-test` pass or UI automation permission blockers are recorded."
+    receipt:
+      result: done
+      changed_files:
+        - "CLI/Sources/CLIRecipeCatalog.swift"
+        - "CLI/Sources/CLIRecipeCatalogDryRun.swift"
+        - "Sources/Views/CaptureWindowView.swift"
+        - "Sources/Views/ChannelsView.swift"
+        - "Sources/Views/ProjectsTabView.swift"
+        - "scripts/cli-agent-smoke.sh"
+      commands:
+        - cmd: "make test"
+          status: pass
+          summary: "446 tests passed."
+        - cmd: "make cli-test"
+          status: pass
+          summary: "CLI build, smoke, agent smoke, and catalog check passed."
+      notes:
+        - "make ui-test was attempted after T008 changes but the local XCTest runner hung after 'Running tests' and before emitting test cases; xcodebuild and test runner were terminated to avoid leaving processes running. This follows repeated T007 automation initialization failures in the same local environment."
+      summary: "Capture form content fields now communicate that a title or capture text is required. App channel creation now labels additions as local-only and points verification-sensitive workflows to the CLI. Project add and rename flows show validation feedback and keep failed rename edits open. Recipe search now directly matches natural 'add subreddit' queries."
+      acceptance:
+        - "Capture title/body copy communicates that at least one is required."
+        - "In-app channel creation clearly labels additions as local-only and points to CLI verification."
+        - "Project add/rename validation failures surface clear feedback; failed renames no longer silently close edit mode."
+        - "Recipe search finds relevant subreddit setup recipes for natural queries such as add subreddit."
+        - "CLI smoke covers add-subreddit recipe discovery."
+        - "make test and make cli-test pass."
+        - "make ui-test is blocked by local XCTest automation state, not by an app test failure."
+
+  - id: T009
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Review CI coverage enforcement and PR path-filter risks, then decide whether to implement thresholds, changed-file gates, or documented deferrals."
+    inputs:
+      - "T003 and T004 receipts"
+      - ".github/workflows/ci.yml"
+      - "coverage artifacts from the latest unit/UI runs if available"
+    constraints:
+      - "Read-only."
+      - "Do not implement."
+      - "Prefer a realistic gate that protects important behavior without making early development brittle."
+    expected_output:
+      - "Decision on coverage threshold or changed-file coverage gate."
+      - "Decision on PR path-filter/package metadata validation."
+      - "Worker task details if implementation is approved."
+      - "Deferral rationale if not approved."
+    acceptance_criteria:
+      - "Coverage enforcement is either converted into a Worker task with exact acceptance criteria or deferred with a concrete rationale."
+      - "Path-filter behavior for package/release metadata is either corrected by a Worker task or explicitly accepted as a tradeoff."
+      - "Decision references current CI commands and measured coverage evidence."
+    receipt:
+      result: done
+      decision: approved
+      coverage_decision: deferred
+      path_filter_decision: implement_package_metadata_gate
+      full_outcome_complete: false
+      summary: "Deferred numeric and changed-file coverage gates for this tranche because current app coverage is low, local Makefile tests do not produce coverage, and SwiftUI-heavy changes would make changed-file coverage noisy. Approved a narrow package/release metadata CI gate because package.json, package-lock.json, .releaserc.json, and commitlint.config.cjs can currently skip main PR checks while CI Gate accepts skipped jobs."
+      evidence:
+        - ".github/workflows/ci.yml unit-tests runs xcodebuild test with -enableCodeCoverage YES and uploads coverage artifacts."
+        - "Judge inspected latest local coverage evidence: RedditReminder.app 24.31% versus critique baseline 23.80%."
+        - "Current detect-changes filters include code/project/workflow paths but not package/release metadata."
+
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: medium
+    objective: "Fix CI PR path filtering so package/release metadata changes receive validation instead of green skipped main checks; leave coverage enforcement explicitly deferred by T009."
+    allowed_files:
+      - ".github/workflows/ci.yml"
+      - "README.md"
+    verify:
+      - "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\"); puts \"ci yaml ok\"'"
+      - "ruby -e 'require \"yaml\"; ci=YAML.load_file(\".github/workflows/ci.yml\"); jobs=ci.fetch(\"jobs\"); abort(\"missing package-metadata job\") unless jobs.key?(\"package-metadata\"); filters=ci.dig(\"jobs\",\"detect-changes\",\"steps\").find { |s| s[\"id\"] == \"filter\" }.dig(\"with\",\"filters\"); %w[package.json package-lock.json .releaserc.json commitlint.config.cjs].each { |p| abort(\"missing #{p}\") unless filters.include?(p) }; gate_needs=jobs.dig(\"ci-gate\",\"needs\"); abort(\"gate missing package-metadata\") unless gate_needs.include?(\"package-metadata\"); puts \"ci package metadata gate ok\"'"
+      - "npm ci"
+    stop_if:
+      - "Workflow changes would make docs-only PRs fail instead of intentionally skipping expensive checks."
+      - "Package metadata validation requires GitHub tokens or live semantic-release credentials; use npm ci and static JSON/config checks instead."
+      - "Static workflow validation shows package-only PRs would still skip all required validation."
+      - "A coverage gate is requested during implementation; stop and return to Judge because T009 deferred coverage enforcement."
+    acceptance_criteria:
+      - "detect-changes exposes a package/release metadata output for package.json, package-lock.json, .releaserc.json, and commitlint.config.cjs."
+      - "A package-metadata CI job runs for package/release metadata PRs and validates npm dependency metadata with npm ci plus static JSON/config sanity checks that do not require release credentials."
+      - "ci-gate includes package-metadata and fails when it fails or is cancelled, while still allowing skipped jobs for docs-only PRs."
+      - "Existing code-change behavior is preserved: lint, build, unit-tests, cli-tests, ui-tests, and file-size-check still run for current code filters."
+      - "Coverage report generation/upload remains unchanged, with no numeric threshold or changed-file gate added."
+      - "README briefly documents that CI runs package/release metadata validation for package metadata changes and that coverage is reported but not currently enforced."
+    receipt:
+      result: done
+      changed_files:
+        - ".github/workflows/ci.yml"
+        - "README.md"
+      commands:
+        - cmd: "ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\"); puts \"ci yaml ok\"'"
+          status: pass
+        - cmd: "ruby -e 'require \"yaml\"; ci=YAML.load_file(\".github/workflows/ci.yml\"); jobs=ci.fetch(\"jobs\"); abort(\"missing package-metadata job\") unless jobs.key?(\"package-metadata\"); filters=ci.dig(\"jobs\",\"detect-changes\",\"steps\").find { |s| s[\"id\"] == \"filter\" }.dig(\"with\",\"filters\"); %w[package.json package-lock.json .releaserc.json commitlint.config.cjs].each { |p| abort(\"missing #{p}\") unless filters.include?(p) }; gate_needs=jobs.dig(\"ci-gate\",\"needs\"); abort(\"gate missing package-metadata\") unless gate_needs.include?(\"package-metadata\"); puts \"ci package metadata gate ok\"'"
+          status: pass
+        - cmd: "npm ci"
+          status: pass
+          summary: "Installed 343 packages; npm audit reported existing 1 moderate and 1 high vulnerability."
+      summary: "CI now detects package/release metadata changes separately, runs a lightweight package-metadata job with npm ci plus JSON/config loading, and includes that job in ci-gate. Code-change jobs and coverage reporting/upload remain unchanged. README documents package metadata validation and the current report-only coverage policy."
+      acceptance:
+        - "detect-changes exposes package_metadata for package.json, package-lock.json, .releaserc.json, and commitlint.config.cjs."
+        - "package-metadata CI job runs npm ci and static package/release config sanity checks without release credentials."
+        - "ci-gate includes package-metadata and fails on failure/cancellation while preserving skipped docs-only behavior."
+        - "Existing code-change behavior is preserved."
+        - "Coverage report generation/upload remains unchanged; no numeric threshold or changed-file gate was added."
+        - "README documents package metadata validation and report-only coverage."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Audit whether the critique-hardening tranche satisfies the original GoalBuddy planning and implementation outcome."
+    inputs:
+      - "All task receipts"
+      - "Latest git diff"
+      - "Latest verification command results"
+      - "Original three-agent critique findings in goal.intake.existing_plan_facts"
+    constraints:
+      - "Read-only."
+      - "Reject completion if required Worker work remains queued, active, or unverified."
+      - "Reject completion if any high-priority critique finding lacks a fix, blocker, or explicit deferral rationale."
+      - "Reject completion if only planning was completed."
+    expected_output:
+      - "complete | not_complete"
+      - "full_outcome_complete: true | false"
+      - "Finding-by-finding evidence map"
+      - "Missing evidence"
+      - "Next task if not complete"
+    acceptance_criteria:
+      - "Every accepted critique finding is mapped to a done receipt, blocked receipt, or deferral decision."
+      - "High-priority functionality, data-safety, and CI safety findings have implementation evidence unless blocked."
+      - "Verification commands include the relevant unit, CLI, and UI/CI checks or documented environment blockers."
+      - "The final receipt states `full_outcome_complete: true` only when the original outcome is actually met."
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "Final audit accepted completion. T002-T010 are all done with receipts; no required Worker task remains queued or active. The diff contains implementation, test, CI, and docs changes matching the critique findings. High-priority functionality, data-safety, and CI-safety findings are fixed or explicitly deferred with rationale."
+      evidence:
+        - "Multi-subreddit posting correctness fixed through notification partial posting and capture reconciliation receipts in T002."
+        - "UI-test store isolation and CI UI-test gating fixed in T003/T004."
+        - "Destructive/data-loss UX coverage fixed in T005, including project deletion confirmation, edit add-channel guard, and unskipped destructive UI test."
+        - "CLI destination validation and per-subreddit progress/actions fixed in T006."
+        - "Multi-subreddit Reddit handoff is destination-specific in T007."
+        - "UX/discoverability polish findings addressed in T008."
+        - "Coverage enforcement explicitly deferred by T009 with rationale; package/release metadata PR path-filter gap fixed in T010."
+        - "git diff --check passed."
+      missing_evidence: []
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: pass
+    task: T999
+    commands:
+      - "git diff --check"

--- a/package-lock.json
+++ b/package-lock.json
@@ -400,6 +400,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -1296,6 +1297,7 @@
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1343,6 +1345,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -1745,9 +1748,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2535,6 +2538,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2715,9 +2719,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+      "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2796,8 +2800,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/config": "^10.9.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -2821,11 +2825,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.6",
-        "libnpmexec": "^10.2.6",
-        "libnpmfund": "^7.0.20",
+        "libnpmdiff": "^8.1.7",
+        "libnpmexec": "^10.2.7",
+        "libnpmfund": "^7.0.21",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.6",
+        "libnpmpack": "^9.1.7",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -2956,7 +2960,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.3",
+      "version": "9.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3004,7 +3008,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3418,7 +3422,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -3641,7 +3645,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3723,12 +3727,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.6",
+      "version": "8.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3742,13 +3746,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.6",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -3765,12 +3769,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.20",
+      "version": "7.0.21",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3"
+        "@npmcli/arborist": "^9.5.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3790,12 +3794,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.6",
+      "version": "9.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4426,12 +4430,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -4565,6 +4569,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5144,6 +5149,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -5998,6 +6004,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6098,8 +6105,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/scripts/cli-agent-smoke.sh
+++ b/scripts/cli-agent-smoke.sh
@@ -48,6 +48,11 @@ assert_contains "validate invalid ok" "$invalid_command" '"ok":true'
 assert_contains "validate invalid" "$invalid_command" '"valid":false'
 assert_contains "validate missing flag" "$invalid_command" "Missing required flag --hours."
 
+destinationless_capture="$(run_json agent validate -- captures create --title "No destination" --text "Body")"
+assert_contains "validate destinationless ok" "$destinationless_capture" '"ok":true'
+assert_contains "validate destinationless invalid" "$destinationless_capture" '"valid":false'
+assert_contains "validate destinationless rejected" "$destinationless_capture" "provide --subreddit or --subreddits"
+
 dry_run_preview="$(run_json agent dry-run -- projects create "Agent Draft")"
 assert_contains "agent dry-run ok" "$dry_run_preview" '"ok":true'
 assert_contains "agent dry-run valid" "$dry_run_preview" '"valid":true'
@@ -59,6 +64,11 @@ assert_contains "agent dry-run read-only ok" "$read_only_preview" '"ok":true'
 assert_contains "agent dry-run read-only invalid" "$read_only_preview" '"valid":false'
 assert_contains "agent dry-run read-only rejected" "$read_only_preview" "read-only"
 
+destinationless_preview="$(run_json agent dry-run -- captures create --title "No destination" --text "Body")"
+assert_contains "agent dry-run destinationless ok" "$destinationless_preview" '"ok":true'
+assert_contains "agent dry-run destinationless invalid" "$destinationless_preview" '"valid":false'
+assert_contains "agent dry-run destinationless rejected" "$destinationless_preview" "provide --subreddit or --subreddits"
+
 context="$(run_json context show --limit 10)"
 assert_contains "context ok" "$context" '"ok":true'
 assert_contains "context counts" "$context" '"counts":'
@@ -66,6 +76,10 @@ assert_contains "context counts" "$context" '"counts":'
 recipes="$(run_json recipes search --query dry-run)"
 assert_contains "recipes ok" "$recipes" '"ok":true'
 assert_contains "recipes dry-run project" "$recipes" '"id":"project.archive-dry-run"'
+
+subreddit_recipes="$(run_json recipes search --query "add subreddit")"
+assert_contains "recipes add subreddit ok" "$subreddit_recipes" '"ok":true'
+assert_contains "recipes add subreddit core" "$subreddit_recipes" '"id":"subreddit.configure-peak-times"'
 
 preview="$(run_json_dry projects create "Agent Draft")"
 assert_contains "dry-run ok" "$preview" '"ok":true'

--- a/scripts/cli-smoke.sh
+++ b/scripts/cli-smoke.sh
@@ -127,6 +127,9 @@ rm -f /tmp/redditreminder-cli-duplicate.out /tmp/redditreminder-cli-duplicate.er
 subreddit_search="$(run_json subreddits search --query side)"
 assert_contains "subreddit search" "$subreddit_search" '"name":"r/SideProject"'
 
+companion_subreddit_created="$(run_json subreddits add CompanionSub)"
+assert_contains "companion subreddit create" "$companion_subreddit_created" '"name":"r/CompanionSub"'
+
 presets="$(run_json peaks presets)"
 assert_contains "peak presets" "$presets" '"label":"Weekday AM"'
 
@@ -250,6 +253,13 @@ assert_contains "event delete id" "$event_deleted" "\"id\":\"$event_id\""
 IMAGE="$TMP_DIR/pixel.png"
 sips -s format png /System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericApplicationIcon.icns --out "$IMAGE" >/dev/null
 
+if run_json captures create --title "No destination" --text "Missing subreddit" >/tmp/redditreminder-cli-destinationless.out 2>/tmp/redditreminder-cli-destinationless.err; then
+  echo "FAIL: destination-less capture create unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "destination-less capture rejected" "$(cat /tmp/redditreminder-cli-destinationless.err)" "requires --subreddit or --subreddits"
+rm -f /tmp/redditreminder-cli-destinationless.out /tmp/redditreminder-cli-destinationless.err
+
 capture_created="$(
   run_json captures create \
     --title "Launch post" \
@@ -258,6 +268,7 @@ capture_created="$(
     --link "https://example.com" \
     --project "Launch Ideas" \
     --subreddit SideProject \
+    --subreddit CompanionSub \
     --media "$IMAGE" \
     --due "2026-05-02T18:00:00Z"
 )"
@@ -277,10 +288,23 @@ assert_contains "capture update ok" "$capture_updated" '"ok":true'
 assert_contains "capture update title" "$capture_updated" '"title":"Updated launch post"'
 assert_contains "capture update link" "$capture_updated" '"https://example.com/updated"'
 
-capture_posted="$(run_json captures mark-posted "$capture_id" --url "https://reddit.com/r/SideProject/comments/abc")"
+capture_partial_posted="$(run_json captures mark-posted "$capture_id" --subreddit SideProject)"
+assert_contains "capture partial mark posted ok" "$capture_partial_posted" '"ok":true'
+assert_contains "capture partial mark posted status" "$capture_partial_posted" '"status":"queued"'
+assert_contains "capture partial sideproject posted" "$capture_partial_posted" '"name":"r/SideProject","posted":true'
+assert_contains "capture partial companion queued" "$capture_partial_posted" '"name":"r/CompanionSub","posted":false'
+
+capture_posted="$(run_json captures mark-posted "$capture_id" --subreddit CompanionSub --url "https://reddit.com/r/CompanionSub/comments/abc")"
 assert_contains "capture mark posted ok" "$capture_posted" '"ok":true'
 assert_contains "capture mark posted status" "$capture_posted" '"status":"posted"'
-assert_contains "capture mark posted url" "$capture_posted" '"postedURL":"https://reddit.com/r/SideProject/comments/abc"'
+assert_contains "capture mark posted url" "$capture_posted" '"postedURL":"https://reddit.com/r/CompanionSub/comments/abc"'
+assert_contains "capture mark posted progress" "$capture_posted" '"name":"r/CompanionSub","posted":true'
+
+capture_partial_queued="$(run_json captures mark-queued "$capture_id" --subreddit SideProject)"
+assert_contains "capture partial mark queued ok" "$capture_partial_queued" '"ok":true'
+assert_contains "capture partial mark queued status" "$capture_partial_queued" '"status":"queued"'
+assert_contains "capture partial sideproject queued" "$capture_partial_queued" '"name":"r/SideProject","posted":false'
+assert_contains "capture partial companion still posted" "$capture_partial_queued" '"name":"r/CompanionSub","posted":true'
 
 capture_queued="$(run_json captures mark-queued "$capture_id")"
 assert_contains "capture mark queued ok" "$capture_queued" '"ok":true'


### PR DESCRIPTION
## Summary

This PR turns the three-agent critique hardening plan into implementation across the highest-risk UX, functionality, CLI, and CI gaps.

It fixes multi-subreddit posting correctness, including per-subreddit notification handling, stale posted-state reconciliation, and destination-specific Reddit handoff controls. It also hardens destructive/data-loss UX with project delete confirmation, an unsaved-edit guard before adding channels, and restored destructive UI coverage.

The CLI now rejects destination-less capture creation, exposes per-subreddit posting progress, and supports destination-scoped posted/queued mutations. CI now runs UI tests for app-code changes, isolates UI test stores, validates package/release metadata changes, keeps coverage reporting explicit, and the lockfile has been refreshed so npm audit is clean.

GoalBuddy receipts for the critique-hardening run are included under docs/goals/redditreminder-critique-hardening/.

## Validation

- make test passed during the hardening run, latest recorded full pass: 446 tests
- make cli-test passed
- make ui-test passed earlier after UI isolation/destructive coverage work; later local attempts were blocked before test execution by XCTest automation initialization timeouts and are recorded in the GoalBuddy receipt
- npm ci passes with found 0 vulnerabilities
- npm audit --json reports 0 vulnerabilities
- CI package metadata static check passes
- git diff --check passes
- GoalBuddy state checker passes for docs/goals/redditreminder-critique-hardening/state.yaml