### PR TITLE
[codex] Refresh macOS menu bar UX

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -19,8 +19,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   let globalShortcut: any GlobalShortcutRegistering
   private var refreshTask: Task<Void, Never>?
   private var shortcutObserver: NSObjectProtocol?
+  private var commandKeyMonitor: Any?
   var activeShortcutConfig: KeyboardShortcutConfig?
-  private var keepAliveWindow: NSWindow?
+  private var settingsWindowController: NSWindowController?
+  private var lifecycleAnchorWindow: NSWindow?
 
   override convenience init() {
     self.init(
@@ -102,8 +104,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     ProcessInfo.processInfo.disableAutomaticTermination(
       "Keep RedditReminder menu bar app running"
     )
-    setupKeepAliveWindow()
     bootstrapApplication()
+    setupLifecycleAnchorWindow()
+    installCommandKeyMonitor()
 
     if AppRuntime.shouldRegisterGlobalShortcut() {
       registerGlobalShortcut()
@@ -159,26 +162,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     menuBarController.setup(popoverContent: popoverView)
   }
 
-  private func setupKeepAliveWindow() {
-    guard keepAliveWindow == nil else { return }
-
-    let window = NSWindow(
-      contentRect: NSRect(x: -10_000, y: -10_000, width: 1, height: 1),
-      styleMask: [.borderless],
-      backing: .buffered,
-      defer: false
-    )
-    window.contentView = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
-    window.backgroundColor = .clear
-    window.alphaValue = 0.01
-    window.ignoresMouseEvents = true
-    window.isOpaque = false
-    window.isReleasedWhenClosed = false
-    window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
-    window.orderFront(nil)
-    keepAliveWindow = window
-  }
-
   private func presentStoreUnavailableAlert(error: Error) {
     let alert = NSAlert()
     alert.alertStyle = .critical
@@ -205,18 +188,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   func applicationWillTerminate(_ notification: Notification) {
     globalShortcut.unregister()
     refreshTask?.cancel()
-    keepAliveWindow?.close()
-    keepAliveWindow = nil
+    settingsWindowController?.close()
+    settingsWindowController = nil
+    lifecycleAnchorWindow?.close()
+    lifecycleAnchorWindow = nil
     ProcessInfo.processInfo.enableAutomaticTermination(
       "Keep RedditReminder menu bar app running"
     )
     if let shortcutObserver {
       NotificationCenter.default.removeObserver(shortcutObserver)
     }
+    if let commandKeyMonitor {
+      NSEvent.removeMonitor(commandKeyMonitor)
+    }
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     false
+  }
+
+  private func setupLifecycleAnchorWindow() {
+    guard lifecycleAnchorWindow == nil else { return }
+
+    let window = NSWindow(
+      contentRect: NSRect(x: -10_000, y: -10_000, width: 1, height: 1),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false
+    )
+    window.level = .popUpMenu
+    window.alphaValue = 0
+    window.ignoresMouseEvents = true
+    window.isReleasedWhenClosed = false
+    window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+    window.orderFrontRegardless()
+    lifecycleAnchorWindow = window
   }
 
   private func startRefreshLoop() {
@@ -227,6 +233,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard !Task.isCancelled else { break }
         runRefreshCycle()
       }
+    }
+  }
+
+  private func installCommandKeyMonitor() {
+    guard commandKeyMonitor == nil else { return }
+    commandKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+      let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+      guard
+        flags.contains(.command),
+        !flags.contains(.option),
+        !flags.contains(.control),
+        !flags.contains(.shift),
+        let key = event.charactersIgnoringModifiers?.lowercased()
+      else {
+        return event
+      }
+
+      switch key {
+      case "n", ",", "w":
+        Task { @MainActor [weak self] in
+          self?.handleCommandKey(key)
+        }
+        return nil
+      default:
+        return event
+      }
+    }
+  }
+
+  private func handleCommandKey(_ key: String) {
+    switch key {
+    case "n":
+      settingsWindowController?.window?.performClose(nil)
+      menuBarController.requestNewCapture()
+    case ",":
+      openSettingsWindow()
+    case "w":
+      let window = NSApp.keyWindow ?? NSApp.orderedWindows.first { window in
+        window.isVisible && window.canBecomeKey
+      }
+      window?.performClose(nil)
+    default:
+      break
     }
   }
 
@@ -272,11 +321,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
   func wireMenuActions(container: ModelContainer) {
     modelContainer = container
     menuBarController.onNewCapture = { [weak self] in
+      self?.settingsWindowController?.window?.performClose(nil)
       self?.menuBarController.requestNewCapture()
     }
-    menuBarController.onOpenPreferences = { [weak self] in
-      self?.menuBarController.requestPreferences()
+    menuBarController.onOpenPreferences = { [weak self] tab in
+      self?.openSettingsWindow(initialTab: tab)
     }
+  }
+
+  func openSettingsWindow(initialTab: PreferencesView.Tab = PreferencesView.defaultTab) {
+    guard let container = modelContainer else {
+      NSLog("RedditReminder: settings skipped — no ModelContainer")
+      return
+    }
+
+    menuBarController.dismissPopover()
+    menuBarController.installMenuShortcuts()
+
+    let settingsView = PreferencesView(
+      notificationService: notificationService,
+      heuristicsStore: heuristicsStore,
+      initialTab: initialTab,
+      onAppStateChanged: { [weak self] in self?.runRefreshCycle() }
+    )
+    .modelContainer(container)
+    .frame(minWidth: 520, idealWidth: 560, minHeight: 360, idealHeight: 420)
+
+    let hostingController = NSHostingController(rootView: settingsView)
+
+    if let window = settingsWindowController?.window {
+      window.contentViewController = hostingController
+      window.makeKeyAndOrderFront(nil)
+      NSApp.activate(ignoringOtherApps: true)
+      menuBarController.installMenuShortcuts()
+      return
+    }
+
+    let window = NSWindow(contentViewController: hostingController)
+    window.title = "Settings"
+    window.styleMask = [.titled, .closable, .miniaturizable]
+    window.minSize = NSSize(width: 520, height: 360)
+    window.isReleasedWhenClosed = false
+    window.center()
+
+    let controller = NSWindowController(window: window)
+    settingsWindowController = controller
+    controller.showWindow(nil)
+    NSApp.activate(ignoringOtherApps: true)
+    menuBarController.installMenuShortcuts()
   }
 
   private var defaultLeadTimeMinutes: Int {
@@ -288,7 +380,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     try heuristicsStore.syncGeneratedEvents(
       for: subreddits,
       context: context,
-      defaultLeadTimeMinutes: defaultLeadTimeMinutes
+      defaultLeadTimeMinutes: defaultLeadTimeMinutes,
+      notificationService: notificationService
     )
   }
 

--- a/Sources/App/RedditReminderApp.swift
+++ b/Sources/App/RedditReminderApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftData
 import SwiftUI
 
 @main
@@ -7,7 +8,37 @@ struct RedditReminderApp: App {
 
   var body: some Scene {
     Settings {
-      EmptyView()
+      SettingsSceneView(appDelegate: appDelegate)
+    }
+  }
+}
+
+private struct SettingsSceneView: View {
+  let appDelegate: AppDelegate
+  @State private var container: ModelContainer?
+
+  var body: some View {
+    Group {
+      if let container {
+        PreferencesView(
+          notificationService: appDelegate.notificationService,
+          heuristicsStore: appDelegate.heuristicsStore,
+          onAppStateChanged: { appDelegate.runRefreshCycle() }
+        )
+        .modelContainer(container)
+      } else {
+        VStack(spacing: 8) {
+          ProgressView()
+          Text("Loading Settings")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .frame(minWidth: 520, idealWidth: 560, minHeight: 360, idealHeight: 420)
+    .onAppear {
+      container = appDelegate.modelContainer
     }
   }
 }

--- a/Sources/Services/HeuristicsStore.swift
+++ b/Sources/Services/HeuristicsStore.swift
@@ -56,13 +56,15 @@ final class HeuristicsStore {
   func syncGeneratedEvents(
     for subreddits: [Subreddit],
     context: ModelContext,
-    defaultLeadTimeMinutes: Int
+    defaultLeadTimeMinutes: Int,
+    notificationService: NotificationService? = nil
   ) throws {
     for subreddit in subreddits {
       try syncGeneratedEvents(
         for: subreddit,
         context: context,
-        defaultLeadTimeMinutes: defaultLeadTimeMinutes
+        defaultLeadTimeMinutes: defaultLeadTimeMinutes,
+        notificationService: notificationService
       )
     }
   }
@@ -70,7 +72,8 @@ final class HeuristicsStore {
   func syncGeneratedEvents(
     for subreddit: Subreddit,
     context: ModelContext,
-    defaultLeadTimeMinutes: Int
+    defaultLeadTimeMinutes: Int,
+    notificationService: NotificationService? = nil
   ) throws {
     let peak = peakInfo(for: subreddit)
     let desired = desiredEvents(for: peak)
@@ -78,6 +81,7 @@ final class HeuristicsStore {
 
     for event in subreddit.events where event.isGeneratedFromHeuristics {
       guard let key = event.generationKey, desiredKeys.contains(key) else {
+        notificationService?.cancelNotifications(eventId: event.id.uuidString)
         context.delete(event)
         continue
       }

--- a/Sources/Services/MenuBarController.swift
+++ b/Sources/Services/MenuBarController.swift
@@ -14,11 +14,12 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
   private var statusItem: NSStatusItem?
   private var popover: NSPopover?
+  private let menuBarLabel = "RR"
 
   /// Called from PopoverContentView to open new capture; wired to ⌘N.
   var onNewCapture: (() -> Void)?
   /// Called from PopoverContentView to open settings; wired to ⌘,.
-  var onOpenPreferences: (() -> Void)?
+  var onOpenPreferences: ((PreferencesView.Tab) -> Void)?
   #if DEBUG
     var onQACopyFirstQueuedCapture: (() -> Void)?
     var onQACopyFirstQueuedSubmitURL: (() -> Void)?
@@ -35,12 +36,15 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
   #endif
 
   func setup(popoverContent: some View) {
-    let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+    let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
     if let button = item.button {
       button.image = NSImage(
         systemSymbolName: "bell.badge", accessibilityDescription: "RedditReminder")
       button.image?.isTemplate = true
+      button.title = menuBarLabel
+      button.imagePosition = .imageLeading
+      button.toolTip = "RedditReminder"
       button.action = #selector(statusItemClicked)
       button.target = self
     }
@@ -87,7 +91,12 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
 
   func requestPreferences() {
     preferencesRequestCount += 1
-    openPopover()
+    openSettingsWindow()
+  }
+
+  func openSettingsWindow(tab: PreferencesView.Tab = PreferencesView.defaultTab) {
+    dismissPopover()
+    onOpenPreferences?(tab)
   }
 
   func dismissPopover() {
@@ -116,11 +125,11 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     }
 
     if badgeCount > 0 {
-      button.title = "\(badgeCount)"
+      button.title = "\(menuBarLabel) \(badgeCount)"
       button.imagePosition = .imageLeading
     } else {
-      button.title = ""
-      button.imagePosition = .imageOnly
+      button.title = menuBarLabel
+      button.imagePosition = .imageLeading
     }
   }
 

--- a/Sources/Services/MenuBarControllerMenus.swift
+++ b/Sources/Services/MenuBarControllerMenus.swift
@@ -29,6 +29,10 @@ extension MenuBarController {
       title: "New Capture", action: #selector(handleNewCapture), keyEquivalent: "n")
     newCaptureItem.target = self
     fileMenu.addItem(newCaptureItem)
+    let closeItem = NSMenuItem(
+      title: "Close", action: #selector(handleCloseWindow), keyEquivalent: "w")
+    closeItem.target = self
+    fileMenu.addItem(closeItem)
     mainMenu.addItem(fileMenuItem)
 
     #if DEBUG
@@ -43,7 +47,14 @@ extension MenuBarController {
   }
 
   @objc private func handleOpenPreferences() {
-    onOpenPreferences?()
+    openSettingsWindow()
+  }
+
+  @objc private func handleCloseWindow() {
+    let window = NSApp.keyWindow ?? NSApp.orderedWindows.first { window in
+      window.isVisible && window.canBecomeKey
+    }
+    window?.performClose(nil)
   }
 }
 

--- a/Sources/Services/NotificationScheduler.swift
+++ b/Sources/Services/NotificationScheduler.swift
@@ -31,6 +31,7 @@ struct NotificationScheduler {
         }
 
         var activeEventIds: Set<String> = []
+        var desiredRequestIds: Set<String> = []
         let nudgeEnabled = defaults.object(forKey: SettingsKey.nudgeWhenEmpty) as? Bool ?? true
 
         for window in windows {
@@ -43,6 +44,7 @@ struct NotificationScheduler {
             }
 
             let subredditName = window.event.subreddit?.name ?? "subreddit"
+            desiredRequestIds.insert(AppNotificationIdentifiers.windowRequestId(eventId: eventId))
             notificationService.scheduleWindowNotification(
                 eventId: eventId,
                 subredditName: subredditName,
@@ -52,12 +54,15 @@ struct NotificationScheduler {
             )
 
             if window.matchingCaptureCount == 0 && nudgeEnabled {
+                desiredRequestIds.insert(AppNotificationIdentifiers.nudgeRequestId(eventId: eventId))
                 notificationService.scheduleEmptyQueueNudge(
                     eventId: eventId,
                     subredditName: subredditName,
                     eventName: window.event.name,
                     fireDate: window.notificationFireDate
                 )
+            } else {
+                notificationService.cancelNudgeNotification(eventId: eventId)
             }
         }
 
@@ -66,6 +71,11 @@ struct NotificationScheduler {
         for staleId in staleIds {
             notificationService.cancelNotifications(eventId: staleId)
         }
+
+        let stalePendingRequestIds = await notificationService.pendingRequestIdentifiers().filter {
+            AppNotificationIdentifiers.isManagedRequestId($0) && !desiredRequestIds.contains($0)
+        }
+        notificationService.cancelNotificationRequests(stalePendingRequestIds)
 
         NSLog("RedditReminder: refresh complete — \(windows.count) windows, \(staleIds.count) cancelled")
         return staleIds.count

--- a/Sources/Services/NotificationService.swift
+++ b/Sources/Services/NotificationService.swift
@@ -7,6 +7,11 @@ protocol NotificationCenterProtocol: Sendable {
   func removePendingNotificationRequests(withIdentifiers identifiers: [String])
   func removeAllPendingNotificationRequests()
   func getAuthorizationStatus() async -> UNAuthorizationStatus
+  func pendingNotificationRequests() async -> [UNNotificationRequest]
+}
+
+extension NotificationCenterProtocol {
+  func pendingNotificationRequests() async -> [UNNotificationRequest] { [] }
 }
 
 extension UNUserNotificationCenter: @retroactive @unchecked Sendable {}
@@ -30,6 +35,10 @@ enum AppNotificationIdentifiers {
 
   static func nudgeRequestId(eventId: String) -> String {
     "nudge-\(eventId)"
+  }
+
+  static func isManagedRequestId(_ identifier: String) -> Bool {
+    identifier.hasPrefix("window-") || identifier.hasPrefix("nudge-")
   }
 }
 
@@ -165,6 +174,23 @@ final class NotificationService {
         AppNotificationIdentifiers.nudgeRequestId(eventId: eventId)
       ]
     )
+  }
+
+  func cancelNudgeNotification(eventId: String) {
+    center.removePendingNotificationRequests(
+      withIdentifiers: [
+        AppNotificationIdentifiers.nudgeRequestId(eventId: eventId)
+      ]
+    )
+  }
+
+  func cancelNotificationRequests(_ identifiers: [String]) {
+    guard !identifiers.isEmpty else { return }
+    center.removePendingNotificationRequests(withIdentifiers: identifiers)
+  }
+
+  func pendingRequestIdentifiers() async -> [String] {
+    await center.pendingNotificationRequests().map(\.identifier)
   }
 
   func cancelAll() {

--- a/Sources/Utilities/Constants.swift
+++ b/Sources/Utilities/Constants.swift
@@ -28,12 +28,7 @@ enum AppColors {
   static let generatedState = Color(red: 0.42, green: 0.38, blue: 0.92)
   static let link = Color.blue
 
-  // Solid popover background — warm cream (light) / warm charcoal (dark)
-  static let popoverBg = Color(nsColor: NSColor(name: nil) { appearance in
-    appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-      ? NSColor(red: 0.13, green: 0.12, blue: 0.11, alpha: 1.0)
-      : NSColor(red: 0.98, green: 0.97, blue: 0.95, alpha: 1.0)
-  })
+  static let popoverUsesSystemMaterial = true
 }
 
 enum SettingsKey {

--- a/Sources/Utilities/PlannerPresentation.swift
+++ b/Sources/Utilities/PlannerPresentation.swift
@@ -15,6 +15,7 @@ struct PlannerCalendarDay {
 
 enum PlannerPresentation {
   static let createCaptureIdentifierPrefix = "planner.createCapture"
+  static let calendarCreateCaptureIdentifierPrefix = "planner.calendar.createCapture"
 
   static func dayGroups(
     from windows: [TimingEngine.UpcomingWindow],
@@ -71,6 +72,11 @@ enum PlannerPresentation {
   static func createCaptureIdentifier(subredditId: UUID?) -> String {
     guard let subredditId else { return createCaptureIdentifierPrefix }
     return "\(createCaptureIdentifierPrefix).\(subredditId.uuidString)"
+  }
+
+  static func calendarCreateCaptureIdentifier(subredditId: UUID?) -> String {
+    guard let subredditId else { return calendarCreateCaptureIdentifierPrefix }
+    return "\(calendarCreateCaptureIdentifierPrefix).\(subredditId.uuidString)"
   }
 
   static func calendarDays(

--- a/Sources/Utilities/SubredditPeakSelection.swift
+++ b/Sources/Utilities/SubredditPeakSelection.swift
@@ -85,6 +85,12 @@ enum SubredditPeakSelection {
     struct AppliedPreset {
         let days: [String]
         let utcHours: [Int]
+        let isExact: Bool
+    }
+
+    private struct UtcDayHour: Hashable {
+        let day: String
+        let hour: Int
     }
 
     static let presets: [PeakPreset] = [
@@ -95,8 +101,7 @@ enum SubredditPeakSelection {
     ]
 
     static func applyPreset(_ preset: PeakPreset, timeZone: TimeZone = .current, referenceDate: Date = Date()) -> AppliedPreset {
-        let utcHours = preset.localHours.map { localHourToUtc($0, timeZone: timeZone, referenceDate: referenceDate) }.sorted()
-        return AppliedPreset(days: preset.days, utcHours: utcHours)
+        localSelectionToUtc(days: preset.days, localHours: preset.localHours, timeZone: timeZone, referenceDate: referenceDate)
     }
 
     struct SuggestedDefaults {
@@ -113,5 +118,81 @@ enum SubredditPeakSelection {
 
     static func needsSuggestedDefaults(daysOverride: [String]?, hoursOverride: [Int]?, peakInfo: PeakInfo?) -> Bool {
         daysOverride == nil && hoursOverride == nil && peakInfo == nil
+    }
+
+    static func localSelectionToUtc(
+        days: [String],
+        localHours: [Int],
+        timeZone: TimeZone = .current,
+        referenceDate: Date = Date()
+    ) -> AppliedPreset {
+        let pairs = Set(days.flatMap { day in
+            localHours.compactMap { hour in
+                utcDayAndHour(localDay: day, localHour: hour, timeZone: timeZone, referenceDate: referenceDate)
+            }
+        })
+        let utcDays = dayKeys.filter { day in pairs.contains { $0.day == day } }
+        let utcHours = Array(Set(pairs.map(\.hour))).sorted()
+        let isExact = pairs.count == utcDays.count * utcHours.count
+        return AppliedPreset(days: utcDays, utcHours: utcHours, isExact: isExact)
+    }
+
+    private static func utcDayAndHour(
+        localDay: String,
+        localHour: Int,
+        timeZone: TimeZone,
+        referenceDate: Date
+    ) -> UtcDayHour? {
+        guard let weekday = weekdayNumber(for: localDay), (0...23).contains(localHour) else {
+            return nil
+        }
+
+        var localCal = Calendar(identifier: .gregorian)
+        localCal.timeZone = timeZone
+        var localDate = referenceDate
+        while localCal.component(.weekday, from: localDate) != weekday {
+            guard let next = localCal.date(byAdding: .day, value: 1, to: localDate) else {
+                return nil
+            }
+            localDate = next
+        }
+
+        var localComps = localCal.dateComponents([.year, .month, .day], from: localDate)
+        localComps.hour = localHour
+        localComps.minute = 0
+        guard let date = localCal.date(from: localComps) else { return nil }
+
+        var utcCal = Calendar(identifier: .gregorian)
+        utcCal.timeZone = TimeZone(identifier: "UTC")!
+        guard let utcDay = dayKey(forWeekday: utcCal.component(.weekday, from: date)) else {
+            return nil
+        }
+        return UtcDayHour(day: utcDay, hour: utcCal.component(.hour, from: date))
+    }
+
+    private static func weekdayNumber(for day: String) -> Int? {
+        switch String(day.lowercased().prefix(3)) {
+        case "sun": return 1
+        case "mon": return 2
+        case "tue": return 3
+        case "wed": return 4
+        case "thu": return 5
+        case "fri": return 6
+        case "sat": return 7
+        default: return nil
+        }
+    }
+
+    private static func dayKey(forWeekday weekday: Int) -> String? {
+        switch weekday {
+        case 1: return "sun"
+        case 2: return "mon"
+        case 3: return "tue"
+        case 4: return "wed"
+        case 5: return "thu"
+        case 6: return "fri"
+        case 7: return "sat"
+        default: return nil
+        }
     }
 }

--- a/Sources/Views/CaptureSubredditPicker.swift
+++ b/Sources/Views/CaptureSubredditPicker.swift
@@ -9,6 +9,7 @@ struct CaptureSubredditPicker: View {
   static let emptyDescriptionText = "Add a subreddit channel before saving this capture."
   static let addChannelButtonText = "Add channel"
   static let addChannelButtonAccessibilityIdentifier = "captureWindow.addChannel"
+  static let addAnotherChannelButtonText = "Add another channel"
 
   var body: some View {
     if subreddits.isEmpty {
@@ -83,6 +84,15 @@ struct CaptureSubredditPicker: View {
       .menuStyle(.borderlessButton)
       .accessibilityLabel("Capture subreddits")
       .accessibilityIdentifier("captureWindow.subreddits")
+
+      Button(action: onAddSubreddit) {
+        Label(Self.addAnotherChannelButtonText, systemImage: "plus")
+          .font(.system(size: 11, weight: .medium))
+          .foregroundStyle(AppColors.redditOrange)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(Self.addAnotherChannelButtonText)
+      .accessibilityIdentifier(Self.addChannelButtonAccessibilityIdentifier)
     }
   }
 }

--- a/Sources/Views/CaptureWindowView+FormState.swift
+++ b/Sources/Views/CaptureWindowView+FormState.swift
@@ -8,7 +8,7 @@ extension CaptureWindowView {
 
       Spacer()
 
-      Button("Cancel", action: onCancel)
+      Button("Cancel") { onCancel(currentDraft) }
         .font(.system(size: 11))
         .foregroundStyle(.secondary)
         .buttonStyle(.plain)

--- a/Sources/Views/CaptureWindowView.swift
+++ b/Sources/Views/CaptureWindowView.swift
@@ -13,8 +13,9 @@ struct CaptureWindowView: View {
   let mode: Mode
   var initialDraft: CaptureFormDraft?
   let onSave: (CaptureFormResult) -> Bool
-  let onCancel: () -> Void
+  let onCancel: (CaptureFormDraft) -> Void
   var onAddSubreddit: (CaptureFormDraft) -> Void = { _ in }
+  var onDraftChanged: (CaptureFormDraft) -> Void = { _ in }
 
   @Query(sort: \Project.name) var projects: [Project]
   @Query(sort: \Subreddit.sortOrder) var subreddits: [Subreddit]
@@ -53,34 +54,25 @@ struct CaptureWindowView: View {
             VStack(spacing: 6) {
               HStack {
                 Spacer()
-                HStack(spacing: 2) {
-                  Button(action: { showPreview = false }) {
-                    Text("Edit")
-                      .font(.system(size: 9, weight: showPreview ? .medium : .semibold))
-                      .foregroundStyle(showPreview ? .secondary : AppColors.redditOrange)
-                      .padding(.horizontal, 6).padding(.vertical, 2)
-                      .background(showPreview ? Color.clear : AppColors.redditOrange.opacity(0.1))
-                      .clipShape(RoundedRectangle(cornerRadius: 3))
-                  }
-                  .buttonStyle(.plain)
-                  .accessibilityLabel("Edit capture text")
-                  .accessibilityIdentifier("captureWindow.text.edit")
-                  Button(action: { showPreview = true }) {
-                    Text("Preview")
-                      .font(.system(size: 9, weight: showPreview ? .semibold : .medium))
-                      .foregroundStyle(showPreview ? AppColors.redditOrange : .secondary)
-                      .padding(.horizontal, 6).padding(.vertical, 2)
-                      .background(showPreview ? AppColors.redditOrange.opacity(0.1) : Color.clear)
-                      .clipShape(RoundedRectangle(cornerRadius: 3))
-                  }
-                  .buttonStyle(.plain)
-                  .accessibilityLabel("Preview capture text")
-                  .accessibilityIdentifier("captureWindow.text.preview")
+                Picker("Capture text mode", selection: $showPreview) {
+                  Text("Edit")
+                    .tag(false)
+                    .accessibilityLabel("Edit capture text")
+                    .accessibilityIdentifier("captureWindow.text.edit")
+                  Text("Preview")
+                    .tag(true)
+                    .accessibilityLabel("Preview capture text")
+                    .accessibilityIdentifier("captureWindow.text.preview")
                 }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 128)
+                .accessibilityIdentifier("captureWindow.text.mode")
               }
               if showPreview {
                 MarkdownPreviewView(text: text)
                   .frame(minHeight: 72)
+                  .accessibilityIdentifier("captureWindow.text.previewContent")
               } else {
                 TextEditor(text: $text)
                   .font(.system(size: 12))
@@ -170,7 +162,13 @@ struct CaptureWindowView: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .onAppear { populateFromMode() }
+    .onAppear {
+      populateFromMode()
+      onDraftChanged(currentDraft)
+    }
+    .onChange(of: currentDraft) {
+      onDraftChanged(currentDraft)
+    }
   }
 
 }

--- a/Sources/Views/PlannerTabCalendarViews.swift
+++ b/Sources/Views/PlannerTabCalendarViews.swift
@@ -132,6 +132,8 @@ extension PlannerTabView {
           Text("·")
           Text(PlannerPresentation.readinessText(for: window.matchingCaptureCount))
             .foregroundStyle(window.matchingCaptureCount == 0 ? AppColors.redditOrange : .secondary)
+          Text("·")
+          sourceBadge(for: window)
         }
         .font(.system(size: 10))
         .foregroundStyle(.secondary)
@@ -139,38 +141,69 @@ extension PlannerTabView {
 
       Spacer(minLength: 0)
 
-      VStack(alignment: .trailing, spacing: 5) {
-        Text(window.event.isGeneratedFromHeuristics ? "Auto" : "Manual")
-          .font(.system(size: 9, weight: .semibold))
-          .foregroundStyle(window.event.isGeneratedFromHeuristics ? AppColors.redditOrange : .secondary)
-          .padding(.horizontal, 6)
-          .padding(.vertical, 3)
-          .background(
-            window.event.isGeneratedFromHeuristics ? AppColors.redditOrange.opacity(0.10) : Color.clear
-          )
-          .clipShape(RoundedRectangle(cornerRadius: 5))
-
-        HStack(spacing: 8) {
-          if window.matchingCaptureCount == 0 {
-            Button(Self.createCaptureActionText) {
-              onCreateCaptureForSubreddit(window.event.subreddit)
-            }
-            .accessibilityIdentifier(
-              PlannerPresentation.createCaptureIdentifier(subredditId: window.event.subreddit?.id)
-            )
-          } else {
-            Button(Self.viewQueueActionText, action: onViewQueue)
-              .accessibilityIdentifier("planner.viewQueue")
-          }
-          Button(Self.editChannelsActionText, action: onEditChannels)
-            .accessibilityIdentifier("planner.editChannels")
-        }
-        .font(.system(size: 10, weight: .medium))
-        .foregroundStyle(AppColors.redditOrange)
-        .buttonStyle(.plain)
+      HStack(spacing: 6) {
+        primaryPlannerAction(for: window)
+        plannerIconButton(
+          systemName: "slider.horizontal.3",
+          label: Self.editChannelsActionText,
+          action: onEditChannels
+        )
+        .accessibilityIdentifier("planner.editChannels")
       }
     }
     .padding(10)
+  }
+
+  func sourceBadge(for window: TimingEngine.UpcomingWindow) -> some View {
+    Text(window.event.isGeneratedFromHeuristics ? "Auto" : "Manual")
+      .font(.system(size: 9, weight: .semibold))
+      .foregroundStyle(window.event.isGeneratedFromHeuristics ? AppColors.redditOrange : .secondary)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 2)
+      .background(
+        window.event.isGeneratedFromHeuristics ? AppColors.redditOrange.opacity(0.10) : Color.clear
+      )
+      .clipShape(RoundedRectangle(cornerRadius: 4))
+  }
+
+  @ViewBuilder
+  func primaryPlannerAction(for window: TimingEngine.UpcomingWindow) -> some View {
+    if window.matchingCaptureCount == 0 {
+      plannerIconButton(
+        systemName: "text.badge.plus",
+        label: Self.createCaptureActionText,
+        action: { onCreateCaptureForSubreddit(window.event.subreddit) }
+      )
+      .accessibilityIdentifier(
+        PlannerPresentation.createCaptureIdentifier(subredditId: window.event.subreddit?.id)
+      )
+    } else {
+      plannerIconButton(
+        systemName: "tray",
+        label: Self.viewQueueActionText,
+        action: onViewQueue
+      )
+      .accessibilityIdentifier("planner.viewQueue")
+    }
+  }
+
+  func plannerIconButton(
+    systemName: String,
+    label: String,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      Image(systemName: systemName)
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(AppColors.redditOrange)
+        .frame(width: Self.rowActionHitSize, height: Self.rowActionHitSize)
+        .background(.quaternary.opacity(0.25))
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .contentShape(RoundedRectangle(cornerRadius: 5))
+    }
+    .buttonStyle(.plain)
+    .help(label)
+    .accessibilityLabel(label)
   }
 
   func calendarDayCell(_ day: PlannerCalendarDay) -> some View {
@@ -222,6 +255,28 @@ extension PlannerTabView {
         )
       )
       .lineLimit(1)
+      Spacer(minLength: 0)
+      if window.matchingCaptureCount == 0 {
+        Button(action: { onCreateCaptureForSubreddit(window.event.subreddit) }) {
+          Image(systemName: "plus.circle")
+            .font(.system(size: 10, weight: .medium))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Self.createCaptureActionText)
+        .accessibilityIdentifier(
+          PlannerPresentation.calendarCreateCaptureIdentifier(
+            subredditId: window.event.subreddit?.id
+          )
+        )
+      } else {
+        Button(action: onViewQueue) {
+          Image(systemName: "list.bullet")
+            .font(.system(size: 10, weight: .medium))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Self.viewQueueActionText)
+        .accessibilityIdentifier("planner.calendar.viewQueue")
+      }
     }
     .font(.system(size: 9, weight: .medium))
     .foregroundStyle(.secondary)

--- a/Sources/Views/PlannerTabView.swift
+++ b/Sources/Views/PlannerTabView.swift
@@ -17,6 +17,8 @@ struct PlannerTabView: View {
   static let createCaptureActionText = "Create capture"
   static let viewQueueActionText = "View queue"
   static let editChannelsActionText = "Edit windows"
+  static let viewModeAccessibilityIdentifier = "planner.viewMode"
+  static let rowActionHitSize: CGFloat = 28
 
   @Environment(\.modelContext) private var modelContext
   @Query(sort: \Capture.createdAt, order: .reverse) private var captures: [Capture]
@@ -94,6 +96,7 @@ struct PlannerTabView: View {
       .labelsHidden()
       .pickerStyle(.segmented)
       .frame(width: 150)
+      .accessibilityIdentifier(Self.viewModeAccessibilityIdentifier)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 12)

--- a/Sources/Views/PopoverContentActions.swift
+++ b/Sources/Views/PopoverContentActions.swift
@@ -23,7 +23,8 @@ extension PopoverContentView {
   }
 
   func openPreferences(tab: PreferencesView.Tab = PreferencesView.defaultTab) {
-    route = .preferences(tab)
+    route = .root
+    menuBarController.openSettingsWindow(tab: tab)
   }
 
   func openWorkspace(_ workspace: PopoverWorkspace) {

--- a/Sources/Views/PopoverContentEmptyStates.swift
+++ b/Sources/Views/PopoverContentEmptyStates.swift
@@ -13,6 +13,8 @@ extension PopoverContentView {
     "Create a capture so your next posting windows have a draft ready."
   nonisolated static let emptyQueueWithWindowsButtonText = "Create capture"
   nonisolated static let emptyQueueWithWindowsButtonIdentifier = "queue.emptyWithWindows.createCapture"
+  nonisolated static let filteredEmptyButtonText = "New capture for this subreddit"
+  nonisolated static let filteredEmptyButtonIdentifier = "queue.filteredEmpty.createCapture"
 
   nonisolated static func queueContentPresentation(
     displayedCaptureCount: Int,
@@ -62,7 +64,9 @@ extension PopoverContentView {
     .padding(.vertical, 28)
   }
 
+  @ViewBuilder
   var filteredEmptyState: some View {
+    let filteredSubreddit = subreddits.first { $0.id == filterSubredditId }
     VStack(spacing: 10) {
       Spacer()
       Image(systemName: "tray")
@@ -71,10 +75,13 @@ extension PopoverContentView {
       Text("No captures for this subreddit")
         .font(.system(size: 12))
         .foregroundStyle(.secondary)
-      Button("+ New Capture", action: openNewCapture)
+      Button(Self.filteredEmptyButtonText) {
+        openNewCapture(for: filteredSubreddit)
+      }
         .font(.system(size: 11, weight: .medium))
         .foregroundStyle(AppColors.redditOrange)
         .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.filteredEmptyButtonIdentifier)
       Spacer()
     }.frame(maxWidth: .infinity)
   }

--- a/Sources/Views/PopoverContentRoutes.swift
+++ b/Sources/Views/PopoverContentRoutes.swift
@@ -23,9 +23,9 @@ extension PopoverContentView {
         showToast(mode.isCreate ? "Draft saved" : "Draft updated")
         return true
       },
-      onCancel: {
+      onCancel: { draft in
         if mode.isCreate {
-          pendingCreateDraft = nil
+          pendingCreateDraft = draft.hasRecoverableContent ? draft : nil
         }
         route = .root
       },
@@ -34,6 +34,11 @@ extension PopoverContentView {
           pendingCreateDraft = draft
         }
         openWorkspace(.channels)
+      },
+      onDraftChanged: { draft in
+        if mode.isCreate {
+          pendingCreateDraft = draft.hasRecoverableContent ? draft : nil
+        }
       }
     )
     .modelContainer(modelContext.container)
@@ -121,7 +126,8 @@ extension PopoverContentView {
   func handlePreferencesRequest() {
     guard menuBarController.preferencesRequestCount > handledPreferencesRequestCount else { return }
     handledPreferencesRequestCount = menuBarController.preferencesRequestCount
-    route = .preferences(PreferencesView.defaultTab)
+    route = .root
+    menuBarController.openSettingsWindow()
   }
 }
 

--- a/Sources/Views/PopoverContentView.swift
+++ b/Sources/Views/PopoverContentView.swift
@@ -5,7 +5,6 @@ enum PopoverRoute {
   case root
   case captureCreate
   case captureEdit(Capture)
-  case preferences(PreferencesView.Tab)
   case postHandoff(Capture)
 }
 
@@ -17,11 +16,11 @@ struct PopoverContentView: View {
   let mediaStore = MediaStore()
 
   @Query(sort: \Capture.createdAt, order: .reverse) private var captures: [Capture]
-  @Query(sort: \Subreddit.sortOrder) private var subreddits: [Subreddit]
+  @Query(sort: \Subreddit.sortOrder) var subreddits: [Subreddit]
   @Environment(\.modelContext) var modelContext
 
   @State private var timingEngine = TimingEngine()
-  @State private var filterSubredditId: UUID?
+  @State var filterSubredditId: UUID?
   @State private var searchText: String = ""
   @State var toast: Toast?
   @State var toastTask: Task<Void, Never>?
@@ -56,16 +55,6 @@ struct PopoverContentView: View {
         captureForm(mode: .create)
       case .captureEdit(let capture):
         captureForm(mode: .edit(capture))
-      case .preferences(let tab):
-        detailScreen(title: "Settings", systemName: "gearshape") {
-          PreferencesView(
-            notificationService: notificationService,
-            heuristicsStore: heuristicsStore,
-            initialTab: tab,
-            onAppStateChanged: onAppStateChanged
-          )
-          .modelContainer(modelContext.container)
-        }
       case .postHandoff(let capture):
         postHandoff(capture)
       }
@@ -75,7 +64,7 @@ struct PopoverContentView: View {
         PopoverToastView(toast: toast)
       }
     }
-    .background(AppColors.popoverBg)
+    .background(.regularMaterial)
     .frame(width: 460).frame(maxHeight: (NSScreen.main?.visibleFrame.height ?? 800) * 0.85)
     .onAppear {
       handlePendingMenuRequests()

--- a/Sources/Views/PostHandoffView.swift
+++ b/Sources/Views/PostHandoffView.swift
@@ -45,7 +45,7 @@ struct PostHandoffView: View {
       footer
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(AppColors.popoverBg)
+    .background(.regularMaterial)
   }
 
   private var header: some View {
@@ -170,9 +170,13 @@ struct PostHandoffView: View {
       Spacer()
 
       Button(action: onMarkPosted) {
-        Label("Mark Posted", systemImage: "checkmark.circle")
+        Label(
+          Self.markPostedButtonText(destinationCount: sortedSubreddits.count),
+          systemImage: "checkmark.circle"
+        )
       }
-      .accessibilityLabel("Mark posted")
+      .help(Self.markPostedAccessibilityLabel(destinationCount: sortedSubreddits.count))
+      .accessibilityLabel(Self.markPostedAccessibilityLabel(destinationCount: sortedSubreddits.count))
       .accessibilityIdentifier("postHandoff.markPosted")
 
       openSubmitControl
@@ -198,6 +202,14 @@ struct PostHandoffView: View {
 
   private func runCopy(_ action: () -> Bool, successMessage: String) {
     statusMessage = action() ? successMessage : "Copy failed"
+  }
+
+  nonisolated static func markPostedButtonText(destinationCount: Int) -> String {
+    destinationCount > 1 ? "Mark All Posted" : "Mark Posted"
+  }
+
+  nonisolated static func markPostedAccessibilityLabel(destinationCount: Int) -> String {
+    destinationCount > 1 ? "Mark all destinations posted" : "Mark posted"
   }
 
 }

--- a/Sources/Views/PreferencesView.swift
+++ b/Sources/Views/PreferencesView.swift
@@ -31,25 +31,20 @@ struct PreferencesView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      HStack(spacing: 0) {
-        ForEach(Tab.allCases, id: \.self) { tab in
-          Button(action: { selectedTab = tab }) {
+      HStack {
+        Picker("Settings section", selection: $selectedTab) {
+          ForEach(Tab.allCases, id: \.self) { tab in
             Text(tab.rawValue)
-              .font(.system(size: 11, weight: selectedTab == tab ? .semibold : .medium))
-              .foregroundStyle(selectedTab == tab ? AppColors.redditOrange : .secondary)
-              .padding(.horizontal, 12)
-              .padding(.vertical, 6)
-              .background(
-                selectedTab == tab
-                  ? AppColors.redditOrange.opacity(0.1)
-                  : Color.clear
-              )
-              .clipShape(RoundedRectangle(cornerRadius: 6))
+              .tag(tab)
+              .accessibilityLabel("\(tab.rawValue) tab")
+              .accessibilityIdentifier("preferences.tab.\(tab.rawValue)")
           }
-          .buttonStyle(.plain)
-          .accessibilityLabel("\(tab.rawValue) tab")
-          .accessibilityIdentifier("preferences.tab.\(tab.rawValue)")
         }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: 320)
+        .accessibilityIdentifier("preferences.tabs")
+        Spacer()
       }
       .padding(.vertical, 10)
       .padding(.horizontal, 16)

--- a/Sources/Views/SubredditRow.swift
+++ b/Sources/Views/SubredditRow.swift
@@ -7,6 +7,9 @@ struct SubredditRow: View {
   nonisolated static let moveUpAccessibilityLabel = "Move channel up"
   nonisolated static let moveDownAccessibilityLabel = "Move channel down"
   nonisolated static let removeAccessibilityLabel = "Remove channel"
+  nonisolated static let collapsedRowsUseCardChrome = false
+  nonisolated static let expandedRowsUseCardChrome = true
+  private static let expandedRowCornerRadius: CGFloat = 8
 
   @Bindable var sub: Subreddit
   let peakInfo: PeakInfo?
@@ -58,7 +61,8 @@ struct SubredditRow: View {
       .buttonStyle(.plain)
       .accessibilityLabel(isExpanded ? "Collapse \(sub.name)" : "Expand \(sub.name)")
       .accessibilityIdentifier("channels.subredditRow.\(sub.id.uuidString).toggle")
-      .padding(10)
+      .padding(.horizontal, isExpanded ? 10 : 8)
+      .padding(.vertical, isExpanded ? 10 : 8)
 
       if isExpanded {
         VStack(alignment: .leading, spacing: 10) {
@@ -134,12 +138,24 @@ struct SubredditRow: View {
         .padding(.bottom, 10)
       }
     }
-    .background(.quaternary.opacity(0.3))
-    .clipShape(RoundedRectangle(cornerRadius: 8))
-    .overlay(
-      RoundedRectangle(cornerRadius: 8)
-        .stroke(.separator, lineWidth: 0.5)
-    )
+    .background {
+      if isExpanded {
+        RoundedRectangle(cornerRadius: Self.expandedRowCornerRadius)
+          .fill(.quaternary.opacity(0.3))
+      }
+    }
+    .overlay {
+      if isExpanded {
+        RoundedRectangle(cornerRadius: Self.expandedRowCornerRadius)
+          .stroke(.separator, lineWidth: 0.5)
+      }
+    }
+    .overlay(alignment: .bottom) {
+      if !isExpanded {
+        Divider()
+          .padding(.leading, 24)
+      }
+    }
     .accessibilityElement(children: .contain)
     .accessibilityLabel(sub.name)
     .accessibilityIdentifier("channels.subredditRow.\(sub.id.uuidString)")
@@ -161,8 +177,13 @@ struct SubredditRow: View {
         .font(.system(size: 12, weight: .medium))
         .foregroundStyle(.secondary)
         .frame(width: 32, height: 32)
-        .background(.quaternary.opacity(0.3))
-        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .background {
+          if isExpanded {
+            RoundedRectangle(cornerRadius: 4)
+              .fill(.quaternary.opacity(0.3))
+          }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 4))
     }
     .menuStyle(.borderlessButton)
     .menuIndicator(.hidden)

--- a/Tests/RedditReminderTests/AppDelegateShortcutRegistrationTests.swift
+++ b/Tests/RedditReminderTests/AppDelegateShortcutRegistrationTests.swift
@@ -116,6 +116,23 @@ private final class RecordingGlobalShortcut: GlobalShortcutRegistering {
     #expect(globalShortcut.unregisterCount == 1)
 }
 
+@Test @MainActor func appDelegateKeepsMenuBarAppRunningAfterLastWindowCloses() {
+    let temporaryDefaults = makeShortcutDefaults()
+    defer { temporaryDefaults.cleanup() }
+    let delegate = makeShortcutDelegate(
+        defaults: temporaryDefaults.defaults,
+        globalShortcut: RecordingGlobalShortcut()
+    )
+
+    #expect(delegate.applicationShouldTerminateAfterLastWindowClosed(NSApp) == false)
+}
+
+@Test @MainActor func appDelegateOwnsLifecycleAnchorForMenuBarLaunches() {
+    let mirror = Mirror(reflecting: AppDelegate())
+
+    #expect(mirror.children.contains { $0.label == "lifecycleAnchorWindow" })
+}
+
 private func makeShortcutDefaults() -> ShortcutTemporaryDefaults {
     let suiteName = "AppDelegateShortcutTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/RedditReminderTests/CaptureCardViewTests.swift
+++ b/Tests/RedditReminderTests/CaptureCardViewTests.swift
@@ -33,4 +33,6 @@ import Testing
   #expect(SubredditRow.moveUpAccessibilityLabel == "Move channel up")
   #expect(SubredditRow.moveDownAccessibilityLabel == "Move channel down")
   #expect(SubredditRow.removeAccessibilityLabel == "Remove channel")
+  #expect(SubredditRow.collapsedRowsUseCardChrome == false)
+  #expect(SubredditRow.expandedRowsUseCardChrome == true)
 }

--- a/Tests/RedditReminderTests/HeuristicsStoreTests.swift
+++ b/Tests/RedditReminderTests/HeuristicsStoreTests.swift
@@ -1,7 +1,20 @@
 import Testing
 import Foundation
 import SwiftData
+import UserNotifications
 @testable import RedditReminder
+
+private final class HeuristicsRecordingNotificationCenter: NotificationCenterProtocol, @unchecked Sendable {
+  private(set) var removedIdentifiers: [[String]] = []
+
+  func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { true }
+  func add(_ request: UNNotificationRequest, withCompletionHandler handler: (@Sendable (Error?) -> Void)?) {}
+  func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+    removedIdentifiers.append(identifiers)
+  }
+  func removeAllPendingNotificationRequests() {}
+  func getAuthorizationStatus() async -> UNAuthorizationStatus { .authorized }
+}
 
 private func makeTestBundle() -> Bundle {
   makePeakTimesTestBundle()
@@ -91,6 +104,38 @@ private func makeTestBundle() -> Bundle {
   #expect(events[0].rrule == "FREQ=WEEKLY;BYDAY=MO")
   #expect(events[0].recurrenceHour == 9)
   #expect(events[0].reminderLeadMinutes == 120)
+}
+
+@Test @MainActor func syncGeneratedEventsCancelsNotificationsForRemovedGeneratedEvents() throws {
+  let container = try makeContainer()
+  let context = ModelContext(container)
+  let sub = Subreddit(name: "r/SideProject")
+  context.insert(sub)
+  try context.save()
+
+  let store = HeuristicsStore(bundle: makeTestBundle())
+  try store.syncGeneratedEvents(for: sub, context: context, defaultLeadTimeMinutes: 60)
+  let originalEvents = try context.fetch(FetchDescriptor<SubredditEvent>())
+  #expect(originalEvents.count == 6)
+
+  let center = HeuristicsRecordingNotificationCenter()
+  let service = NotificationService(center: center)
+  sub.peakDaysOverride = ["mon"]
+  sub.peakHoursUtcOverride = [9]
+  try context.save()
+
+  try store.syncGeneratedEvents(
+    for: sub,
+    context: context,
+    defaultLeadTimeMinutes: 60,
+    notificationService: service
+  )
+
+  let removedIds = Set(center.removedIdentifiers.flatMap { $0 })
+  for event in originalEvents {
+    #expect(removedIds.contains(AppNotificationIdentifiers.windowRequestId(eventId: event.id.uuidString)))
+    #expect(removedIds.contains(AppNotificationIdentifiers.nudgeRequestId(eventId: event.id.uuidString)))
+  }
 }
 
 private func makeContainer() throws -> ModelContainer {

--- a/Tests/RedditReminderTests/MenuBarControllerTests.swift
+++ b/Tests/RedditReminderTests/MenuBarControllerTests.swift
@@ -169,10 +169,10 @@ struct MenuBarControllerTests {
 
   @Test func handleOpenPreferencesInvokesCallback() {
     let controller = MenuBarController()
-    var called = false
-    controller.onOpenPreferences = { called = true }
+    var openedTab: PreferencesView.Tab?
+    controller.onOpenPreferences = { openedTab = $0 }
     controller.perform(NSSelectorFromString("handleOpenPreferences"))
-    #expect(called == true)
+    #expect(openedTab == PreferencesView.defaultTab)
   }
 
   @Test func settingsMenuItemUsesVisibleSettingsLabel() {

--- a/Tests/RedditReminderTests/NotificationSchedulerPermissionTests.swift
+++ b/Tests/RedditReminderTests/NotificationSchedulerPermissionTests.swift
@@ -6,7 +6,9 @@ import UserNotifications
 private final class RecordingNotificationCenter: NotificationCenterProtocol, @unchecked Sendable {
     var authorizationStatus: UNAuthorizationStatus = .authorized
     private(set) var addedRequests: [UNNotificationRequest] = []
+    private(set) var removedIdentifiers: [[String]] = []
     private(set) var removedAll = false
+    var pendingRequests: [UNNotificationRequest] = []
 
     func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
         authorizationStatus == .authorized
@@ -17,7 +19,9 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
         handler?(nil)
     }
 
-    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        removedIdentifiers.append(identifiers)
+    }
 
     func removeAllPendingNotificationRequests() {
         removedAll = true
@@ -25,6 +29,10 @@ private final class RecordingNotificationCenter: NotificationCenterProtocol, @un
 
     func getAuthorizationStatus() async -> UNAuthorizationStatus {
         authorizationStatus
+    }
+
+    func pendingNotificationRequests() async -> [UNNotificationRequest] {
+        pendingRequests
     }
 }
 
@@ -132,4 +140,87 @@ private func makeTestWindow() -> TimingEngine.UpcomingWindow {
     #expect(result == 0)
     #expect(!center.removedAll)
     #expect(center.addedRequests.count == 1)
+}
+
+@Test @MainActor func schedulerCancelsEmptyQueueNudgeWhenQueueHasCaptures() async {
+    let center = RecordingNotificationCenter()
+    center.authorizationStatus = .authorized
+    let (defaults, suiteName) = makeTestDefaults(notificationsEnabled: true)
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(true, forKey: SettingsKey.nudgeWhenEmpty)
+
+    let service = NotificationService(center: center)
+    let scheduler = NotificationScheduler(notificationService: service, defaults: defaults)
+    let window = makeTestWindow()
+
+    let result = await scheduler.schedule(activeEvents: [window.event], windows: [window])
+
+    #expect(result == 0)
+    #expect(center.addedRequests.count == 1)
+    #expect(center.removedIdentifiers.count == 1)
+    #expect(center.removedIdentifiers[0] == [
+        AppNotificationIdentifiers.nudgeRequestId(eventId: window.event.id.uuidString)
+    ])
+}
+
+@Test @MainActor func schedulerCancelsEmptyQueueNudgeWhenNudgesDisabled() async {
+    let center = RecordingNotificationCenter()
+    center.authorizationStatus = .authorized
+    let (defaults, suiteName) = makeTestDefaults(notificationsEnabled: true)
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(false, forKey: SettingsKey.nudgeWhenEmpty)
+
+    let service = NotificationService(center: center)
+    let scheduler = NotificationScheduler(notificationService: service, defaults: defaults)
+    var window = makeTestWindow()
+    window = TimingEngine.UpcomingWindow(
+        event: window.event,
+        eventDate: window.eventDate,
+        notificationFireDate: window.notificationFireDate,
+        urgency: window.urgency,
+        matchingCaptureCount: 0
+    )
+
+    let result = await scheduler.schedule(activeEvents: [window.event], windows: [window])
+
+    #expect(result == 0)
+    #expect(center.addedRequests.count == 1)
+    #expect(center.removedIdentifiers.count == 1)
+    #expect(center.removedIdentifiers[0] == [
+        AppNotificationIdentifiers.nudgeRequestId(eventId: window.event.id.uuidString)
+    ])
+}
+
+@Test @MainActor func schedulerCancelsManagedPendingRequestsForDeletedEvents() async {
+    let center = RecordingNotificationCenter()
+    center.authorizationStatus = .authorized
+    let (defaults, suiteName) = makeTestDefaults(notificationsEnabled: true)
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let deletedEventId = UUID().uuidString
+    center.pendingRequests = [
+        pendingRequest(id: AppNotificationIdentifiers.windowRequestId(eventId: deletedEventId)),
+        pendingRequest(id: AppNotificationIdentifiers.nudgeRequestId(eventId: deletedEventId)),
+        pendingRequest(id: "unrelated-system-request"),
+    ]
+
+    let service = NotificationService(center: center)
+    let scheduler = NotificationScheduler(notificationService: service, defaults: defaults)
+    let window = makeTestWindow()
+
+    let result = await scheduler.schedule(activeEvents: [window.event], windows: [window])
+
+    #expect(result == 0)
+    let removedIds = Set(center.removedIdentifiers.flatMap { $0 })
+    #expect(removedIds.contains(AppNotificationIdentifiers.windowRequestId(eventId: deletedEventId)))
+    #expect(removedIds.contains(AppNotificationIdentifiers.nudgeRequestId(eventId: deletedEventId)))
+    #expect(!removedIds.contains("unrelated-system-request"))
+}
+
+private func pendingRequest(id: String) -> UNNotificationRequest {
+    UNNotificationRequest(
+        identifier: id,
+        content: UNMutableNotificationContent(),
+        trigger: nil
+    )
 }

--- a/Tests/RedditReminderTests/PlannerPresentationTests.swift
+++ b/Tests/RedditReminderTests/PlannerPresentationTests.swift
@@ -53,6 +53,12 @@ import Testing
     PlannerPresentation.createCaptureIdentifier(subredditId: subredditId)
       == "planner.createCapture.00000000-0000-0000-0000-000000000123")
   #expect(PlannerPresentation.createCaptureIdentifier(subredditId: nil) == "planner.createCapture")
+  #expect(
+    PlannerPresentation.calendarCreateCaptureIdentifier(subredditId: subredditId)
+      == "planner.calendar.createCapture.00000000-0000-0000-0000-000000000123")
+  #expect(
+    PlannerPresentation.calendarCreateCaptureIdentifier(subredditId: nil)
+      == "planner.calendar.createCapture")
 }
 
 @Test @MainActor func plannerPresentationCalendarDaysAlwaysReturnsSevenDays() {

--- a/Tests/RedditReminderTests/PopoverChromeViewTests.swift
+++ b/Tests/RedditReminderTests/PopoverChromeViewTests.swift
@@ -22,10 +22,16 @@ import Testing
   #expect(PopoverSearchBarView.clearSearchHitSize == 28)
 }
 
+@Test func popoverChromeUsesSystemMaterial() {
+  #expect(AppColors.popoverUsesSystemMaterial)
+}
+
 @Test @MainActor func plannerExposesActionLabels() {
   #expect(PlannerTabView.createCaptureActionText == "Create capture")
   #expect(PlannerTabView.viewQueueActionText == "View queue")
   #expect(PlannerTabView.editChannelsActionText == "Edit windows")
+  #expect(PlannerTabView.viewModeAccessibilityIdentifier == "planner.viewMode")
+  #expect(PlannerTabView.rowActionHitSize == 28)
 }
 
 @Test @MainActor func queueEmptyWithWindowsExposesCreateCaptureCTA() {
@@ -37,6 +43,9 @@ import Testing
   #expect(
     PopoverContentView.emptyQueueWithWindowsButtonIdentifier
       == "queue.emptyWithWindows.createCapture")
+  #expect(PopoverContentView.filteredEmptyButtonText == "New capture for this subreddit")
+  #expect(
+    PopoverContentView.filteredEmptyButtonIdentifier == "queue.filteredEmpty.createCapture")
 }
 
 @Test @MainActor func queuePresentationShowsOnboardingOnlyWhenNoCapturesNoWindowsAndUnfiltered() {

--- a/Tests/RedditReminderTests/PostHandoffViewTests.swift
+++ b/Tests/RedditReminderTests/PostHandoffViewTests.swift
@@ -9,6 +9,12 @@ import Testing
   #expect(PostHandoffView.copyLinksAccessibilityLabel == "Copy post links")
   #expect(PostHandoffView.copyAllAccessibilityLabel == "Copy full post text")
   #expect(PostHandoffView.openSubmitAccessibilityLabel == "Open Reddit submit page")
+  #expect(PostHandoffView.markPostedButtonText(destinationCount: 1) == "Mark Posted")
+  #expect(PostHandoffView.markPostedButtonText(destinationCount: 2) == "Mark All Posted")
+  #expect(PostHandoffView.markPostedAccessibilityLabel(destinationCount: 1) == "Mark posted")
+  #expect(
+    PostHandoffView.markPostedAccessibilityLabel(destinationCount: 2)
+      == "Mark all destinations posted")
   #expect(
     PostHandoffView.chooseSubmitDestinationAccessibilityLabel == "Choose Reddit submit destination"
   )

--- a/Tests/RedditReminderTests/PreferencesViewTests.swift
+++ b/Tests/RedditReminderTests/PreferencesViewTests.swift
@@ -58,6 +58,7 @@ import Testing
     CaptureSubredditPicker.emptyDescriptionText
       == "Add a subreddit channel before saving this capture.")
   #expect(CaptureSubredditPicker.addChannelButtonText == "Add channel")
+  #expect(CaptureSubredditPicker.addAnotherChannelButtonText == "Add another channel")
   #expect(
     CaptureSubredditPicker.addChannelButtonAccessibilityIdentifier == "captureWindow.addChannel")
 }

--- a/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
+++ b/Tests/RedditReminderTests/SubredditPeakSelectionTests.swift
@@ -114,6 +114,51 @@ import Foundation
     #expect(result.days == ["mon", "tue", "wed", "thu", "fri"])
     // PDT is UTC-7: local 8=UTC15, 9=UTC16, 10=UTC17, 11=UTC18
     #expect(result.utcHours == [15, 16, 17, 18])
+    #expect(result.isExact)
+}
+
+@Test func localSelectionToUtcShiftsDayWhenLocalHourCrossesUtcMidnight() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+
+    let result = SubredditPeakSelection.localSelectionToUtc(
+        days: ["mon"],
+        localHours: [20],
+        timeZone: pdt,
+        referenceDate: summer
+    )
+
+    #expect(result.days == ["tue"])
+    #expect(result.utcHours == [3])
+    #expect(result.isExact)
+}
+
+@Test func localSelectionToUtcFlagsMixedUtcDayShiftsAsInexact() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+
+    let result = SubredditPeakSelection.localSelectionToUtc(
+        days: ["mon"],
+        localHours: [8, 20],
+        timeZone: pdt,
+        referenceDate: summer
+    )
+
+    #expect(result.days == ["mon", "tue"])
+    #expect(result.utcHours == [3, 15])
+    #expect(!result.isExact)
+}
+
+@Test func weekdayPMPresetShiftsToFollowingUtcDaysWhenNeeded() {
+    let pdt = TimeZone(identifier: "America/Los_Angeles")!
+    let summer = DateComponents(calendar: .current, year: 2024, month: 7, day: 1).date!
+    let preset = SubredditPeakSelection.presets[1]
+
+    let result = SubredditPeakSelection.applyPreset(preset, timeZone: pdt, referenceDate: summer)
+
+    #expect(result.days == ["tue", "wed", "thu", "fri", "sat"])
+    #expect(result.utcHours == [0, 1, 2, 3])
+    #expect(result.isExact)
 }
 
 @Test func suggestedDefaultsReturnsWeekdayAMPreset() {

--- a/Tests/RedditReminderUITests/RedditReminderSmokeUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderSmokeUITests.swift
@@ -2,6 +2,32 @@ import XCTest
 
 @MainActor
 final class RedditReminderSmokeUITests: XCTestCase {
+    func testPopoverChromePrimaryControlsRemainVisible() throws {
+        continueAfterFailure = false
+        let app = makeSeededRedditReminderApp()
+        defer { app.terminate() }
+
+        launchAndWaitForRedditReminder(app)
+        openHomePopover(in: app)
+
+        let controlIdentifiers = [
+            "popover.header.queue",
+            "popover.header.posted",
+            "popover.header.planner",
+            "popover.header.channels",
+            "popover.header.projects",
+            "popover.header.settings",
+            "popover.header.newCapture",
+        ]
+
+        for identifier in controlIdentifiers {
+            let control = app.buttons[identifier]
+            XCTAssertTrue(control.waitForExistence(timeout: 3), "\(identifier) should exist")
+            XCTAssertGreaterThan(control.frame.width, 10, "\(identifier) should have visible width")
+            XCTAssertGreaterThan(control.frame.height, 10, "\(identifier) should have visible height")
+        }
+    }
+
     func testKeyboardCommandsOpenPopoverScreens() throws {
         continueAfterFailure = false
         let app = makeSeededRedditReminderApp()
@@ -11,9 +37,9 @@ final class RedditReminderSmokeUITests: XCTestCase {
         openNewCaptureRoute(in: app)
         cancelCaptureRoute(in: app)
 
-        let settingsButton = app.buttons["popover.header.settings"]
-        XCTAssertTrue(settingsButton.waitForExistence(timeout: 3))
-        settingsButton.click()
-        XCTAssertTrue(app.buttons["preferences.tab.General"].waitForExistence(timeout: 3))
-    }
+    let settingsButton = app.buttons["popover.header.settings"]
+    XCTAssertTrue(settingsButton.waitForExistence(timeout: 3))
+    settingsButton.click()
+    XCTAssertTrue(app.descendants(matching: .any)["preferences.content.General"].waitForExistence(timeout: 3))
+  }
 }

--- a/Tests/RedditReminderUITests/RedditReminderUITestSupport.swift
+++ b/Tests/RedditReminderUITests/RedditReminderUITestSupport.swift
@@ -61,8 +61,8 @@ extension XCTestCase {
     XCTAssertTrue(settingsButton.waitForExistence(timeout: 3), "Settings button should exist")
     settingsButton.click()
     XCTAssertTrue(
-      app.buttons["preferences.tab.General"].waitForExistence(timeout: 3),
-      "Preferences route should expose the General tab"
+      app.descendants(matching: .any)["preferences.content.General"].waitForExistence(timeout: 3),
+      "Settings window should expose the General content"
     )
   }
 

--- a/Tests/RedditReminderUITests/RedditReminderUXFlowUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderUXFlowUITests.swift
@@ -63,6 +63,120 @@ final class RedditReminderUXFlowUITests: XCTestCase {
         XCTAssertTrue(app.buttons["captureWindow.save"].isEnabled)
     }
 
+    func testCancelPreservesRecoverableCreateDraft() throws {
+        continueAfterFailure = false
+        let app = makeSeededRedditReminderApp()
+        defer { app.terminate() }
+
+        launchAndWaitForRedditReminder(app)
+        openNewCaptureRoute(in: app)
+
+        let titleField = app.textFields["captureWindow.title"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+        titleField.click()
+        titleField.typeText("Protected draft title")
+
+        XCTAssertTrue(app.buttons["captureWindow.addChannel"].waitForExistence(timeout: 3))
+        cancelCaptureRoute(in: app)
+
+        let newCaptureButton = app.buttons["popover.header.newCapture"]
+        XCTAssertTrue(newCaptureButton.waitForExistence(timeout: 3))
+        newCaptureButton.click()
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+
+        XCTAssertEqual(app.textFields["captureWindow.title"].value as? String, "Protected draft title")
+    }
+
+    func testPreferencesShortcutPreservesRecoverableCreateDraft() throws {
+        continueAfterFailure = false
+        let app = makeSeededRedditReminderApp()
+        defer { app.terminate() }
+
+        launchAndWaitForRedditReminder(app)
+        openNewCaptureRoute(in: app)
+
+        let titleField = app.textFields["captureWindow.title"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+        titleField.click()
+        titleField.typeText("Shortcut protected draft")
+
+        app.typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["preferences.content.General"].waitForExistence(timeout: 3)
+        )
+
+        app.typeKey("w", modifierFlags: .command)
+
+        app.typeKey("n", modifierFlags: .command)
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+
+        XCTAssertEqual(app.textFields["captureWindow.title"].value as? String, "Shortcut protected draft")
+    }
+
+    func testExistingChannelAddChannelPreservesDraftFields() throws {
+        continueAfterFailure = false
+        let app = makeSeededRedditReminderApp()
+        defer { app.terminate() }
+
+        launchAndWaitForRedditReminder(app)
+        openNewCaptureRoute(in: app)
+
+        let titleField = app.textFields["captureWindow.title"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+        titleField.click()
+        titleField.typeText("Existing channel draft")
+
+        let addChannel = app.buttons["captureWindow.addChannel"]
+        XCTAssertTrue(addChannel.waitForExistence(timeout: 3))
+        addChannel.click()
+
+        let channelField = app.textFields["channels.addSubreddit.textField"]
+        XCTAssertTrue(channelField.waitForExistence(timeout: 3))
+        channelField.click()
+        channelField.typeText("ExistingFlowQA")
+
+        let addChannelButton = app.buttons["channels.addSubreddit.button"]
+        XCTAssertTrue(addChannelButton.waitForExistence(timeout: 3))
+        addChannelButton.click()
+
+        let newCaptureButton = app.buttons["popover.header.newCapture"]
+        XCTAssertTrue(newCaptureButton.waitForExistence(timeout: 3))
+        newCaptureButton.click()
+
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+        XCTAssertEqual(app.textFields["captureWindow.title"].value as? String, "Existing channel draft")
+    }
+
+    func testPlannerCalendarCreateActionOpensCaptureWithChannelContext() throws {
+        continueAfterFailure = false
+        let app = makeSeededRedditReminderApp()
+        defer { app.terminate() }
+
+        launchAndWaitForRedditReminder(app)
+        openHomePopover(in: app)
+        openWorkspace("popover.header.planner", in: app)
+
+        let viewMode = app.descendants(matching: .any)["planner.viewMode"]
+        XCTAssertTrue(viewMode.waitForExistence(timeout: 3))
+        viewMode.coordinate(withNormalizedOffset: CGVector(dx: 0.75, dy: 0.5)).click()
+
+        let createButton = firstButton(withIdentifierPrefix: "planner.calendar.createCapture.", in: app)
+        XCTAssertTrue(createButton.waitForExistence(timeout: 3))
+        createButton.click()
+
+        let titleField = app.textFields["captureWindow.title"]
+        XCTAssertTrue(titleField.waitForExistence(timeout: 3))
+        titleField.click()
+        titleField.typeText("Calendar context title")
+
+        let textView = app.textViews["captureWindow.text"]
+        XCTAssertTrue(textView.waitForExistence(timeout: 3))
+        textView.click()
+        textView.typeText("Calendar context body")
+
+        XCTAssertTrue(app.buttons["captureWindow.save"].isEnabled)
+    }
+
     func testNoChannelAddChannelPreservesDraftFields() throws {
         continueAfterFailure = false
         let app = makeClearedRedditReminderApp()

--- a/Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift
+++ b/Tests/RedditReminderUITests/RedditReminderWorkflowUITests.swift
@@ -17,6 +17,30 @@ final class RedditReminderWorkflowUITests: XCTestCase {
     XCTAssertTrue(cancelButton.exists)
   }
 
+  func testCaptureTextModeUsesSegmentedPreviewControl() throws {
+    continueAfterFailure = false
+    let app = makeSeededRedditReminderApp()
+    defer { app.terminate() }
+
+    launchAndWaitForRedditReminder(app)
+    openNewCaptureRoute(in: app)
+
+    let textEditor = app.textViews["captureWindow.text"]
+    XCTAssertTrue(textEditor.waitForExistence(timeout: 3), "Capture text editor should exist")
+
+    let modeControl = app.descendants(matching: .any)["captureWindow.text.mode"]
+    XCTAssertTrue(modeControl.waitForExistence(timeout: 3), "Capture text mode control should exist")
+
+    modeControl.coordinate(withNormalizedOffset: CGVector(dx: 0.84, dy: 0.5)).click()
+    XCTAssertTrue(
+      app.descendants(matching: .any)["captureWindow.text.previewContent"].waitForExistence(timeout: 3),
+      "Preview content should appear after selecting Preview"
+    )
+
+    modeControl.coordinate(withNormalizedOffset: CGVector(dx: 0.16, dy: 0.5)).click()
+    XCTAssertTrue(textEditor.waitForExistence(timeout: 3), "Text editor should return after selecting Edit")
+  }
+
   func testPreferencesTabNavigation() throws {
     continueAfterFailure = false
     let app = makeSeededRedditReminderApp()
@@ -25,11 +49,15 @@ final class RedditReminderWorkflowUITests: XCTestCase {
     launchAndWaitForRedditReminder(app)
     openPreferencesRoute(in: app)
 
-    let tabs = ["General", "Notifications", "Backup"]
-    for tab in tabs {
-      let tabButton = app.buttons["preferences.tab.\(tab)"]
-      XCTAssertTrue(tabButton.waitForExistence(timeout: 3), "Tab '\(tab)' should exist")
-      tabButton.click()
+    let tabs = [
+      ("General", CGVector(dx: 0.16, dy: 0.5)),
+      ("Notifications", CGVector(dx: 0.5, dy: 0.5)),
+      ("Backup", CGVector(dx: 0.84, dy: 0.5)),
+    ]
+    let segmentedTabs = app.descendants(matching: .any)["preferences.tabs"]
+    XCTAssertTrue(segmentedTabs.waitForExistence(timeout: 3), "Settings tabs should exist")
+    for (tab, offset) in tabs {
+      segmentedTabs.coordinate(withNormalizedOffset: offset).click()
       XCTAssertTrue(
         app.descendants(matching: .any)["preferences.content.\(tab)"].waitForExistence(timeout: 3),
         "Tab '\(tab)' should expose its content"


### PR DESCRIPTION
## Summary

Refreshes the macOS menu bar app experience using native desktop patterns:

- Moves Settings into a native app window and routes menu/keyboard settings actions there.
- Keeps the menu bar app alive after closing windows with an explicit lifecycle anchor.
- Makes the menu bar extra easier to spot by using a variable-width `RR` label with the queue count.
- Replaces custom segmented controls with native segmented pickers in Settings and capture text mode.
- Uses system material for the popover and post handoff surfaces.
- Tightens planner row/calendar actions, channel row chrome, filtered empty states, and multi-destination post handoff copy.
- Adds notification cleanup around generated event refreshes so stale window/nudge requests do not linger.
- Extends unit and UI coverage for the refreshed flows.

## Why

The macOS UX review found several places where the app behaved more like an embedded custom panel than a native menu bar app. The most important runtime issue was that removing the previous hidden keep-alive window let the app exit immediately after LaunchServices launch because the SwiftUI app only owns Settings plus an AppKit status item. This PR restores that lifecycle responsibility deliberately while keeping Settings and command handling native.

## Validation

- Clean worktree verification at commit `148c9e3`: `make build-debug && make test`
- Build succeeded
- Tests passed: 456 tests
- Manual QA launch previously verified from `/Users/neonwatty/Applications/RedditReminder.app` with seeded data and visible menu bar item `RR 6`
